### PR TITLE
CDP-22: Add the organisation-app to docker compose services

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,8 +15,8 @@
 **/bin
 **/charts
 **/docker-compose*
+**/compose*
 **/Dockerfile*
-**/node_modules
 **/npm-debug.log
 **/obj
 **/secrets.dev.yaml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Build containers
     env:
+      CDP_ORGANISATION_APP_PORT: 3000
       CDP_TENANT_PORT: 8811
       CDP_ORGANISATION_PORT: 8822
       CDP_PERSON_PORT: 8833

--- a/Frontend/organisation-app/Dockerfile
+++ b/Frontend/organisation-app/Dockerfile
@@ -1,0 +1,27 @@
+FROM node:20-alpine as base
+WORKDIR /app
+RUN apk add --no-cache curl
+
+FROM base as dependencies
+COPY package.json package-lock.json /app/
+RUN npm ci
+
+FROM base as source
+
+COPY --from=dependencies /app/package.json /app/package-lock.json /app/
+COPY --from=dependencies /app/node_modules /app/node_modules
+COPY tsconfig.json /app/
+COPY public/ /app/public
+COPY src/ /app/src
+
+FROM source as build
+RUN npm run build
+
+FROM base as serve
+RUN npm install -g serve
+COPY --from=build /app/build /app/build
+CMD ["serve", "-s", "/app/build"]
+
+FROM source as dev
+HEALTHCHECK CMD curl --fail --silent --write-out '{\"status\":%{http_code}}' --output /dev/null http://127.0.0.1:3000/
+CMD ["npm", "start"]

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ ps:
 	@docker compose ps
 .PHONY: ps
 
+CDP_ORGANISATION_APP_PORT ?= 3000
 CDP_TENANT_PORT ?= 8080
 CDP_ORGANISATION_PORT ?= 8082
 CDP_PERSON_PORT ?= 8084
@@ -46,6 +47,9 @@ OpenAPI: up
 define COMPOSE_OVERRIDE_YML
 version: '3'
 services:
+  organisation-app:
+    ports:
+      - "${CDP_ORGANISATION_APP_PORT:-3000}:3000"
   tenant:
     ports:
       - "$${CDP_TENANT_PORT:-8080}:8080"

--- a/compose.common.yml
+++ b/compose.common.yml
@@ -8,6 +8,9 @@ services:
       dockerfile: Dockerfile
       target: dev
     image: 'cabinetoffice/org-info-organisation-app:${IMAGE_VERSION:-latest}'
+    volumes:
+      - ./Frontend/organisation-app:/app
+    command: sh -c 'npm ci && npm start'
 
   tenant:
     container_name: co-org-info-tenant

--- a/compose.common.yml
+++ b/compose.common.yml
@@ -1,6 +1,14 @@
 version: '3'
 
 services:
+  organisation-app:
+    container_name: co-org-info-organisation-app
+    build:
+      context: Frontend/organisation-app
+      dockerfile: Dockerfile
+      target: dev
+    image: 'cabinetoffice/org-info-organisation-app:${IMAGE_VERSION:-latest}'
+
   tenant:
     container_name: co-org-info-tenant
     build:

--- a/compose.yml
+++ b/compose.yml
@@ -1,4 +1,8 @@
 services:
+  organisation-app:
+    extends:
+      file: compose.common.yml
+      service: organisation-app
   tenant:
     extends:
       file: compose.common.yml


### PR DESCRIPTION
The Dockerfile is constructed from multiple stages:

* base - installs all system dependencies
  * dependencies - installs application dependencies
  * source - bundles application source code
    * build - packages the application as static files
    * dev - runs the application in development mode
  * serve - serves the application packages as static files
 
Docker compose mounts the `Frontend/organisation-app` as a volume, so it's possible to use this setup for development.

## Developer notes

If you have the `compose.override.yml` file locally, you'll need to either remove it so it's re-generated, or add the following section under `services`:

```
  organisation-app:
    ports:
      - "${CDP_ORGANISATION_APP_PORT:-3000}:3000"
```