### PR TITLE
Improve speed of `npm ci` on Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -17,6 +17,8 @@
 **/docker-compose*
 **/compose*
 **/Dockerfile*
+**/.npm
+**/node_modules
 **/npm-debug.log
 **/obj
 **/secrets.dev.yaml

--- a/Frontend/organisation-app/.gitignore
+++ b/Frontend/organisation-app/.gitignore
@@ -2,6 +2,7 @@
 
 # dependencies
 /node_modules
+/.npm
 /.pnp
 .pnp.js
 

--- a/compose.common.yml
+++ b/compose.common.yml
@@ -10,7 +10,7 @@ services:
     image: 'cabinetoffice/org-info-organisation-app:${IMAGE_VERSION:-latest}'
     volumes:
       - ./Frontend/organisation-app:/app
-    command: sh -c 'npm ci && npm start'
+    command: sh -c 'npm ci --cache /app/.npm && npm start'
 
   tenant:
     container_name: co-org-info-tenant


### PR DESCRIPTION
An improvement over #2

`npm ci` always starts fresh, which is good for reproducible builds, but bad for performance. Using the cache directory makes it slightly faster. This way node_modules can be ignored from the Docker context again.