### PR TITLE
Document the process of preventing a service from starting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,31 +52,43 @@ services:
       - "$${CDP_ORGANISATION_APP_PORT:-80}:8080"
     environment:
       - ASPNETCORE_ENVIRONMENT=Development
+    deploy:
+      replicas: 1
   tenant:
     ports:
       - "$${CDP_TENANT_PORT:-8080}:8080"
     environment:
       - ASPNETCORE_ENVIRONMENT=Development
+    deploy:
+      replicas: 1
   organisation:
     ports:
       - '$${CDP_ORGANISATION_PORT:-8082}:8080'
     environment:
       - ASPNETCORE_ENVIRONMENT=Development
+    deploy:
+      replicas: 1
   person:
     ports:
       - '$${CDP_PERSON_PORT:-8084}:8080'
     environment:
       - ASPNETCORE_ENVIRONMENT=Development
+    deploy:
+      replicas: 1
   forms:
     ports:
       - '$${CDP_FORMS_PORT:-8086}:8080'
     environment:
       - ASPNETCORE_ENVIRONMENT=Development
+    deploy:
+      replicas: 1
   data-sharing:
     ports:
       - '$${CDP_DATA_SHARING_PORT:-8088}:8080'
     environment:
       - ASPNETCORE_ENVIRONMENT=Development
+    deploy:
+      replicas: 1
 endef
 
 export COMPOSE_OVERRIDE_YML

--- a/README.md
+++ b/README.md
@@ -38,13 +38,24 @@ make up
 
 The first run creates `compose.override.yml` that can be used to override service configuration locally.
 
-By default service ports are mapped as follows:
+By default service and application ports are mapped as follows:
 
+* OrganisationApp - - http://localhost/
 * Tenant - http://localhost:8080/swagger/
 * Organisation - http://localhost:8082/swagger/
 * Person - http://localhost:8084/swagger/
 * Forms - http://localhost:8086/swagger/
 * Data Sharing - http://localhost:8088/swagger/
+
+In order to prevent selected service(s) from starting, configure the number of replicate in `compose.override.yml` to 0:
+
+```yaml
+# ...
+  person:
+    deploy:
+      replicas: 0
+    # ...
+```
 
 Stop all Docker services:
 


### PR DESCRIPTION
In order to prevent selected service(s) from starting, configure the number of replicate in `compose.override.yml` to 0:

```yaml
services:
  organisation-app:
    ports:
      - "${CDP_ORGANISATION_APP_PORT:-80}:8080"
    environment:
      - ASPNETCORE_ENVIRONMENT=Development
    deploy:
      replicas: 0
```
