### PR TITLE
Refactor session tests to avoid mocking a 3rd party type

### DIFF
--- a/Frontend/CO.CDP.OrganisationApp/Session.cs
+++ b/Frontend/CO.CDP.OrganisationApp/Session.cs
@@ -6,28 +6,21 @@ namespace CO.CDP.OrganisationApp
     {
         public T? Get<T>(string key)
         {
-            CheckSessionIsNull();
-
-            var value = httpContextAccessor.HttpContext!.Session.GetString(key);
+            var value = GetSession().GetString(key);
             return value == null ? default : JsonSerializer.Deserialize<T>(value);
         }
 
         public void Set<T>(string key, T value)
         {
-            CheckSessionIsNull();
-
-            httpContextAccessor.HttpContext!.Session
-                .SetString(key, JsonSerializer.Serialize(value));
+            GetSession().SetString(key, JsonSerializer.Serialize(value));
         }
 
         public void Remove(string key)
         {
-            CheckSessionIsNull();
-
-            httpContextAccessor.HttpContext!.Session.Remove(key);
+            GetSession().Remove(key);
         }
 
-        private void CheckSessionIsNull()
+        private Microsoft.AspNetCore.Http.ISession GetSession()
         {
             try
             {
@@ -35,6 +28,7 @@ namespace CO.CDP.OrganisationApp
                 {
                     throw new Exception("Session is not available");
                 }
+                return httpContextAccessor.HttpContext!.Session;
             }
             catch (InvalidOperationException cause)
             {

--- a/Frontend/CO.CDP.OrganisationApp/Session.cs
+++ b/Frontend/CO.CDP.OrganisationApp/Session.cs
@@ -29,9 +29,16 @@ namespace CO.CDP.OrganisationApp
 
         private void CheckSessionIsNull()
         {
-            if (httpContextAccessor.HttpContext?.Session == null)
+            try
             {
-                throw new Exception("Session is not available");
+                if (httpContextAccessor.HttpContext?.Session == null)
+                {
+                    throw new Exception("Session is not available");
+                }
+            }
+            catch (InvalidOperationException cause)
+            {
+                throw new Exception("Session is not available", cause);
             }
         }
     }


### PR DESCRIPTION
Here's how the Session can be tested without mocking the 3rd party type, for reasons explained in https://github.com/cabinetoffice/GCGS-Central-Digital-Platform/pull/18#issuecomment-1999813018.

While refactoring I found an additional case where the HTTP context might be null, which beautifully proves the point.