### PR TITLE
Build a dedicated migrations container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,11 @@ ps:
 	@docker compose ps
 .PHONY: ps
 
+db: compose.override.yml
+	@docker compose up -d db tenant-migrations
+	@docker compose logs -f tenant-migrations
+.PHONY: up
+
 OpenAPI: build
 	@mkdir -p OpenAPI
 	cp ./Services/CO.CDP.Tenant.WebApi/OpenAPI/CO.CDP.Tenant.WebApi.json OpenAPI/Tenant.json

--- a/README.md
+++ b/README.md
@@ -65,3 +65,11 @@ Stop all Docker services:
 ```bash
 make down
 ```
+
+To only start the database and apply migrations run:
+
+
+```bash
+make db
+```
+

--- a/compose.common.yml
+++ b/compose.common.yml
@@ -44,6 +44,17 @@ services:
       timeout: 10s
       retries: 10
 
+  tenant-migrations:
+    container_name: co-cdp-tenant-migrations
+    restart: no
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: migrations-tenant
+    image: 'cabinetoffice/cdp-tenant-migrations:${IMAGE_VERSION:-latest}'
+    environment:
+      - ASPNETCORE_ENVIRONMENT=Production
+
   organisation:
     container_name: co-cdp-organisation
     build:

--- a/compose.yml
+++ b/compose.yml
@@ -19,6 +19,16 @@ services:
       - db:db
     depends_on:
       - db
+  tenant-migrations:
+    extends:
+      file: compose.common.yml
+      service: tenant-migrations
+    links:
+      - db:db
+    depends_on:
+      - db
+    environment:
+      MIGRATIONS_CONNECTION_STRING: "Server=db;Database=cdp;Username=cdp_user;Password=cdp123;"
   organisation:
     extends:
       file: compose.common.yml

--- a/compose.yml
+++ b/compose.yml
@@ -26,7 +26,8 @@ services:
     links:
       - db:db
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     environment:
       MIGRATIONS_CONNECTION_STRING: "Server=db;Database=cdp;Username=cdp_user;Password=cdp123;"
   organisation:


### PR DESCRIPTION
An alternative to #34 #44.

This PR introduces a database migrations container. It includes a self-contained migrations bundle that is able to execute database migrations given a connection string.