### PR TITLE
Tidying/docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,42 +50,42 @@ services:
     ports:
       - "$${CDP_ORGANISATION_APP_PORT:-80}:8080"
     environment:
-      - ASPNETCORE_ENVIRONMENT=Development
+      ASPNETCORE_ENVIRONMENT: Development
     deploy:
       replicas: 1
   tenant:
     ports:
       - "$${CDP_TENANT_PORT:-8080}:8080"
     environment:
-      - ASPNETCORE_ENVIRONMENT=Development
+      ASPNETCORE_ENVIRONMENT: Development
     deploy:
       replicas: 1
   organisation:
     ports:
       - '$${CDP_ORGANISATION_PORT:-8082}:8080'
     environment:
-      - ASPNETCORE_ENVIRONMENT=Development
+      ASPNETCORE_ENVIRONMENT: Development
     deploy:
       replicas: 1
   person:
     ports:
       - '$${CDP_PERSON_PORT:-8084}:8080'
     environment:
-      - ASPNETCORE_ENVIRONMENT=Development
+      ASPNETCORE_ENVIRONMENT: Development
     deploy:
       replicas: 1
   forms:
     ports:
       - '$${CDP_FORMS_PORT:-8086}:8080'
     environment:
-      - ASPNETCORE_ENVIRONMENT=Development
+      ASPNETCORE_ENVIRONMENT: Development
     deploy:
       replicas: 1
   data-sharing:
     ports:
       - '$${CDP_DATA_SHARING_PORT:-8088}:8080'
     environment:
-      - ASPNETCORE_ENVIRONMENT=Development
+      ASPNETCORE_ENVIRONMENT: Development
     deploy:
       replicas: 1
 endef

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,6 @@ OpenAPI: build
 	cp ./Services/CO.CDP.Forms.WebApi/OpenAPI/CO.CDP.Forms.WebApi.json OpenAPI/Forms.json
 
 define COMPOSE_OVERRIDE_YML
-version: '3'
 services:
   db:
     ports:

--- a/compose.common.yml
+++ b/compose.common.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   db:
     container_name: co-cdp-db

--- a/compose.common.yml
+++ b/compose.common.yml
@@ -18,8 +18,7 @@ services:
       target: final-organisation-app
     image: 'cabinetoffice/cdp-organisation-app:${IMAGE_VERSION:-latest}'
     environment:
-      - ASPNETCORE_ENVIRONMENT=Production
-      - TenantService=http://tenant:8080
+      ASPNETCORE_ENVIRONMENT: Production
     healthcheck:
       test: ["CMD-SHELL", "curl --fail --silent --write-out '{\"status\":%{http_code}}' --output /dev/null http://127.0.0.1:8080/health"]
       start_period: 10s
@@ -35,7 +34,7 @@ services:
       target: final-tenant
     image: 'cabinetoffice/cdp-tenant:${IMAGE_VERSION:-latest}'
     environment:
-      - ASPNETCORE_ENVIRONMENT=Production
+      ASPNETCORE_ENVIRONMENT: Production
     healthcheck:
       test: ["CMD-SHELL", "curl --fail --silent --write-out '{\"status\":%{http_code}}' --output /dev/null http://127.0.0.1:8080/health"]
       start_period: 10s
@@ -52,7 +51,7 @@ services:
       target: migrations-tenant
     image: 'cabinetoffice/cdp-tenant-migrations:${IMAGE_VERSION:-latest}'
     environment:
-      - ASPNETCORE_ENVIRONMENT=Production
+      ASPNETCORE_ENVIRONMENT: Production
 
   organisation-migrations:
     container_name: co-cdp-organisation-migrations
@@ -63,7 +62,7 @@ services:
       target: migrations-organisation
     image: 'cabinetoffice/cdp-organisation-migrations:${IMAGE_VERSION:-latest}'
     environment:
-      - ASPNETCORE_ENVIRONMENT=Production
+      ASPNETCORE_ENVIRONMENT: Production
 
   organisation:
     container_name: co-cdp-organisation
@@ -73,7 +72,7 @@ services:
       target: final-organisation
     image: 'cabinetoffice/cdp-organisation:${IMAGE_VERSION:-latest}'
     environment:
-      - ASPNETCORE_ENVIRONMENT=Production
+      ASPNETCORE_ENVIRONMENT: Production
     healthcheck:
       test: ["CMD-SHELL", "curl --fail --silent --write-out '{\"status\":%{http_code}}' --output /dev/null http://127.0.0.1:8080/health"]
       start_period: 10s
@@ -89,7 +88,7 @@ services:
       target: final-person
     image: 'cabinetoffice/cdp-person:${IMAGE_VERSION:-latest}'
     environment:
-      - ASPNETCORE_ENVIRONMENT=Production
+      ASPNETCORE_ENVIRONMENT: Production
     healthcheck:
       test: ["CMD-SHELL", "curl --fail --silent --write-out '{\"status\":%{http_code}}' --output /dev/null http://127.0.0.1:8080/health"]
       start_period: 10s
@@ -105,7 +104,7 @@ services:
       target: final-forms
     image: 'cabinetoffice/cdp-forms:${IMAGE_VERSION:-latest}'
     environment:
-      - ASPNETCORE_ENVIRONMENT=Production
+      ASPNETCORE_ENVIRONMENT: Production
     healthcheck:
       test: ["CMD-SHELL", "curl --fail --silent --write-out '{\"status\":%{http_code}}' --output /dev/null http://127.0.0.1:8080/health"]
       start_period: 10s
@@ -121,7 +120,7 @@ services:
       target: final-data-sharing
     image: 'cabinetoffice/cdp-data-sharing:${IMAGE_VERSION:-latest}'
     environment:
-      - ASPNETCORE_ENVIRONMENT=Production
+      ASPNETCORE_ENVIRONMENT: Production
     healthcheck:
       test: ["CMD-SHELL", "curl --fail --silent --write-out '{\"status\":%{http_code}}' --output /dev/null http://127.0.0.1:8080/health"]
       start_period: 10s

--- a/compose.yml
+++ b/compose.yml
@@ -17,6 +17,8 @@ services:
       service: tenant
     depends_on:
       - db
+    environment:
+      ConnectionStrings__TenantDatabase: 'Server=db;Database=cdp;Username=cdp_user;Password=cdp123;'
   tenant-migrations:
     extends:
       file: compose.common.yml
@@ -41,6 +43,8 @@ services:
       service: organisation
     depends_on:
       - db
+    environment:
+      ConnectionStrings__OrganisationDatabase: 'Server=db;Database=cdp;Username=cdp_user;Password=cdp123;'
   person:
     extends:
       file: compose.common.yml

--- a/compose.yml
+++ b/compose.yml
@@ -15,16 +15,12 @@ services:
     extends:
       file: compose.common.yml
       service: tenant
-    links:
-      - db:db
     depends_on:
       - db
   tenant-migrations:
     extends:
       file: compose.common.yml
       service: tenant-migrations
-    links:
-      - db:db
     depends_on:
       db:
         condition: service_healthy
@@ -34,8 +30,6 @@ services:
     extends:
       file: compose.common.yml
       service: organisation-migrations
-    links:
-      - db:db
     depends_on:
       db:
         condition: service_healthy
@@ -45,31 +39,23 @@ services:
     extends:
       file: compose.common.yml
       service: organisation
-    links:
-      - db:db
     depends_on:
       - db
   person:
     extends:
       file: compose.common.yml
       service: person
-    links:
-      - db:db
     depends_on:
       - db
   forms:
     extends:
       file: compose.common.yml
       service: forms
-    links:
-      - db:db
     depends_on:
       - db
   data-sharing:
     extends:
       file: compose.common.yml
       service: data-sharing
-    links:
-      - db:db
     depends_on:
       - db

--- a/compose.yml
+++ b/compose.yml
@@ -11,6 +11,8 @@ services:
     extends:
       file: compose.common.yml
       service: organisation-app
+    environment:
+      TenantService: 'http://tenant:8080'
   tenant:
     extends:
       file: compose.common.yml


### PR DESCRIPTION
* [Remove the obsolete compose version](https://github.com/cabinetoffice/GCGS-Central-Digital-Platform/commit/273231d1f67963c99119c4eb7dc6275ebb29585e)
* [Remove the redundant links configuration](https://github.com/cabinetoffice/GCGS-Central-Digital-Platform/commit/66c56865eb18817c0488e9d82b4283a6d9819e32) - links can be used to give aliases which we haven't leveraged.
* [Configure database connections for docker containers that use the database](https://github.com/cabinetoffice/GCGS-Central-Digital-Platform/commit/1995ea2e763f5f307344046bb808d2590e88a248) - a recent Docker update seems to have broken referencing by localhost.