### PR TITLE
Tidy database context

### DIFF
--- a/Services/CO.CDP.Organisation.WebApi/Program.cs
+++ b/Services/CO.CDP.Organisation.WebApi/Program.cs
@@ -3,6 +3,7 @@ using CO.CDP.Organisation.WebApi.AutoMapper;
 using CO.CDP.Organisation.WebApi.Model;
 using CO.CDP.Organisation.WebApi.UseCase;
 using CO.CDP.OrganisationInformation.Persistence;
+using Microsoft.EntityFrameworkCore;
 using Organisation = CO.CDP.Organisation.WebApi.Model.Organisation;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -16,7 +17,8 @@ builder.Services.AddProblemDetails();
 builder.Services.AddHealthChecks();
 builder.Services.AddAutoMapper(typeof(WebApiToPersistenceProfile));
 
-builder.Services.AddScoped<OrganisationInformationContext>(_ => new OrganisationInformationContext(builder.Configuration.GetConnectionString("OrganisationInformationDatabase") ?? ""));
+builder.Services.AddDbContext<OrganisationInformationContext>(o =>
+    o.UseNpgsql(builder.Configuration.GetConnectionString("OrganisationInformationDatabase") ?? ""));
 builder.Services.AddScoped<IOrganisationRepository, DatabaseOrganisationRepository>();
 builder.Services.AddScoped<IPersonRepository, DatabasePersonRepository>();
 builder.Services.AddScoped<IUseCase<RegisterOrganisation, Organisation>, RegisterOrganisationUseCase>();

--- a/Services/CO.CDP.OrganisationInformation.Persistence.Tests/DatabaseOrganisationRepositoryTest.cs
+++ b/Services/CO.CDP.OrganisationInformation.Persistence.Tests/DatabaseOrganisationRepositoryTest.cs
@@ -1,6 +1,5 @@
 using CO.CDP.Testcontainers.PostgreSql;
 using FluentAssertions;
-using Microsoft.EntityFrameworkCore;
 using static CO.CDP.OrganisationInformation.Persistence.Organisation;
 using static CO.CDP.OrganisationInformation.Persistence.Tests.EntityFactory;
 
@@ -158,17 +157,6 @@ public class DatabaseOrganisationRepositoryTest(PostgreSqlFixture postgreSql) : 
 
     private IOrganisationRepository OrganisationRepository()
     {
-        return new DatabaseOrganisationRepository(OrganisationInformationContext());
-    }
-
-    private OrganisationInformationContext OrganisationInformationContext()
-    {
-        var options = new DbContextOptionsBuilder<OrganisationInformationContext>()
-            .UseNpgsql(postgreSql.ConnectionString)
-            .Options;
-        var context = new OrganisationInformationContext(options);
-        context.Database.Migrate();
-        context.SaveChanges();
-        return context;
+        return new DatabaseOrganisationRepository(postgreSql.OrganisationInformationContext());
     }
 }

--- a/Services/CO.CDP.OrganisationInformation.Persistence.Tests/DatabaseOrganisationRepositoryTest.cs
+++ b/Services/CO.CDP.OrganisationInformation.Persistence.Tests/DatabaseOrganisationRepositoryTest.cs
@@ -163,7 +163,10 @@ public class DatabaseOrganisationRepositoryTest(PostgreSqlFixture postgreSql) : 
 
     private OrganisationInformationContext OrganisationInformationContext()
     {
-        var context = new OrganisationInformationContext(postgreSql.ConnectionString);
+        var options = new DbContextOptionsBuilder<OrganisationInformationContext>()
+            .UseNpgsql(postgreSql.ConnectionString)
+            .Options;
+        var context = new OrganisationInformationContext(options);
         context.Database.Migrate();
         context.SaveChanges();
         return context;

--- a/Services/CO.CDP.OrganisationInformation.Persistence.Tests/DatabasePersonRepositoryTest.cs
+++ b/Services/CO.CDP.OrganisationInformation.Persistence.Tests/DatabasePersonRepositoryTest.cs
@@ -107,7 +107,10 @@ public class DatabasePersonRepositoryTest(PostgreSqlFixture postgreSql) : IClass
 
     private OrganisationInformationContext OrganisationInformationContext()
     {
-        var context = new OrganisationInformationContext(postgreSql.ConnectionString);
+        var options = new DbContextOptionsBuilder<OrganisationInformationContext>()
+            .UseNpgsql(postgreSql.ConnectionString)
+            .Options;
+        var context = new OrganisationInformationContext(options);
         context.Database.Migrate();
         context.SaveChanges();
         return context;

--- a/Services/CO.CDP.OrganisationInformation.Persistence.Tests/DatabasePersonRepositoryTest.cs
+++ b/Services/CO.CDP.OrganisationInformation.Persistence.Tests/DatabasePersonRepositoryTest.cs
@@ -1,6 +1,5 @@
 using CO.CDP.Testcontainers.PostgreSql;
 using FluentAssertions;
-using Microsoft.EntityFrameworkCore;
 using static CO.CDP.OrganisationInformation.Persistence.Tests.EntityFactory;
 
 namespace CO.CDP.OrganisationInformation.Persistence.Tests;
@@ -102,17 +101,6 @@ public class DatabasePersonRepositoryTest(PostgreSqlFixture postgreSql) : IClass
 
     private IPersonRepository PersonRepository()
     {
-        return new DatabasePersonRepository(OrganisationInformationContext());
-    }
-
-    private OrganisationInformationContext OrganisationInformationContext()
-    {
-        var options = new DbContextOptionsBuilder<OrganisationInformationContext>()
-            .UseNpgsql(postgreSql.ConnectionString)
-            .Options;
-        var context = new OrganisationInformationContext(options);
-        context.Database.Migrate();
-        context.SaveChanges();
-        return context;
+        return new DatabasePersonRepository(postgreSql.OrganisationInformationContext());
     }
 }

--- a/Services/CO.CDP.OrganisationInformation.Persistence.Tests/DatabaseTenantRepositoryTest.cs
+++ b/Services/CO.CDP.OrganisationInformation.Persistence.Tests/DatabaseTenantRepositoryTest.cs
@@ -110,17 +110,6 @@ public class DatabaseTenantRepositoryTest(PostgreSqlFixture postgreSql) : IClass
 
     private ITenantRepository TenantRepository()
     {
-        return new DatabaseTenantRepository(OrganisationInformationContext());
-    }
-
-    private OrganisationInformationContext OrganisationInformationContext()
-    {
-        var options = new DbContextOptionsBuilder<OrganisationInformationContext>()
-            .UseNpgsql(postgreSql.ConnectionString)
-            .Options;
-        var context = new OrganisationInformationContext(options);
-        context.Database.Migrate();
-        context.SaveChanges();
-        return context;
+        return new DatabaseTenantRepository(postgreSql.OrganisationInformationContext());
     }
 }

--- a/Services/CO.CDP.OrganisationInformation.Persistence.Tests/DatabaseTenantRepositoryTest.cs
+++ b/Services/CO.CDP.OrganisationInformation.Persistence.Tests/DatabaseTenantRepositoryTest.cs
@@ -115,7 +115,10 @@ public class DatabaseTenantRepositoryTest(PostgreSqlFixture postgreSql) : IClass
 
     private OrganisationInformationContext OrganisationInformationContext()
     {
-        var context = new OrganisationInformationContext(postgreSql.ConnectionString);
+        var options = new DbContextOptionsBuilder<OrganisationInformationContext>()
+            .UseNpgsql(postgreSql.ConnectionString)
+            .Options;
+        var context = new OrganisationInformationContext(options);
         context.Database.Migrate();
         context.SaveChanges();
         return context;

--- a/Services/CO.CDP.OrganisationInformation.Persistence.Tests/PostgreSqlFixtureExtensions.cs
+++ b/Services/CO.CDP.OrganisationInformation.Persistence.Tests/PostgreSqlFixtureExtensions.cs
@@ -1,0 +1,20 @@
+using CO.CDP.Testcontainers.PostgreSql;
+using Microsoft.EntityFrameworkCore;
+
+namespace CO.CDP.OrganisationInformation.Persistence.Tests;
+
+public static class PostgreSqlFixtureExtensions
+{
+    public static OrganisationInformationContext OrganisationInformationContext(this PostgreSqlFixture postgreSql)
+    {
+        var context = new OrganisationInformationContext(postgreSql.DbContextOptions<OrganisationInformationContext>());
+        context.Database.Migrate();
+        context.SaveChanges();
+        return context;
+    }
+
+    private static DbContextOptions<TC> DbContextOptions<TC>(this PostgreSqlFixture postgreSql) where TC : DbContext =>
+        new DbContextOptionsBuilder<TC>()
+            .UseNpgsql(postgreSql.ConnectionString)
+            .Options;
+}

--- a/Services/CO.CDP.OrganisationInformation.Persistence/OrganisationInformationContext.cs
+++ b/Services/CO.CDP.OrganisationInformation.Persistence/OrganisationInformationContext.cs
@@ -2,15 +2,21 @@ using Microsoft.EntityFrameworkCore;
 
 namespace CO.CDP.OrganisationInformation.Persistence;
 
-public class OrganisationInformationContext(string connectionString) : DbContext
+public class OrganisationInformationContext(DbContextOptions<OrganisationInformationContext> options)
+    : DbContext(options)
 {
+    public OrganisationInformationContext(string connectionString) : this(
+        new DbContextOptionsBuilder<OrganisationInformationContext>().UseNpgsql(connectionString).Options
+    )
+    {
+    }
+
     public DbSet<Tenant> Tenants { get; set; } = null!;
     public DbSet<Organisation> Organisations { get; set; } = null!;
     public DbSet<Person> Persons { get; set; } = null!;
 
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
-        optionsBuilder.UseNpgsql(connectionString);
     }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/Services/CO.CDP.OrganisationInformation.Persistence/OrganisationInformationContext.cs
+++ b/Services/CO.CDP.OrganisationInformation.Persistence/OrganisationInformationContext.cs
@@ -5,19 +5,9 @@ namespace CO.CDP.OrganisationInformation.Persistence;
 public class OrganisationInformationContext(DbContextOptions<OrganisationInformationContext> options)
     : DbContext(options)
 {
-    public OrganisationInformationContext(string connectionString) : this(
-        new DbContextOptionsBuilder<OrganisationInformationContext>().UseNpgsql(connectionString).Options
-    )
-    {
-    }
-
     public DbSet<Tenant> Tenants { get; set; } = null!;
     public DbSet<Organisation> Organisations { get; set; } = null!;
     public DbSet<Person> Persons { get; set; } = null!;
-
-    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-    {
-    }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/Services/CO.CDP.Person.WebApi/Program.cs
+++ b/Services/CO.CDP.Person.WebApi/Program.cs
@@ -3,6 +3,7 @@ using CO.CDP.Person.WebApi.Api;
 using CO.CDP.Person.WebApi.AutoMapper;
 using CO.CDP.Person.WebApi.Model;
 using CO.CDP.Person.WebApi.UseCase;
+using Microsoft.EntityFrameworkCore;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -15,7 +16,8 @@ builder.Services.AddProblemDetails();
 builder.Services.AddHealthChecks();
 builder.Services.AddAutoMapper(typeof(WebApiToPersistenceProfile));
 
-builder.Services.AddScoped<OrganisationInformationContext>(_ => new OrganisationInformationContext(builder.Configuration.GetConnectionString("OrganisationInformationDatabase") ?? ""));
+builder.Services.AddDbContext<OrganisationInformationContext>(o =>
+    o.UseNpgsql(builder.Configuration.GetConnectionString("OrganisationInformationDatabase") ?? ""));
 builder.Services.AddScoped<IPersonRepository, DatabasePersonRepository>();
 builder.Services.AddScoped<IUseCase<RegisterPerson, CO.CDP.Person.WebApi.Model.Person>, RegisterPersonUseCase>();
 builder.Services.AddScoped<IUseCase<Guid, CO.CDP.Person.WebApi.Model.Person?>, GetPersonUseCase>();

--- a/Services/CO.CDP.Tenant.WebApi/Program.cs
+++ b/Services/CO.CDP.Tenant.WebApi/Program.cs
@@ -3,6 +3,7 @@ using CO.CDP.Tenant.WebApi.Api;
 using CO.CDP.Tenant.WebApi.AutoMapper;
 using CO.CDP.Tenant.WebApi.Model;
 using CO.CDP.Tenant.WebApi.UseCase;
+using Microsoft.EntityFrameworkCore;
 using Tenant = CO.CDP.Tenant.WebApi.Model.Tenant;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -16,7 +17,8 @@ builder.Services.AddProblemDetails();
 builder.Services.AddHealthChecks();
 builder.Services.AddAutoMapper(typeof(WebApiToPersistenceProfile));
 
-builder.Services.AddScoped<OrganisationInformationContext>(_ => new OrganisationInformationContext(builder.Configuration.GetConnectionString("OrganisationInformationDatabase") ?? ""));
+builder.Services.AddDbContext<OrganisationInformationContext>(o =>
+    o.UseNpgsql(builder.Configuration.GetConnectionString("OrganisationInformationDatabase") ?? ""));
 builder.Services.AddScoped<ITenantRepository, DatabaseTenantRepository>();
 builder.Services.AddScoped<IUseCase<RegisterTenant, Tenant>, RegisterTenantUseCase>();
 builder.Services.AddScoped<IUseCase<Guid, Tenant?>, GetTenantUseCase>();


### PR DESCRIPTION
* make the constructor accept DbContextOptions as recommended in documentation instead of the connection string
* move the choice of database out of our custom db context
* make it easier to construct the db context for the postgres docker container