### PR TITLE
Fix dereference of a possibly null reference in repo tests

### DIFF
--- a/Services/CO.CDP.OrganisationInformation.Persistence.Tests/DatabasePersonRepositoryTest.cs
+++ b/Services/CO.CDP.OrganisationInformation.Persistence.Tests/DatabasePersonRepositoryTest.cs
@@ -100,7 +100,7 @@ public class DatabasePersonRepositoryTest(PostgreSqlFixture postgreSql) : IClass
         var found = await repository.Find(person.Guid);
 
         found.Should().NotBeNull();
-        found?.Organisations.Should().Contain(org => org.Guid == organisation.Guid);
+        found.As<Person>().Organisations.Should().Contain(org => org.Guid == organisation.Guid);
     }
 
 

--- a/Services/CO.CDP.OrganisationInformation.Persistence.Tests/DatabaseTenantRepositoryTest.cs
+++ b/Services/CO.CDP.OrganisationInformation.Persistence.Tests/DatabaseTenantRepositoryTest.cs
@@ -126,8 +126,8 @@ public class DatabaseTenantRepositoryTest(PostgreSqlFixture postgreSql) : IClass
 
         found.Should().NotBeNull();
         found.As<Tenant>().Persons.Should().HaveCount(2);
-        found.Persons.Should().Contain(p => p.Guid == person1.Guid);
-        found.Persons.Should().Contain(p => p.Guid == person2.Guid);
+        found.As<Tenant>().Persons.Should().Contain(p => p.Guid == person1.Guid);
+        found.As<Tenant>().Persons.Should().Contain(p => p.Guid == person2.Guid);
     }
 
 


### PR DESCRIPTION
Resolve warnings in DatabasePersonRepositoryTest & DatabaseTenantRepositoryTest