### PR TITLE
Document error responses (data sharing API)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,8 @@ ENV NUGET_PACKAGES="${NUGET_PACKAGES}"
 WORKDIR /src
 COPY Libraries/CO.CDP.Common/CO.CDP.Common.csproj Libraries/CO.CDP.Common/
 COPY Libraries/CO.CDP.Common.Tests/CO.CDP.Common.Tests.csproj Libraries/CO.CDP.Common.Tests/
+COPY Libraries/CO.CDP.Swashbuckle/CO.CDP.Swashbuckle.csproj Libraries/CO.CDP.Swashbuckle/
+COPY Libraries/CO.CDP.Swashbuckle.Tests/CO.CDP.Swashbuckle.Tests.csproj Libraries/CO.CDP.Swashbuckle.Tests/
 COPY Frontend/CO.CDP.OrganisationApp/CO.CDP.OrganisationApp.csproj Frontend/CO.CDP.OrganisationApp/
 COPY Frontend/CO.CDP.OrganisationApp.Tests/CO.CDP.OrganisationApp.Tests.csproj Frontend/CO.CDP.OrganisationApp.Tests/
 COPY Libraries/CO.CDP.Tenant.WebApiClient/CO.CDP.Tenant.WebApiClient.csproj Libraries/CO.CDP.Tenant.WebApiClient/

--- a/GCGS-Central-Digital-Platform.sln
+++ b/GCGS-Central-Digital-Platform.sln
@@ -64,6 +64,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CO.CDP.TestKit.Mvc.Tests", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CO.CDP.TestKit.Mvc", "TestKit\CO.CDP.TestKit.Mvc\CO.CDP.TestKit.Mvc.csproj", "{A34220C0-CE7E-4966-9175-111EE5D04676}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CO.CDP.Swashbuckle", "Libraries\CO.CDP.Swashbuckle\CO.CDP.Swashbuckle.csproj", "{F84FB143-7483-4BE9-BD4A-8BF10E93E859}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CO.CDP.Swashbuckle.Tests", "Libraries\CO.CDP.Swashbuckle.Tests\CO.CDP.Swashbuckle.Tests.csproj", "{9D53B3DD-81C0-4249-8284-5FCDE3151516}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -174,6 +178,14 @@ Global
 		{A34220C0-CE7E-4966-9175-111EE5D04676}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A34220C0-CE7E-4966-9175-111EE5D04676}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A34220C0-CE7E-4966-9175-111EE5D04676}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F84FB143-7483-4BE9-BD4A-8BF10E93E859}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F84FB143-7483-4BE9-BD4A-8BF10E93E859}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F84FB143-7483-4BE9-BD4A-8BF10E93E859}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F84FB143-7483-4BE9-BD4A-8BF10E93E859}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9D53B3DD-81C0-4249-8284-5FCDE3151516}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9D53B3DD-81C0-4249-8284-5FCDE3151516}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9D53B3DD-81C0-4249-8284-5FCDE3151516}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9D53B3DD-81C0-4249-8284-5FCDE3151516}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Libraries/CO.CDP.Swashbuckle.Tests/CO.CDP.Swashbuckle.Tests.csproj
+++ b/Libraries/CO.CDP.Swashbuckle.Tests/CO.CDP.Swashbuckle.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="coverlet.collector" Version="6.0.0"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
+        <PackageReference Include="xunit" Version="2.5.3"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3"/>
+        <PackageReference Include="FluentAssertions" Version="6.12.0" />
+        <ProjectReference Include="..\CO.CDP.Swashbuckle\CO.CDP.Swashbuckle.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="Xunit"/>
+    </ItemGroup>
+
+</Project>

--- a/Libraries/CO.CDP.Swashbuckle.Tests/Filter/ProblemDetailsOperationFilterTest.cs
+++ b/Libraries/CO.CDP.Swashbuckle.Tests/Filter/ProblemDetailsOperationFilterTest.cs
@@ -1,0 +1,148 @@
+using CO.CDP.Swashbuckle.Filter;
+using DotSwashbuckle.AspNetCore.SwaggerGen;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using FluentAssertions.Numeric;
+using FluentAssertions.Primitives;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Models;
+
+namespace CO.CDP.Swashbuckle.Tests.Filter;
+
+public class ProblemDetailsOperationFilterTest
+{
+    [Theory]
+    [InlineData(400, "Bad Request", "https://tools.ietf.org/html/rfc7231#section-6.5.1")]
+    [InlineData(401, "Unauthorized", "https://tools.ietf.org/html/rfc7235#section-3.1")]
+    [InlineData(403, "Forbidden", "https://tools.ietf.org/html/rfc7231#section-6.5.3")]
+    [InlineData(404, "Not Found", "https://tools.ietf.org/html/rfc7231#section-6.5.4")]
+    [InlineData(406, "Not Acceptable", "https://tools.ietf.org/html/rfc7231#section-6.5.6")]
+    [InlineData(409, "Conflict", "https://tools.ietf.org/html/rfc7231#section-6.5.8")]
+    [InlineData(415, "Unsupported Media Type", "https://tools.ietf.org/html/rfc7231#section-6.5.13")]
+    [InlineData(422, "Unprocessable Entity", "https://tools.ietf.org/html/rfc4918#section-11.2")]
+    [InlineData(500, "Internal Server Error", "https://tools.ietf.org/html/rfc7231#section-6.6.1")]
+    public void ItDocumentsErrorResponses(int status, string title, string type)
+    {
+        var operation = GivenOperationWithResponse($"{status}", "application/json");
+
+        new ProblemDetailsOperationFilter().Apply(operation, OperationFilterContext());
+
+        operation.Should().BeResponseOf($"{status}", "application/json")
+            .And.Example.As<OpenApiObject>()
+            .Should(o =>
+            {
+                using (new AssertionScope())
+                {
+                    o.Should().Contain("status", status);
+                    o.Should().Contain("title", title);
+                    o.Should().Contain("type", type);
+                }
+            });
+    }
+
+    [Fact]
+    public void ItIgnoresUnusedStatusCodeResponses()
+    {
+        var operation = GivenOperationWithResponse("401", "application/json");
+
+        new ProblemDetailsOperationFilter().Apply(operation, OperationFilterContext());
+
+        operation.Responses.Should().ContainKey("401");
+        operation.Responses.Should().NotContainKey("403");
+    }
+
+    [Fact]
+    public void ItIgnoresUnusedMediaTypeResponses()
+    {
+        var operation = GivenOperationWithResponse("401", "application/xml");
+
+        new ProblemDetailsOperationFilter().Apply(operation, OperationFilterContext());
+
+        operation.Responses["401"].As<OpenApiResponse>().Content.Should().NotContainKey("application/json");
+        operation.Responses["401"].As<OpenApiResponse>().Content.Should().ContainKey("application/xml");
+        operation.Responses["401"].As<OpenApiResponse>().Content["application/xml"].Example.Should().NotBeNull();
+    }
+
+    private static OpenApiOperation GivenOperationWithResponse(string responseKey, string responseMediaType) =>
+        new()
+        {
+            Responses =
+            {
+                {
+                    responseKey, new OpenApiResponse
+                    {
+                        Content =
+                        {
+                            { responseMediaType, new OpenApiMediaType() }
+                        }
+                    }
+                }
+            }
+        };
+
+    private static OperationFilterContext OperationFilterContext()
+    {
+        return new OperationFilterContext(new ApiDescription(), null, null, null);
+    }
+}
+
+public static class AssertionsExtensions
+{
+    public static void Should<T>(this T value, Action<T> assertions)
+    {
+        assertions(value);
+    }
+}
+
+public static class OpenApiAssertionsExtensions
+{
+    public static OpenApiOperationAssertions Should(this OpenApiOperation operation)
+    {
+        return new OpenApiOperationAssertions(operation);
+    }
+
+    public static OpenApiObjectAssertions Should(this OpenApiObject value)
+    {
+        return new OpenApiObjectAssertions(value);
+    }
+}
+
+public class OpenApiOperationAssertions(OpenApiOperation operation)
+{
+    public AndConstraint<OpenApiMediaType> BeResponseOf(string key, string mediaType)
+    {
+        return new AndConstraint<OpenApiMediaType>(
+            operation.Responses[key].As<OpenApiResponse>()
+                .Content[mediaType].As<OpenApiMediaType>()
+        );
+    }
+}
+
+public class OpenApiObjectAssertions(OpenApiObject value)
+    : ReferenceTypeAssertions<OpenApiObject, OpenApiObjectAssertions>(value)
+{
+    private readonly OpenApiObject _value = value;
+
+    public AndConstraint<StringAssertions> Contain(string name, string expectedValue)
+    {
+        return _value[name]
+                .As<OpenApiString>()
+                .Value
+                .Should()
+                .Be(expectedValue)
+            ;
+    }
+
+    public AndConstraint<NumericAssertions<int>> Contain(string name, int expectedValue)
+    {
+        return _value[name]
+                .As<OpenApiInteger>()
+                .Value
+                .Should()
+                .Be(expectedValue)
+            ;
+    }
+
+    protected override string Identifier => "OpenApiObject";
+}

--- a/Libraries/CO.CDP.Swashbuckle/CO.CDP.Swashbuckle.csproj
+++ b/Libraries/CO.CDP.Swashbuckle/CO.CDP.Swashbuckle.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.1"/>
+        <PackageReference Include="DotSwashbuckle.AspNetCore" Version="3.0.8"/>
+    </ItemGroup>
+</Project>

--- a/Libraries/CO.CDP.Swashbuckle/Filter/ProblemDetailsOperationFilter.cs
+++ b/Libraries/CO.CDP.Swashbuckle/Filter/ProblemDetailsOperationFilter.cs
@@ -15,6 +15,7 @@ public class ProblemDetailsOperationFilter : IOperationFilter
         ["type"] = new OpenApiString("https://tools.ietf.org/html/rfc7231#section-6.5.1"),
         ["title"] = new OpenApiString(ReasonPhrases.GetReasonPhrase(StatusCodes.Status400BadRequest)),
         ["status"] = new OpenApiInteger(StatusCodes.Status400BadRequest),
+        ["detail"] = new OpenApiString("Error details."),
         ["errors"] = new OpenApiObject
         {
             ["property1"] = new OpenApiArray
@@ -29,6 +30,7 @@ public class ProblemDetailsOperationFilter : IOperationFilter
         ["type"] = new OpenApiString("https://tools.ietf.org/html/rfc7235#section-3.1"),
         ["title"] = new OpenApiString(ReasonPhrases.GetReasonPhrase(StatusCodes.Status401Unauthorized)),
         ["status"] = new OpenApiInteger(StatusCodes.Status401Unauthorized),
+        ["detail"] = new OpenApiString("Error details."),
     };
 
     private static readonly OpenApiObject Status403ProblemDetails = new()
@@ -36,6 +38,7 @@ public class ProblemDetailsOperationFilter : IOperationFilter
         ["type"] = new OpenApiString("https://tools.ietf.org/html/rfc7231#section-6.5.3"),
         ["title"] = new OpenApiString(ReasonPhrases.GetReasonPhrase(StatusCodes.Status403Forbidden)),
         ["status"] = new OpenApiInteger(StatusCodes.Status403Forbidden),
+        ["detail"] = new OpenApiString("Error details."),
     };
 
     private static readonly OpenApiObject Status404ProblemDetails = new()
@@ -43,6 +46,7 @@ public class ProblemDetailsOperationFilter : IOperationFilter
         ["type"] = new OpenApiString("https://tools.ietf.org/html/rfc7231#section-6.5.4"),
         ["title"] = new OpenApiString(ReasonPhrases.GetReasonPhrase(StatusCodes.Status404NotFound)),
         ["status"] = new OpenApiInteger(StatusCodes.Status404NotFound),
+        ["detail"] = new OpenApiString("Error details."),
     };
 
     private static readonly OpenApiObject Status406ProblemDetails = new()
@@ -50,6 +54,7 @@ public class ProblemDetailsOperationFilter : IOperationFilter
         ["type"] = new OpenApiString("https://tools.ietf.org/html/rfc7231#section-6.5.6"),
         ["title"] = new OpenApiString(ReasonPhrases.GetReasonPhrase(StatusCodes.Status406NotAcceptable)),
         ["status"] = new OpenApiInteger(StatusCodes.Status406NotAcceptable),
+        ["detail"] = new OpenApiString("Error details."),
     };
 
     private static readonly OpenApiObject Status409ProblemDetails = new()
@@ -57,6 +62,7 @@ public class ProblemDetailsOperationFilter : IOperationFilter
         ["type"] = new OpenApiString("https://tools.ietf.org/html/rfc7231#section-6.5.8"),
         ["title"] = new OpenApiString(ReasonPhrases.GetReasonPhrase(StatusCodes.Status409Conflict)),
         ["status"] = new OpenApiInteger(StatusCodes.Status409Conflict),
+        ["detail"] = new OpenApiString("Error details."),
     };
 
     private static readonly OpenApiObject Status415ProblemDetails = new()
@@ -64,6 +70,7 @@ public class ProblemDetailsOperationFilter : IOperationFilter
         ["type"] = new OpenApiString("https://tools.ietf.org/html/rfc7231#section-6.5.13"),
         ["title"] = new OpenApiString(ReasonPhrases.GetReasonPhrase(StatusCodes.Status415UnsupportedMediaType)),
         ["status"] = new OpenApiInteger(StatusCodes.Status415UnsupportedMediaType),
+        ["detail"] = new OpenApiString("Error details."),
     };
 
     private static readonly OpenApiObject _status422ProblemDetails = new()
@@ -71,6 +78,7 @@ public class ProblemDetailsOperationFilter : IOperationFilter
         ["type"] = new OpenApiString("https://tools.ietf.org/html/rfc4918#section-11.2"),
         ["title"] = new OpenApiString(ReasonPhrases.GetReasonPhrase(StatusCodes.Status422UnprocessableEntity)),
         ["status"] = new OpenApiInteger(StatusCodes.Status422UnprocessableEntity),
+        ["detail"] = new OpenApiString("Error details."),
     };
 
     private static readonly OpenApiObject Status500ProblemDetails = new()
@@ -78,6 +86,7 @@ public class ProblemDetailsOperationFilter : IOperationFilter
         ["type"] = new OpenApiString("https://tools.ietf.org/html/rfc7231#section-6.6.1"),
         ["title"] = new OpenApiString(ReasonPhrases.GetReasonPhrase(StatusCodes.Status500InternalServerError)),
         ["status"] = new OpenApiInteger(StatusCodes.Status500InternalServerError),
+        ["detail"] = new OpenApiString("Error details."),
     };
 
     private readonly Dictionary<string, IOpenApiAny> _problemDetails = new()

--- a/Libraries/CO.CDP.Swashbuckle/Filter/ProblemDetailsOperationFilter.cs
+++ b/Libraries/CO.CDP.Swashbuckle/Filter/ProblemDetailsOperationFilter.cs
@@ -15,7 +15,6 @@ public class ProblemDetailsOperationFilter : IOperationFilter
         ["type"] = new OpenApiString("https://tools.ietf.org/html/rfc7231#section-6.5.1"),
         ["title"] = new OpenApiString(ReasonPhrases.GetReasonPhrase(StatusCodes.Status400BadRequest)),
         ["status"] = new OpenApiInteger(StatusCodes.Status400BadRequest),
-        ["traceId"] = new OpenApiString("00-982607166a542147b435be3a847aaa12-fc75498eb9f09a83-00"),
         ["errors"] = new OpenApiObject
         {
             ["property1"] = new OpenApiArray
@@ -30,7 +29,6 @@ public class ProblemDetailsOperationFilter : IOperationFilter
         ["type"] = new OpenApiString("https://tools.ietf.org/html/rfc7235#section-3.1"),
         ["title"] = new OpenApiString(ReasonPhrases.GetReasonPhrase(StatusCodes.Status401Unauthorized)),
         ["status"] = new OpenApiInteger(StatusCodes.Status401Unauthorized),
-        ["traceId"] = new OpenApiString("00-982607166a542147b435be3a847aaa12-fc75498eb9f09a83-00"),
     };
 
     private static readonly OpenApiObject Status403ProblemDetails = new()
@@ -38,7 +36,6 @@ public class ProblemDetailsOperationFilter : IOperationFilter
         ["type"] = new OpenApiString("https://tools.ietf.org/html/rfc7231#section-6.5.3"),
         ["title"] = new OpenApiString(ReasonPhrases.GetReasonPhrase(StatusCodes.Status403Forbidden)),
         ["status"] = new OpenApiInteger(StatusCodes.Status403Forbidden),
-        ["traceId"] = new OpenApiString("00-982607166a542147b435be3a847aaa12-fc75498eb9f09a83-00"),
     };
 
     private static readonly OpenApiObject Status404ProblemDetails = new()
@@ -46,7 +43,6 @@ public class ProblemDetailsOperationFilter : IOperationFilter
         ["type"] = new OpenApiString("https://tools.ietf.org/html/rfc7231#section-6.5.4"),
         ["title"] = new OpenApiString(ReasonPhrases.GetReasonPhrase(StatusCodes.Status404NotFound)),
         ["status"] = new OpenApiInteger(StatusCodes.Status404NotFound),
-        ["traceId"] = new OpenApiString("00-982607166a542147b435be3a847aaa12-fc75498eb9f09a83-00"),
     };
 
     private static readonly OpenApiObject Status406ProblemDetails = new()
@@ -54,7 +50,6 @@ public class ProblemDetailsOperationFilter : IOperationFilter
         ["type"] = new OpenApiString("https://tools.ietf.org/html/rfc7231#section-6.5.6"),
         ["title"] = new OpenApiString(ReasonPhrases.GetReasonPhrase(StatusCodes.Status406NotAcceptable)),
         ["status"] = new OpenApiInteger(StatusCodes.Status406NotAcceptable),
-        ["traceId"] = new OpenApiString("00-982607166a542147b435be3a847aaa12-fc75498eb9f09a83-00"),
     };
 
     private static readonly OpenApiObject Status409ProblemDetails = new()
@@ -62,7 +57,6 @@ public class ProblemDetailsOperationFilter : IOperationFilter
         ["type"] = new OpenApiString("https://tools.ietf.org/html/rfc7231#section-6.5.8"),
         ["title"] = new OpenApiString(ReasonPhrases.GetReasonPhrase(StatusCodes.Status409Conflict)),
         ["status"] = new OpenApiInteger(StatusCodes.Status409Conflict),
-        ["traceId"] = new OpenApiString("00-982607166a542147b435be3a847aaa12-fc75498eb9f09a83-00"),
     };
 
     private static readonly OpenApiObject Status415ProblemDetails = new()
@@ -70,7 +64,6 @@ public class ProblemDetailsOperationFilter : IOperationFilter
         ["type"] = new OpenApiString("https://tools.ietf.org/html/rfc7231#section-6.5.13"),
         ["title"] = new OpenApiString(ReasonPhrases.GetReasonPhrase(StatusCodes.Status415UnsupportedMediaType)),
         ["status"] = new OpenApiInteger(StatusCodes.Status415UnsupportedMediaType),
-        ["traceId"] = new OpenApiString("00-982607166a542147b435be3a847aaa12-fc75498eb9f09a83-00"),
     };
 
     private static readonly OpenApiObject _status422ProblemDetails = new()
@@ -78,7 +71,6 @@ public class ProblemDetailsOperationFilter : IOperationFilter
         ["type"] = new OpenApiString("https://tools.ietf.org/html/rfc4918#section-11.2"),
         ["title"] = new OpenApiString(ReasonPhrases.GetReasonPhrase(StatusCodes.Status422UnprocessableEntity)),
         ["status"] = new OpenApiInteger(StatusCodes.Status422UnprocessableEntity),
-        ["traceId"] = new OpenApiString("00-982607166a542147b435be3a847aaa12-fc75498eb9f09a83-00"),
     };
 
     private static readonly OpenApiObject Status500ProblemDetails = new()
@@ -86,7 +78,6 @@ public class ProblemDetailsOperationFilter : IOperationFilter
         ["type"] = new OpenApiString("https://tools.ietf.org/html/rfc7231#section-6.6.1"),
         ["title"] = new OpenApiString(ReasonPhrases.GetReasonPhrase(StatusCodes.Status500InternalServerError)),
         ["status"] = new OpenApiInteger(StatusCodes.Status500InternalServerError),
-        ["traceId"] = new OpenApiString("00-982607166a542147b435be3a847aaa12-fc75498eb9f09a83-00"),
     };
 
     private readonly Dictionary<string, IOpenApiAny> _problemDetails = new()

--- a/Libraries/CO.CDP.Swashbuckle/Filter/ProblemDetailsOperationFilter.cs
+++ b/Libraries/CO.CDP.Swashbuckle/Filter/ProblemDetailsOperationFilter.cs
@@ -1,0 +1,116 @@
+using System.Net.Mime;
+using DotSwashbuckle.AspNetCore.SwaggerGen;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Models;
+
+namespace CO.CDP.Swashbuckle.Filter;
+
+/// Inspired by the <a href="https://stackoverflow.com/a/75673373">StackOverflow answer</a>.
+public class ProblemDetailsOperationFilter : IOperationFilter
+{
+    private static readonly OpenApiObject Status400ProblemDetails = new()
+    {
+        ["type"] = new OpenApiString("https://tools.ietf.org/html/rfc7231#section-6.5.1"),
+        ["title"] = new OpenApiString(ReasonPhrases.GetReasonPhrase(StatusCodes.Status400BadRequest)),
+        ["status"] = new OpenApiInteger(StatusCodes.Status400BadRequest),
+        ["traceId"] = new OpenApiString("00-982607166a542147b435be3a847aaa12-fc75498eb9f09a83-00"),
+        ["errors"] = new OpenApiObject
+        {
+            ["property1"] = new OpenApiArray
+            {
+                new OpenApiString("The property field is required"),
+            },
+        },
+    };
+
+    private static readonly OpenApiObject Status401ProblemDetails = new()
+    {
+        ["type"] = new OpenApiString("https://tools.ietf.org/html/rfc7235#section-3.1"),
+        ["title"] = new OpenApiString(ReasonPhrases.GetReasonPhrase(StatusCodes.Status401Unauthorized)),
+        ["status"] = new OpenApiInteger(StatusCodes.Status401Unauthorized),
+        ["traceId"] = new OpenApiString("00-982607166a542147b435be3a847aaa12-fc75498eb9f09a83-00"),
+    };
+
+    private static readonly OpenApiObject Status403ProblemDetails = new()
+    {
+        ["type"] = new OpenApiString("https://tools.ietf.org/html/rfc7231#section-6.5.3"),
+        ["title"] = new OpenApiString(ReasonPhrases.GetReasonPhrase(StatusCodes.Status403Forbidden)),
+        ["status"] = new OpenApiInteger(StatusCodes.Status403Forbidden),
+        ["traceId"] = new OpenApiString("00-982607166a542147b435be3a847aaa12-fc75498eb9f09a83-00"),
+    };
+
+    private static readonly OpenApiObject Status404ProblemDetails = new()
+    {
+        ["type"] = new OpenApiString("https://tools.ietf.org/html/rfc7231#section-6.5.4"),
+        ["title"] = new OpenApiString(ReasonPhrases.GetReasonPhrase(StatusCodes.Status404NotFound)),
+        ["status"] = new OpenApiInteger(StatusCodes.Status404NotFound),
+        ["traceId"] = new OpenApiString("00-982607166a542147b435be3a847aaa12-fc75498eb9f09a83-00"),
+    };
+
+    private static readonly OpenApiObject Status406ProblemDetails = new()
+    {
+        ["type"] = new OpenApiString("https://tools.ietf.org/html/rfc7231#section-6.5.6"),
+        ["title"] = new OpenApiString(ReasonPhrases.GetReasonPhrase(StatusCodes.Status406NotAcceptable)),
+        ["status"] = new OpenApiInteger(StatusCodes.Status406NotAcceptable),
+        ["traceId"] = new OpenApiString("00-982607166a542147b435be3a847aaa12-fc75498eb9f09a83-00"),
+    };
+
+    private static readonly OpenApiObject Status409ProblemDetails = new()
+    {
+        ["type"] = new OpenApiString("https://tools.ietf.org/html/rfc7231#section-6.5.8"),
+        ["title"] = new OpenApiString(ReasonPhrases.GetReasonPhrase(StatusCodes.Status409Conflict)),
+        ["status"] = new OpenApiInteger(StatusCodes.Status409Conflict),
+        ["traceId"] = new OpenApiString("00-982607166a542147b435be3a847aaa12-fc75498eb9f09a83-00"),
+    };
+
+    private static readonly OpenApiObject Status415ProblemDetails = new()
+    {
+        ["type"] = new OpenApiString("https://tools.ietf.org/html/rfc7231#section-6.5.13"),
+        ["title"] = new OpenApiString(ReasonPhrases.GetReasonPhrase(StatusCodes.Status415UnsupportedMediaType)),
+        ["status"] = new OpenApiInteger(StatusCodes.Status415UnsupportedMediaType),
+        ["traceId"] = new OpenApiString("00-982607166a542147b435be3a847aaa12-fc75498eb9f09a83-00"),
+    };
+
+    private static readonly OpenApiObject _status422ProblemDetails = new()
+    {
+        ["type"] = new OpenApiString("https://tools.ietf.org/html/rfc4918#section-11.2"),
+        ["title"] = new OpenApiString(ReasonPhrases.GetReasonPhrase(StatusCodes.Status422UnprocessableEntity)),
+        ["status"] = new OpenApiInteger(StatusCodes.Status422UnprocessableEntity),
+        ["traceId"] = new OpenApiString("00-982607166a542147b435be3a847aaa12-fc75498eb9f09a83-00"),
+    };
+
+    private static readonly OpenApiObject Status500ProblemDetails = new()
+    {
+        ["type"] = new OpenApiString("https://tools.ietf.org/html/rfc7231#section-6.6.1"),
+        ["title"] = new OpenApiString(ReasonPhrases.GetReasonPhrase(StatusCodes.Status500InternalServerError)),
+        ["status"] = new OpenApiInteger(StatusCodes.Status500InternalServerError),
+        ["traceId"] = new OpenApiString("00-982607166a542147b435be3a847aaa12-fc75498eb9f09a83-00"),
+    };
+
+    private readonly Dictionary<string, IOpenApiAny> _problemDetails = new()
+    {
+        { StatusCodes.Status400BadRequest.ToString(), Status400ProblemDetails },
+        { StatusCodes.Status401Unauthorized.ToString(), Status401ProblemDetails },
+        { StatusCodes.Status403Forbidden.ToString(), Status403ProblemDetails },
+        { StatusCodes.Status404NotFound.ToString(), Status404ProblemDetails },
+        { StatusCodes.Status406NotAcceptable.ToString(), Status406ProblemDetails },
+        { StatusCodes.Status409Conflict.ToString(), Status409ProblemDetails },
+        { StatusCodes.Status415UnsupportedMediaType.ToString(), Status415ProblemDetails },
+        { StatusCodes.Status422UnprocessableEntity.ToString(), _status422ProblemDetails },
+        { StatusCodes.Status500InternalServerError.ToString(), Status500ProblemDetails },
+    };
+
+    public void Apply(OpenApiOperation operation, OperationFilterContext context)
+    {
+        foreach (var operationResponse in operation.Responses)
+        {
+            _problemDetails.TryGetValue(operationResponse.Key, out var problemDetail);
+            foreach (var content in operationResponse.Value.Content)
+            {
+                content.Value.Example = problemDetail;
+            }
+        }
+    }
+}

--- a/Services/CO.CDP.DataSharing.WebApi/Api/DataSharing.cs
+++ b/Services/CO.CDP.DataSharing.WebApi/Api/DataSharing.cs
@@ -1,6 +1,8 @@
 using System.Reflection;
 using CO.CDP.DataSharing.WebApi.Model;
+using CO.CDP.Swashbuckle.Filter;
 using DotSwashbuckle.AspNetCore.SwaggerGen;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.OpenApi.Models;
 
 namespace CO.CDP.DataSharing.WebApi.Api;
@@ -36,7 +38,8 @@ public static class EndpointExtensions
                             "https://cdp.cabinetoffice.gov.uk/organisations/f4596cdd-12e5-4f25-9db1-4312474e516f")
                     }
                 ],
-                AdditionalEntities = [
+                AdditionalEntities =
+                [
                     new OrganisationReference
                     {
                         Id = Guid.Parse("f4596cdd-12e5-4f25-9db1-4312474e516f"),
@@ -51,7 +54,8 @@ public static class EndpointExtensions
                     Scheme = "CDP-PPON",
                     Id = "1e39d0ce-3abd-43c5-9f23-78c92e437f2a",
                     LegalName = "Acme Corporation Ltd",
-                    Uri = new Uri("https://cdp.cabinetoffice.gov.uk/organisations/1e39d0ce-3abd-43c5-9f23-78c92e437f2a")
+                    Uri = new Uri(
+                        "https://cdp.cabinetoffice.gov.uk/organisations/1e39d0ce-3abd-43c5-9f23-78c92e437f2a")
                 },
                 AdditionalIdentifiers =
                 [
@@ -100,7 +104,8 @@ public static class EndpointExtensions
                         {
                             Name = "_Steel01",
                             Type = FormQuestionType.Text,
-                            Text = "<span style='font-weight: bold;'>Central Government Only - UK</span><span style='font-size:16.000000000000004px'><br /></span><p><span style='font-size:13.333299999999998px'>For contracts which relate to projects/programmes (i) with a value of \u00a310 million or more; or (ii) a value of less than \u00a310 million where it is anticipated that the project will require in excess of 500 tonnes of steel; please describe the steel specific supply chain management systems, policies, standards and procedures you have in place to ensure robust supply chain management and compliance with relevant legislation.</span><span style='font-size:16.000000000000004px'></span></p><span style='font-size:13.333299999999998px'>Please provide details of previous similar projects where you have demonstrated a high level of competency and effectiveness in managing all supply chain members involved in steel supply or production to ensure a sustainable and resilient supply of steel.</span>",
+                            Text =
+                                "<span style='font-weight: bold;'>Central Government Only - UK</span><span style='font-size:16.000000000000004px'><br /></span><p><span style='font-size:13.333299999999998px'>For contracts which relate to projects/programmes (i) with a value of \u00a310 million or more; or (ii) a value of less than \u00a310 million where it is anticipated that the project will require in excess of 500 tonnes of steel; please describe the steel specific supply chain management systems, policies, standards and procedures you have in place to ensure robust supply chain management and compliance with relevant legislation.</span><span style='font-size:16.000000000000004px'></span></p><span style='font-size:13.333299999999998px'>Please provide details of previous similar projects where you have demonstrated a high level of competency and effectiveness in managing all supply chain members involved in steel supply or production to ensure a sustainable and resilient supply of steel.</span>",
                             IsRequired = false,
                             SectionName = "Steel"
                         },
@@ -108,7 +113,8 @@ public static class EndpointExtensions
                         {
                             Name = "_Steel02",
                             Type = FormQuestionType.Text,
-                            Text = "<p>Please provide all the relevant details of previous breaches of health and safety legislation in the last 5 years, applicable to the country in which you operate, on comparable projects, for both:&nbsp;<span style='font-size:13.333299999999998px'>Your organisation</span></p><span style='font-size:13.333299999999998px'>All your supply chain members involved in the production or supply of steel</span>",
+                            Text =
+                                "<p>Please provide all the relevant details of previous breaches of health and safety legislation in the last 5 years, applicable to the country in which you operate, on comparable projects, for both:&nbsp;<span style='font-size:13.333299999999998px'>Your organisation</span></p><span style='font-size:13.333299999999998px'>All your supply chain members involved in the production or supply of steel</span>",
                             IsRequired = true,
                             SectionName = "Steel"
                         },
@@ -116,7 +122,8 @@ public static class EndpointExtensions
                         {
                             Name = "_ModernSlavery01",
                             Type = FormQuestionType.Text,
-                            Text = "Central Government Only - Tackling Modern Slavery in Supply Chains<span style='font-size:16.000000000000004px'><br /></span><span style='font-size:13.333299999999998px'>If you are a relevant commercial organisation subject to Section 54 of the Modern Slavery Act 2015, and if your latest statement is available electronically please provide:</span><span style='font-size:16.000000000000004px'><br /></span><span style='font-size:13.333299999999998px'i. the web address,</span><span style='font-size:16.000000000000004px'><br /></span><span style='font-size:13.333299999999998px>ii. precise reference of the documents.</span><span style='font-size:16.000000000000004px'><br /></span><span style='font-size:13.333299999999998p'>iii. If your latest statement is not available electronically, please provide a copy.</span>",
+                            Text =
+                                "Central Government Only - Tackling Modern Slavery in Supply Chains<span style='font-size:16.000000000000004px'><br /></span><span style='font-size:13.333299999999998px'>If you are a relevant commercial organisation subject to Section 54 of the Modern Slavery Act 2015, and if your latest statement is available electronically please provide:</span><span style='font-size:16.000000000000004px'><br /></span><span style='font-size:13.333299999999998px'i. the web address,</span><span style='font-size:16.000000000000004px'><br /></span><span style='font-size:13.333299999999998px>ii. precise reference of the documents.</span><span style='font-size:16.000000000000004px'><br /></span><span style='font-size:13.333299999999998p'>iii. If your latest statement is not available electronically, please provide a copy.</span>",
                             IsRequired = true,
                             SectionName = "Modern slavery"
                         },
@@ -124,7 +131,8 @@ public static class EndpointExtensions
                         {
                             Name = "_CarbonNetZero01",
                             Type = FormQuestionType.Boolean,
-                            Text = "Please confirm that you have detailed your environmental management measures by completing and publishing a Carbon Reduction Plan which meets the required reporting standard.",
+                            Text =
+                                "Please confirm that you have detailed your environmental management measures by completing and publishing a Carbon Reduction Plan which meets the required reporting standard.",
                             IsRequired = true,
                             SectionName = "Carbon Net Zero"
                         }
@@ -145,8 +153,9 @@ public static class EndpointExtensions
                     ]
                 },
             })
-            .Produces<SupplierInformation>(200, "application/json")
-            .Produces(StatusCodes.Status404NotFound)
+            .Produces<SupplierInformation>(StatusCodes.Status200OK, "application/json")
+            .Produces<ProblemDetails>(StatusCodes.Status401Unauthorized)
+            .Produces<ProblemDetails>(StatusCodes.Status404NotFound)
             .WithOpenApi(operation =>
             {
                 operation.OperationId = "GetSharedData";
@@ -154,7 +163,8 @@ public static class EndpointExtensions
                     "[STUB] Operation to obtain Supplier information which has been shared as part of a notice. [STUB]";
                 operation.Summary = "[STUB] Request Supplier Submitted Information. [STUB]";
                 operation.Responses["200"].Description = "Organisation Information including Form Answers.";
-                operation.Responses["404"].Description = "Share code not found or not authorised.";
+                operation.Responses["401"].Description = "Valid authentication credentials are missing in the request.";
+                operation.Responses["404"].Description = "Share code not found or the caller is not authorised to use it.";
                 return operation;
             });
 
@@ -168,6 +178,7 @@ public static class EndpointExtensions
                 }
             ))
             .Produces<ShareReceipt>(StatusCodes.Status200OK, "application/json")
+            .Produces<ProblemDetails>(StatusCodes.Status401Unauthorized)
             .WithOpenApi(operation =>
             {
                 operation.OperationId = "CreateSharedData";
@@ -175,6 +186,7 @@ public static class EndpointExtensions
                     "[STUB] Operation to obtain Supplier information which has been shared as part of a notice. [STUB]";
                 operation.Summary = "[STUB] Create Supplier Submitted Information. [STUB]";
                 operation.Responses["200"].Description = "Organisation Information created.";
+                operation.Responses["401"].Description = "Valid authentication credentials are missing in the request.";
                 return operation;
             });
     }
@@ -192,5 +204,6 @@ public static class ApiExtensions
         });
         options.IncludeXmlComments(Path.Combine(AppContext.BaseDirectory,
             $"{Assembly.GetExecutingAssembly().GetName().Name}.xml"));
+        options.OperationFilter<ProblemDetailsOperationFilter>();
     }
 }

--- a/Services/CO.CDP.DataSharing.WebApi/Api/DataSharing.cs
+++ b/Services/CO.CDP.DataSharing.WebApi/Api/DataSharing.cs
@@ -156,6 +156,7 @@ public static class EndpointExtensions
             .Produces<SupplierInformation>(StatusCodes.Status200OK, "application/json")
             .Produces<ProblemDetails>(StatusCodes.Status401Unauthorized)
             .Produces<ProblemDetails>(StatusCodes.Status404NotFound)
+            .Produces<ProblemDetails>(StatusCodes.Status500InternalServerError)
             .WithOpenApi(operation =>
             {
                 operation.OperationId = "GetSharedData";
@@ -165,6 +166,7 @@ public static class EndpointExtensions
                 operation.Responses["200"].Description = "Organisation Information including Form Answers.";
                 operation.Responses["401"].Description = "Valid authentication credentials are missing in the request.";
                 operation.Responses["404"].Description = "Share code not found or the caller is not authorised to use it.";
+                operation.Responses["500"].Description = "Internal server error.";
                 return operation;
             });
 
@@ -179,6 +181,7 @@ public static class EndpointExtensions
             ))
             .Produces<ShareReceipt>(StatusCodes.Status200OK, "application/json")
             .Produces<ProblemDetails>(StatusCodes.Status401Unauthorized)
+            .Produces<ProblemDetails>(StatusCodes.Status500InternalServerError)
             .WithOpenApi(operation =>
             {
                 operation.OperationId = "CreateSharedData";
@@ -187,6 +190,7 @@ public static class EndpointExtensions
                 operation.Summary = "[STUB] Create Supplier Submitted Information. [STUB]";
                 operation.Responses["200"].Description = "Organisation Information created.";
                 operation.Responses["401"].Description = "Valid authentication credentials are missing in the request.";
+                operation.Responses["500"].Description = "Internal server error.";
                 return operation;
             });
     }

--- a/Services/CO.CDP.DataSharing.WebApi/CO.CDP.DataSharing.WebApi.csproj
+++ b/Services/CO.CDP.DataSharing.WebApi/CO.CDP.DataSharing.WebApi.csproj
@@ -14,6 +14,8 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.1"/>
+        <PackageReference Include="DotSwashbuckle.AspNetCore" Version="3.0.8"/>
         <ProjectReference Include="..\..\Libraries\CO.CDP.Swashbuckle\CO.CDP.Swashbuckle.csproj" />
     </ItemGroup>
 

--- a/Services/CO.CDP.DataSharing.WebApi/CO.CDP.DataSharing.WebApi.csproj
+++ b/Services/CO.CDP.DataSharing.WebApi/CO.CDP.DataSharing.WebApi.csproj
@@ -14,8 +14,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.1"/>
-        <PackageReference Include="DotSwashbuckle.AspNetCore" Version="3.0.8" />
+        <ProjectReference Include="..\..\Libraries\CO.CDP.Swashbuckle\CO.CDP.Swashbuckle.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Services/CO.CDP.DataSharing.WebApi/Program.cs
+++ b/Services/CO.CDP.DataSharing.WebApi/Program.cs
@@ -9,6 +9,8 @@ builder.Services.AddSwaggerGen(options => { options.DocumentDataSharingApi(); })
 
 builder.Services.AddHealthChecks();
 
+builder.Services.AddProblemDetails();
+
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.


### PR DESCRIPTION
* Document DataSharing error responses

* Convert exceptions to `ProblemDetails` responses (in DataSharing)

    ```csharp
    builder.Services.AddProblemDetails();
    ```

* Provide a library for documenting `ProblemDetails` examples (CO.CDP.Swashbuckle)
  
   It can be added to the application by:
   ```csharp
   builder.Services.AddSwaggerGen(options => options.OperationFilter<ProblemDetailsOperationFilter>() }
   ```

    As a result, responses that use ProblemDetails will be documented with examples:
  
    <img width="549" alt="image" src="https://github.com/cabinetoffice/GCGS-Central-Digital-Platform/assets/190447/968ef23e-e6be-499c-92e5-be272d7b2aa9">
