### PR TITLE
Align IDE ports with docker compose defaults

### DIFF
--- a/Frontend/CO.CDP.OrganisationApp/Properties/launchSettings.json
+++ b/Frontend/CO.CDP.OrganisationApp/Properties/launchSettings.json
@@ -27,7 +27,7 @@
             "commandName": "Project",
             "dotnetRunMessages": true,
             "launchBrowser": true,
-            "applicationUrl": "https://localhost:7149;http://localhost:5219",
+            "applicationUrl": "https://localhost:7149;http://localhost:8090",
             "environmentVariables": {
                 "ASPNETCORE_ENVIRONMENT": "Development",
                 "ASPNETCORE_HOSTINGSTARTUPASSEMBLIES": "Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation"

--- a/README.md
+++ b/README.md
@@ -20,11 +20,34 @@ First, containers need to be built:
 make build-docker
 ```
 
-The database can be then started together with migrations:
+The database can be then started together with migrations (`make db`):
 
 ```bash
 docker compose up -d db organisation-information-migrations
 ```
+
+### Mixing services started by IDE with Docker
+
+During development, testing, or debugging it's often useful to run some services with Docker,
+while others with an IDE.
+
+To do that, first start all the services with Docker. Remember to override environment variables for services
+that you plan to run in an IDE:
+
+```bash
+OrganisationService=http://host.docker.internal:8082 docker compose up -d
+```
+
+In the above example, we pointed the Organisation service to the one we plan to start with the IDE.
+`host.docker.internal` is used to connect from Docker containers to the host machine.
+
+Next, stop selected services in Docker:
+
+```bash
+docker compose stop organisation
+```
+
+Finally, start the selected services in the IDE.
 
 ### Configuration
 

--- a/Services/CO.CDP.DataSharing.WebApi/DataSharing.http
+++ b/Services/CO.CDP.DataSharing.WebApi/DataSharing.http
@@ -1,6 +1,6 @@
-@DataSharing_HostAddress = http://localhost:5203
+@DataSharing_HostAddress = http://localhost:8088
 
-GET {{DataSharing_HostAddress}}/share/data
+GET {{DataSharing_HostAddress}}/share/data/c161cc9b
 Accept: application/json
 
 ###

--- a/Services/CO.CDP.DataSharing.WebApi/Properties/launchSettings.json
+++ b/Services/CO.CDP.DataSharing.WebApi/Properties/launchSettings.json
@@ -14,7 +14,7 @@
       "dotnetRunMessages": true,
       "launchBrowser": true,
       "launchUrl": "swagger",
-      "applicationUrl": "http://localhost:5203",
+      "applicationUrl": "http://localhost:8088",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
@@ -24,7 +24,7 @@
       "dotnetRunMessages": true,
       "launchBrowser": true,
       "launchUrl": "swagger",
-      "applicationUrl": "https://localhost:7176;http://localhost:5203",
+      "applicationUrl": "https://localhost:7176;http://localhost:8088",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/Services/CO.CDP.Forms.WebApi/Forms.http
+++ b/Services/CO.CDP.Forms.WebApi/Forms.http
@@ -1,4 +1,4 @@
-@Forms_HostAddress = http://localhost:5014
+@Forms_HostAddress = http://localhost:8086
 
 GET {{Forms_HostAddress}}/forms/
 Accept: application/json

--- a/Services/CO.CDP.Forms.WebApi/Properties/launchSettings.json
+++ b/Services/CO.CDP.Forms.WebApi/Properties/launchSettings.json
@@ -14,7 +14,7 @@
       "dotnetRunMessages": true,
       "launchBrowser": true,
       "launchUrl": "swagger",
-      "applicationUrl": "http://localhost:5014",
+      "applicationUrl": "http://localhost:8086",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
@@ -24,7 +24,7 @@
       "dotnetRunMessages": true,
       "launchBrowser": true,
       "launchUrl": "swagger",
-      "applicationUrl": "https://localhost:7032;http://localhost:5014",
+      "applicationUrl": "https://localhost:7032;http://localhost:8086",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/Services/CO.CDP.Organisation.WebApi/Organisation.http
+++ b/Services/CO.CDP.Organisation.WebApi/Organisation.http
@@ -1,4 +1,4 @@
-@Organisation_HostAddress = http://localhost:5288
+@Organisation_HostAddress = http://localhost:8082
 
 GET {{Organisation_HostAddress}}/organisations/
 Accept: application/json

--- a/Services/CO.CDP.Organisation.WebApi/Properties/launchSettings.json
+++ b/Services/CO.CDP.Organisation.WebApi/Properties/launchSettings.json
@@ -14,7 +14,7 @@
       "dotnetRunMessages": true,
       "launchBrowser": true,
       "launchUrl": "swagger",
-      "applicationUrl": "http://localhost:5288",
+      "applicationUrl": "http://localhost:8082",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "ConnectionStrings__OrganisationInformationDatabase": "Server=localhost;Database=cdp;Username=cdp_user;Password=cdp123;"
@@ -25,7 +25,7 @@
       "dotnetRunMessages": true,
       "launchBrowser": true,
       "launchUrl": "swagger",
-      "applicationUrl": "https://localhost:7208;http://localhost:5288",
+      "applicationUrl": "https://localhost:7208;http://localhost:8082",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/Services/CO.CDP.Person.WebApi/Person.http
+++ b/Services/CO.CDP.Person.WebApi/Person.http
@@ -1,4 +1,4 @@
-@Person_HostAddress = http://localhost:5120
+@Person_HostAddress = http://localhost:8084
 
 GET {{Person_HostAddress}}/persons/
 Accept: application/json

--- a/Services/CO.CDP.Person.WebApi/Properties/launchSettings.json
+++ b/Services/CO.CDP.Person.WebApi/Properties/launchSettings.json
@@ -14,7 +14,7 @@
       "dotnetRunMessages": true,
       "launchBrowser": true,
       "launchUrl": "swagger",
-      "applicationUrl": "http://localhost:5120",
+      "applicationUrl": "http://localhost:8084",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
@@ -24,7 +24,7 @@
       "dotnetRunMessages": true,
       "launchBrowser": true,
       "launchUrl": "swagger",
-      "applicationUrl": "https://localhost:7130;http://localhost:5120",
+      "applicationUrl": "https://localhost:7130;http://localhost:8084",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/Services/CO.CDP.Tenant.WebApi/Properties/launchSettings.json
+++ b/Services/CO.CDP.Tenant.WebApi/Properties/launchSettings.json
@@ -14,7 +14,7 @@
       "dotnetRunMessages": true,
       "launchBrowser": true,
       "launchUrl": "swagger",
-      "applicationUrl": "http://localhost:5182",
+      "applicationUrl": "http://localhost:8080",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "ConnectionStrings__OrganisationInformationDatabase": "Server=localhost;Database=cdp;Username=cdp_user;Password=cdp123;"
@@ -25,7 +25,7 @@
       "dotnetRunMessages": true,
       "launchBrowser": true,
       "launchUrl": "swagger",
-      "applicationUrl": "https://localhost:7264;http://localhost:5182",
+      "applicationUrl": "https://localhost:7264;http://localhost:8080",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/Services/CO.CDP.Tenant.WebApi/Tenant.http
+++ b/Services/CO.CDP.Tenant.WebApi/Tenant.http
@@ -1,4 +1,4 @@
-@Tenant_HostAddress = http://localhost:5182
+@Tenant_HostAddress = http://localhost:8080
 
 GET {{Tenant_HostAddress}}/tenants/
 Accept: application/json

--- a/compose.yml
+++ b/compose.yml
@@ -21,9 +21,9 @@ services:
       file: compose.common.yml
       service: organisation-app
     environment:
-      TenantService: 'http://tenant:8080'
-      OrganisationService: 'http://organisation:8080'
-      PersonService: 'http://person:8080'
+      TenantService: '${TenantService:-http://tenant:8080}'
+      OrganisationService: '${OrganisationService:-http://organisation:8080}'
+      PersonService: '${PersonService:-http://person:8080}'
   tenant:
     extends:
       file: compose.common.yml


### PR DESCRIPTION
This change lowers the friction to mix services started with Docker and an IDE.

## Mixing services started by IDE with Docker

During development, testing, or debugging it's often useful to run some services with Docker,
while others with an IDE.

To do that, first start all the services with Docker. Remember to override environment variables for services
that you plan to run in an IDE:

```bash
OrganisationService=http://host.docker.internal:8082 docker compose up -d
```

In the above example, we pointed the Organisation service to the one we plan to start with the IDE.
`host.docker.internal` is used to connect from Docker containers to the host machine.

Next, stop selected services in Docker:

```bash
docker compose stop organisation
```

Finally, start the selected services in the IDE.