### PR TITLE
DP-128: Include organisation scope in the tenant lookup response

### DIFF
--- a/Services/CO.CDP.Tenant.WebApi/Api/Tenant.cs
+++ b/Services/CO.CDP.Tenant.WebApi/Api/Tenant.cs
@@ -77,12 +77,13 @@ public static class EndpointExtensions
                                     Id = Guid.Parse("826def77-311c-424d-a86e-069029c859c0"),
                                     Name = "Acme Corporation / John Doe",
                                     Organisations = [
-                                        new OrganisationReference
+                                        new UserOrganisation
                                         {
                                             Id = Guid.Parse("23135984-b706-47db-8867-b4e34016b501"),
                                             Name = "Acme Corporation",
                                             Roles = [PartyRole.Supplier],
-                                            Uri = new Uri("/organsations/23135984-b706-47db-8867-b4e34016b501")
+                                            Uri = new Uri("/organsations/23135984-b706-47db-8867-b4e34016b501"),
+                                            Scopes = ["Responder"]
                                         }
                                     ]
                                 }

--- a/Services/CO.CDP.Tenant.WebApi/Model/TenantLookup.cs
+++ b/Services/CO.CDP.Tenant.WebApi/Model/TenantLookup.cs
@@ -30,5 +30,22 @@ internal record UserTenant
     /// <example>"Acme Corporation / John Doe"</example>
     public required string Name { get; init; }
 
-    public required List<OrganisationReference> Organisations { get; init; } = [];
+    public required List<UserOrganisation> Organisations { get; init; } = [];
+}
+
+internal record UserOrganisation
+{
+    /// <example>"f4596cdd-12e5-4f25-9db1-4312474e516f"</example>
+    public required Guid Id { get; init; }
+
+    /// <example>"Acme Group Ltd"</example>
+    public required string Name { get; init; }
+
+    public required List<PartyRole> Roles { get; init; }
+
+    /// <example>"https://cdp.cabinetoffice.gov.uk/organisations/f4596cdd-12e5-4f25-9db1-4312474e516f"</example>
+    public required Uri Uri { get; init; }
+
+    /// <example>["Responder"]</example>
+    public required List<string> Scopes { get; init; }
 }


### PR DESCRIPTION
```json
{
  "user": {
    "urn": "urn:fdc:gov.uk:2022:43af5a8b-f4c0-414b-b341-d4f1fa894302",
    "name": "John Doe",
    "email": "john@example.com"
  },
  "tenants": [
    {
      "id": "826def77-311c-424d-a86e-069029c859c0",
      "name": "Acme Corporation / John Doe",
      "organisations": [
        {
          "id": "f4596cdd-12e5-4f25-9db1-4312474e516f",
          "name": "Acme Group Ltd",
          "roles": [
            "Buyer"
          ],
          "uri": "https://cdp.cabinetoffice.gov.uk/organisations/f4596cdd-12e5-4f25-9db1-4312474e516f",
          "scopes": [
            "Responder"
          ]
        }
      ]
    }
  ]
}
```