### PR TITLE
DP-1 Wire up subdomains to corresponding services

### DIFF
--- a/terragrunt/modules/core-iam/ci-datasource.tf
+++ b/terragrunt/modules/core-iam/ci-datasource.tf
@@ -211,6 +211,7 @@ data "aws_iam_policy_document" "terraform_global" {
       "elasticloadbalancing:DescribeListeners",
       "elasticloadbalancing:DescribeLoadBalancerAttributes",
       "elasticloadbalancing:DescribeLoadBalancers",
+      "elasticloadbalancing:DescribeRules",
       "elasticloadbalancing:DescribeTags",
       "elasticloadbalancing:DescribeTargetGroupAttributes",
       "elasticloadbalancing:DescribeTargetGroups",
@@ -357,11 +358,14 @@ data "aws_iam_policy_document" "terraform_product" {
       "elasticloadbalancing:AddTags",
       "elasticloadbalancing:Create*",
       "elasticloadbalancing:Delete*",
+      "elasticloadbalancing:Describe*",
       "elasticloadbalancing:Modify*",
+      "elasticloadbalancing:SetRulePriorities",
     ]
     effect = "Allow"
     resources = [
       "arn:aws:elasticloadbalancing:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:listener/app/cdp-*",
+      "arn:aws:elasticloadbalancing:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:listener-rule/app/cdp-*",
       "arn:aws:elasticloadbalancing:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:loadbalancer/app/cdp-*",
       "arn:aws:elasticloadbalancing:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:targetgroup/cdp-*",
     ]

--- a/terragrunt/modules/ecs-service/listeners.tf
+++ b/terragrunt/modules/ecs-service/listeners.tf
@@ -1,25 +1,3 @@
-resource "aws_lb_listener" "ecs_http" {
-  count = var.listening_port != null ? 1 : 0
-
-  load_balancer_arn = var.ecs_alb_arn
-  port              = var.listening_port
-  protocol          = "HTTP"
-  tags              = var.tags
-
-  default_action {
-    target_group_arn = aws_lb_target_group.this[0].arn
-    type             = "forward"
-  }
-  #   default_action {
-  #     redirect {
-  #       status_code = "HTTP_301"
-  #       protocol    = "HTTPS"
-  #       port        = "443"
-  #     }
-  #     type = "redirect"
-  #   }
-}
-
 resource "aws_lb_target_group" "this" {
   count = var.listening_port != null ? 1 : 0
 
@@ -44,4 +22,26 @@ resource "aws_lb_target_group" "this" {
   lifecycle {
     create_before_destroy = false
   }
+}
+
+
+resource "aws_lb_listener_rule" "this" {
+  count = var.listening_port != null ? 1 : 0
+
+
+  listener_arn = var.ecs_listener_arn
+  priority     = var.host_port - 8000
+
+  action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.this[0].arn
+  }
+
+  condition {
+    host_header {
+      values = ["${var.name}.dev.supplier.information.findatender.codatt.net"]
+    }
+  }
+
+  tags = merge(var.tags, { Name : var.name })
 }

--- a/terragrunt/modules/ecs-service/variables.tf
+++ b/terragrunt/modules/ecs-service/variables.tf
@@ -30,8 +30,8 @@ variable "desired_count" {
   type        = number
 }
 
-variable "ecs_alb_arn" {
-  description = "ECS Application Loadbalancer ARN"
+variable "ecs_listener_arn" {
+  description = "ECS Application Loadbalancer Listener ARN"
   type        = string
 }
 

--- a/terragrunt/modules/ecs/load-balancer.tf
+++ b/terragrunt/modules/ecs/load-balancer.tf
@@ -15,3 +15,22 @@ resource "aws_lb" "ecs" {
     }
   )
 }
+
+resource "aws_lb_listener" "ecs_http" {
+
+  load_balancer_arn = aws_lb.ecs.arn
+  port              = 80
+  protocol          = "HTTP"
+  tags              = var.tags
+
+  default_action {
+    type = "fixed-response"
+
+    fixed_response {
+      content_type = "text/plain"
+      message_body = "Fixed response from ${var.environment} environment"
+      status_code  = "200"
+    }
+  }
+
+}

--- a/terragrunt/modules/ecs/service-data-sharing.tf
+++ b/terragrunt/modules/ecs/service-data-sharing.tf
@@ -34,7 +34,7 @@ module "ecs_service_data_sharing" {
   cluster_id             = aws_ecs_cluster.this.id
   container_port         = local.data_sharing.ports.container
   cpu                    = local.data_sharing.cpu
-  ecs_alb_arn            = aws_lb.ecs.arn
+  ecs_listener_arn       = aws_lb_listener.ecs_http.arn
   ecs_alb_sg_id          = var.alb_sg_id
   ecs_service_base_sg_id = var.ecs_sg_id
   environment            = var.environment

--- a/terragrunt/modules/ecs/service-forms.tf
+++ b/terragrunt/modules/ecs/service-forms.tf
@@ -33,7 +33,7 @@ module "ecs_service_forms" {
   cluster_id             = aws_ecs_cluster.this.id
   container_port         = local.forms.ports.container
   cpu                    = local.forms.cpu
-  ecs_alb_arn            = aws_lb.ecs.arn
+  ecs_listener_arn       = aws_lb_listener.ecs_http.arn
   ecs_alb_sg_id          = var.alb_sg_id
   ecs_service_base_sg_id = var.ecs_sg_id
   environment            = var.environment

--- a/terragrunt/modules/ecs/service-organisation-app.tf
+++ b/terragrunt/modules/ecs/service-organisation-app.tf
@@ -37,7 +37,7 @@ module "ecs_service_organisation_app" {
   cluster_id             = aws_ecs_cluster.this.id
   container_port         = local.organisation_app.ports.container
   cpu                    = local.organisation_app.cpu
-  ecs_alb_arn            = aws_lb.ecs.arn
+  ecs_listener_arn       = aws_lb_listener.ecs_http.arn
   ecs_alb_sg_id          = var.alb_sg_id
   ecs_service_base_sg_id = var.ecs_sg_id
   environment            = var.environment

--- a/terragrunt/modules/ecs/service-organisation.tf
+++ b/terragrunt/modules/ecs/service-organisation.tf
@@ -34,7 +34,7 @@ module "ecs_service_organisation" {
   cluster_id             = aws_ecs_cluster.this.id
   container_port         = local.organisation.ports.container
   cpu                    = local.organisation.cpu
-  ecs_alb_arn            = aws_lb.ecs.arn
+  ecs_listener_arn       = aws_lb_listener.ecs_http.arn
   ecs_alb_sg_id          = var.alb_sg_id
   ecs_service_base_sg_id = var.ecs_sg_id
   environment            = var.environment

--- a/terragrunt/modules/ecs/service-person.tf
+++ b/terragrunt/modules/ecs/service-person.tf
@@ -34,7 +34,7 @@ module "ecs_service_person" {
   cluster_id             = aws_ecs_cluster.this.id
   container_port         = local.person.ports.container
   cpu                    = local.person.cpu
-  ecs_alb_arn            = aws_lb.ecs.arn
+  ecs_listener_arn       = aws_lb_listener.ecs_http.arn
   ecs_alb_sg_id          = var.alb_sg_id
   ecs_service_base_sg_id = var.ecs_sg_id
   environment            = var.environment

--- a/terragrunt/modules/ecs/service-tenant.tf
+++ b/terragrunt/modules/ecs/service-tenant.tf
@@ -34,7 +34,7 @@ module "ecs_service_tenant" {
   cluster_id             = aws_ecs_cluster.this.id
   container_port         = local.tenant.ports.container
   cpu                    = local.tenant.cpu
-  ecs_alb_arn            = aws_lb.ecs.arn
+  ecs_listener_arn       = aws_lb_listener.ecs_http.arn
   ecs_alb_sg_id          = var.alb_sg_id
   ecs_service_base_sg_id = var.ecs_sg_id
   environment            = var.environment

--- a/terragrunt/modules/ecs/task-organisation-information-migrations.tf
+++ b/terragrunt/modules/ecs/task-organisation-information-migrations.tf
@@ -33,7 +33,7 @@ module "ecs_service_organisation_information_migrations" {
   cluster_id             = aws_ecs_cluster.this.id
   container_port         = local.organisation_information_migrations.ports.container
   cpu                    = local.organisation_information_migrations.cpu
-  ecs_alb_arn            = aws_lb.ecs.arn
+  ecs_listener_arn       = aws_lb_listener.ecs_http.arn
   ecs_alb_sg_id          = var.alb_sg_id
   ecs_service_base_sg_id = var.ecs_sg_id
   environment            = var.environment


### PR DESCRIPTION
[DP-1](https://noticingsystem.atlassian.net/browse/DP-1)
This will allow HTTP access to all services via **supplier.information.findatender.codatt.net** domain, i.e.:
- http://tenant.dev.supplier.information.findatender.codatt.net/swagger
- http://organisation.dev.supplier.information.findatender.codatt.net/swagger
- http://person.dev.supplier.information.findatender.codatt.net/swagger
- http://forms.dev.supplier.information.findatender.codatt.net/swagger
- http://data-sharing.dev.supplier.information.findatender.codatt.net/swagger
- http://organisation-app.dev.supplier.information.findatender.codatt.net
