### PR TITLE
DP-1 Provision certificate enable HTTPS access

### DIFF
--- a/terragrunt/components/service/ecs/terragrunt.hcl
+++ b/terragrunt/components/service/ecs/terragrunt.hcl
@@ -39,6 +39,7 @@ dependency core_networking {
   mock_outputs = {
     private_subnet_ids          = "mock"
     private_subnets_cidr_blocks = "mock"
+    public_hosted_zone_fqdn     = "mock"
     public_hosted_zone_id       = "mock"
     public_subnet_ids           = "mock"
     public_subnets_cidr_blocks  = "mock"
@@ -90,6 +91,7 @@ inputs = {
 
   private_subnet_ids          = dependency.core_networking.outputs.private_subnet_ids
   private_subnets_cidr_blocks = dependency.core_networking.outputs.private_subnets_cidr_blocks
+  public_hosted_zone_fqdn     = dependency.core_networking.outputs.public_hosted_zone_fqdn
   public_hosted_zone_id       = dependency.core_networking.outputs.public_hosted_zone_id
   public_subnet_ids           = dependency.core_networking.outputs.public_subnet_ids
   public_subnets_cidr_blocks  = dependency.core_networking.outputs.public_subnets_cidr_blocks

--- a/terragrunt/modules/core-iam/ci-datasource.tf
+++ b/terragrunt/modules/core-iam/ci-datasource.tf
@@ -61,6 +61,21 @@ data "aws_iam_policy_document" "terraform_global" {
 
   statement {
     actions = [
+      "acm:AddTagsToCertificate",
+      "acm:DeleteCertificate",
+      "acm:DescribeCertificate",
+      "acm:ListTagsForCertificate",
+      "acm:RequestCertificate",
+    ]
+    effect = "Allow"
+    resources = [
+      "*",
+    ]
+    sid = "ManageACMs"
+  }
+
+  statement {
+    actions = [
       "apigateway:DELETE",
       "apigateway:GET",
       "apigateway:PATCH",

--- a/terragrunt/modules/core-networking/outputs.tf
+++ b/terragrunt/modules/core-networking/outputs.tf
@@ -21,6 +21,10 @@ output "private_subnets_cidr_blocks" {
   value       = aws_subnet.private.*.cidr_block
 }
 
+output "public_hosted_zone_fqdn" {
+  value = aws_route53_zone.public.name
+}
+
 output "public_hosted_zone_id" {
   value = aws_route53_zone.public.id
 }

--- a/terragrunt/modules/ecs/acm.tf
+++ b/terragrunt/modules/ecs/acm.tf
@@ -1,0 +1,32 @@
+resource "aws_acm_certificate" "this" {
+  domain_name       = var.public_hosted_zone_fqdn
+  subject_alternative_names = ["*.${var.public_hosted_zone_fqdn}"] # @todo (ABN) Restrict to service sub-domains
+  validation_method = "DNS"
+
+  tags = merge(var.tags, { Name = var.public_hosted_zone_fqdn })
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_acm_certificate_validation" "this" {
+  certificate_arn         = aws_acm_certificate.this.arn
+  validation_record_fqdns = [for record in aws_acm_certificate.this.domain_validation_options : record.resource_record_name]
+}
+
+resource "aws_route53_record" "cert_validation" {
+  for_each = {
+    for dvo in aws_acm_certificate.this.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+  allow_overwrite = true
+  name            = each.value.name
+  records         = [each.value.record]
+  ttl             = 60
+  type            = each.value.type
+  zone_id         = var.public_hosted_zone_id
+}

--- a/terragrunt/modules/ecs/load-balancer.tf
+++ b/terragrunt/modules/ecs/load-balancer.tf
@@ -16,11 +16,12 @@ resource "aws_lb" "ecs" {
   )
 }
 
-resource "aws_lb_listener" "ecs_http" {
+resource "aws_lb_listener" "ecs" {
 
+  certificate_arn   = aws_acm_certificate.this.arn
   load_balancer_arn = aws_lb.ecs.arn
-  port              = 80
-  protocol          = "HTTP"
+  port              = 443
+  protocol          = "HTTPS"
   tags              = var.tags
 
   default_action {
@@ -31,6 +32,23 @@ resource "aws_lb_listener" "ecs_http" {
       message_body = "Fixed response from ${var.environment} environment"
       status_code  = "200"
     }
+  }
+}
+
+resource "aws_lb_listener" "ecs_http" {
+
+  load_balancer_arn = aws_lb.ecs.arn
+  port              = 80
+  protocol          = "HTTP"
+  tags              = var.tags
+
+  default_action {
+    redirect {
+      status_code = "HTTP_301"
+      protocol    = "HTTPS"
+      port        = "443"
+    }
+    type = "redirect"
   }
 
 }

--- a/terragrunt/modules/ecs/security-groups.tf
+++ b/terragrunt/modules/ecs/security-groups.tf
@@ -1,5 +1,15 @@
+resource "aws_security_group_rule" "public_access_to_alb" {
+  description       = "Public access to ${local.name_prefix} service via ALB"
+  from_port         = 443
+  protocol          = "TCP"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = var.alb_sg_id
+  to_port           = 443
+  type              = "ingress"
+}
+
 resource "aws_security_group_rule" "public_access_to_alb_http" {
-  description       = "Public access to ${local.name_prefix} service via ALB 80"
+  description       = "Public access to ${local.name_prefix} service via ALB port 80"
   from_port         = 80
   protocol          = "TCP"
   cidr_blocks       = ["0.0.0.0/0"]

--- a/terragrunt/modules/ecs/service-data-sharing.tf
+++ b/terragrunt/modules/ecs/service-data-sharing.tf
@@ -34,7 +34,7 @@ module "ecs_service_data_sharing" {
   cluster_id             = aws_ecs_cluster.this.id
   container_port         = local.data_sharing.ports.container
   cpu                    = local.data_sharing.cpu
-  ecs_listener_arn       = aws_lb_listener.ecs_http.arn
+  ecs_listener_arn       = aws_lb_listener.ecs.arn
   ecs_alb_sg_id          = var.alb_sg_id
   ecs_service_base_sg_id = var.ecs_sg_id
   environment            = var.environment

--- a/terragrunt/modules/ecs/service-forms.tf
+++ b/terragrunt/modules/ecs/service-forms.tf
@@ -33,7 +33,7 @@ module "ecs_service_forms" {
   cluster_id             = aws_ecs_cluster.this.id
   container_port         = local.forms.ports.container
   cpu                    = local.forms.cpu
-  ecs_listener_arn       = aws_lb_listener.ecs_http.arn
+  ecs_listener_arn       = aws_lb_listener.ecs.arn
   ecs_alb_sg_id          = var.alb_sg_id
   ecs_service_base_sg_id = var.ecs_sg_id
   environment            = var.environment

--- a/terragrunt/modules/ecs/service-organisation-app.tf
+++ b/terragrunt/modules/ecs/service-organisation-app.tf
@@ -37,7 +37,7 @@ module "ecs_service_organisation_app" {
   cluster_id             = aws_ecs_cluster.this.id
   container_port         = local.organisation_app.ports.container
   cpu                    = local.organisation_app.cpu
-  ecs_listener_arn       = aws_lb_listener.ecs_http.arn
+  ecs_listener_arn       = aws_lb_listener.ecs.arn
   ecs_alb_sg_id          = var.alb_sg_id
   ecs_service_base_sg_id = var.ecs_sg_id
   environment            = var.environment

--- a/terragrunt/modules/ecs/service-organisation.tf
+++ b/terragrunt/modules/ecs/service-organisation.tf
@@ -34,7 +34,7 @@ module "ecs_service_organisation" {
   cluster_id             = aws_ecs_cluster.this.id
   container_port         = local.organisation.ports.container
   cpu                    = local.organisation.cpu
-  ecs_listener_arn       = aws_lb_listener.ecs_http.arn
+  ecs_listener_arn       = aws_lb_listener.ecs.arn
   ecs_alb_sg_id          = var.alb_sg_id
   ecs_service_base_sg_id = var.ecs_sg_id
   environment            = var.environment

--- a/terragrunt/modules/ecs/service-person.tf
+++ b/terragrunt/modules/ecs/service-person.tf
@@ -34,7 +34,7 @@ module "ecs_service_person" {
   cluster_id             = aws_ecs_cluster.this.id
   container_port         = local.person.ports.container
   cpu                    = local.person.cpu
-  ecs_listener_arn       = aws_lb_listener.ecs_http.arn
+  ecs_listener_arn       = aws_lb_listener.ecs.arn
   ecs_alb_sg_id          = var.alb_sg_id
   ecs_service_base_sg_id = var.ecs_sg_id
   environment            = var.environment

--- a/terragrunt/modules/ecs/service-tenant.tf
+++ b/terragrunt/modules/ecs/service-tenant.tf
@@ -34,7 +34,7 @@ module "ecs_service_tenant" {
   cluster_id             = aws_ecs_cluster.this.id
   container_port         = local.tenant.ports.container
   cpu                    = local.tenant.cpu
-  ecs_listener_arn       = aws_lb_listener.ecs_http.arn
+  ecs_listener_arn       = aws_lb_listener.ecs.arn
   ecs_alb_sg_id          = var.alb_sg_id
   ecs_service_base_sg_id = var.ecs_sg_id
   environment            = var.environment

--- a/terragrunt/modules/ecs/task-organisation-information-migrations.tf
+++ b/terragrunt/modules/ecs/task-organisation-information-migrations.tf
@@ -33,7 +33,7 @@ module "ecs_service_organisation_information_migrations" {
   cluster_id             = aws_ecs_cluster.this.id
   container_port         = local.organisation_information_migrations.ports.container
   cpu                    = local.organisation_information_migrations.cpu
-  ecs_listener_arn       = aws_lb_listener.ecs_http.arn
+  ecs_listener_arn       = aws_lb_listener.ecs.arn
   ecs_alb_sg_id          = var.alb_sg_id
   ecs_service_base_sg_id = var.ecs_sg_id
   environment            = var.environment

--- a/terragrunt/modules/ecs/variables.tf
+++ b/terragrunt/modules/ecs/variables.tf
@@ -47,6 +47,11 @@ variable "product" {
   })
 }
 
+variable "public_hosted_zone_fqdn" {
+  description = "Fully qualified domain name of the public hosted zone"
+  type        = string
+}
+
 variable "public_hosted_zone_id" {
   description = "ID of the public hosted zone"
   type        = string


### PR DESCRIPTION
[DP-1](https://noticingsystem.atlassian.net/browse/DP-1)
This will enable HTTPS for all sub-domains of **supplier.information.findatender.codatt.net** domain, i.e.:
- https://tenant.dev.supplier.information.findatender.codatt.net/swagger
- https://organisation.dev.supplier.information.findatender.codatt.net/swagger
- https://person.dev.supplier.information.findatender.codatt.net/swagger
- https://forms.dev.supplier.information.findatender.codatt.net/swagger
- https://data-sharing.dev.supplier.information.findatender.codatt.net/swagger
- https://organisation-app.dev.supplier.information.findatender.codatt.net/