### PR TITLE
DP-1 Create and link the domain alias to organisation-app

### DIFF
--- a/terragrunt/modules/ecs-service/listeners.tf
+++ b/terragrunt/modules/ecs-service/listeners.tf
@@ -39,7 +39,7 @@ resource "aws_lb_listener_rule" "this" {
 
   condition {
     host_header {
-      values = ["${var.name}.${var.product.public_hosted_zone}"]
+      values = var.is_frontend_app ? local.tg_host_header_with_alias : local.tg_host_header
     }
   }
 

--- a/terragrunt/modules/ecs-service/locals.tf
+++ b/terragrunt/modules/ecs-service/locals.tf
@@ -1,0 +1,4 @@
+locals {
+  tg_host_header            = ["${var.name}.${var.product.public_hosted_zone}"]
+  tg_host_header_with_alias = ["${var.name}.${var.product.public_hosted_zone}", var.product.public_hosted_zone]
+}

--- a/terragrunt/modules/ecs-service/variables.tf
+++ b/terragrunt/modules/ecs-service/variables.tf
@@ -64,6 +64,12 @@ variable "host_port" {
   type        = number
 }
 
+variable "is_frontend_app" {
+  description = "Weather it is an API or the Frontend service, to link the domain alias to"
+  type        = bool
+  default     = false
+}
+
 variable "listening_port" {
   description = "Port on which the load balancer is listening for this service"
   type        = number

--- a/terragrunt/modules/ecs/route53.tf
+++ b/terragrunt/modules/ecs/route53.tf
@@ -8,3 +8,16 @@ resource "aws_route53_record" "ecs_alb" {
 
   records = [aws_lb.ecs.dns_name]
 }
+
+resource "aws_route53_record" "ecs_alb_frontend_alias" {
+
+  name    = var.product.public_hosted_zone
+  type    = "A"
+  zone_id = var.public_hosted_zone_id
+
+  alias {
+    evaluate_target_health = true
+    name                   = aws_lb.ecs.dns_name
+    zone_id                = aws_lb.ecs.zone_id
+  }
+}

--- a/terragrunt/modules/ecs/service-organisation-app.tf
+++ b/terragrunt/modules/ecs/service-organisation-app.tf
@@ -42,6 +42,7 @@ module "ecs_service_organisation_app" {
   ecs_service_base_sg_id = var.ecs_sg_id
   family                 = "app"
   host_port              = local.organisation_app.ports.host
+  is_frontend_app        = true
   listening_port         = local.organisation_app.ports.listener
   memory                 = local.organisation_app.memory
   name                   = local.organisation_app.name


### PR DESCRIPTION
[DP-1](https://noticingsystem.atlassian.net/browse/DP-1)

This will create [dev.supplier.information.findatender.codatt.net](https://dev.supplier.information.findatender.codatt.net) alias and link it to the **organisation-app**, _aka frontend_.
Similar to the existing [organisation-app.dev.supplier.information.findatender.codatt.net](https://organisation-app.dev.supplier.information.findatender.codatt.net/)