### PR TITLE
DP-1 Set the service environmnet names to wither prod or dev

### DIFF
--- a/terragrunt/modules/ecs-service/variables.tf
+++ b/terragrunt/modules/ecs-service/variables.tf
@@ -65,7 +65,7 @@ variable "host_port" {
 }
 
 variable "is_frontend_app" {
-  description = "Weather it is an API or the Frontend service, to link the domain alias to"
+  description = "Whether it is an API or the Frontend service, to link the domain alias to"
   type        = bool
   default     = false
 }

--- a/terragrunt/modules/ecs/locals.tf
+++ b/terragrunt/modules/ecs/locals.tf
@@ -1,5 +1,7 @@
 locals {
 
+  service_environment = var.environment == "production" ? "Production" : "Development"
+
   ecr_urls = [
     for repos in aws_ecr_repository.this.* : { for repo, attr in repos : repo => attr.repository_url }
     ][

--- a/terragrunt/modules/ecs/service-data-sharing.tf
+++ b/terragrunt/modules/ecs/service-data-sharing.tf
@@ -20,7 +20,7 @@ module "ecs_service_data_sharing" {
       container_port       = local.data_sharing.ports.container
       cpu                  = local.data_sharing.cpu
       conn_string_location = var.db_connection_secret_arn
-      environment          = title(var.environment)
+      environment          = local.service_environment
       host_port            = local.data_sharing.ports.host
       image                = "${local.ecr_urls[local.data_sharing.name]}:latest"
       lg_name              = aws_cloudwatch_log_group.tasks[local.data_sharing.name].name

--- a/terragrunt/modules/ecs/service-forms.tf
+++ b/terragrunt/modules/ecs/service-forms.tf
@@ -19,7 +19,7 @@ module "ecs_service_forms" {
     {
       container_port = local.forms.ports.container
       cpu            = local.forms.cpu
-      environment    = title(var.environment)
+      environment    = local.service_environment
       host_port      = local.forms.ports.host
       image          = "${local.ecr_urls[local.forms.name]}:latest"
       lg_name        = aws_cloudwatch_log_group.tasks[local.forms.name].name

--- a/terragrunt/modules/ecs/service-organisation-app.tf
+++ b/terragrunt/modules/ecs/service-organisation-app.tf
@@ -20,7 +20,7 @@ module "ecs_service_organisation_app" {
       container_port       = local.organisation_app.ports.container
       cpu                  = local.organisation_app.cpu
       conn_string_location = var.db_connection_secret_arn
-      environment          = title(var.environment)
+      environment          = local.service_environment
       host_port            = local.organisation_app.ports.host
       image                = "${local.ecr_urls[local.organisation_app.name]}:latest"
       lg_name              = aws_cloudwatch_log_group.tasks[local.organisation_app.name].name

--- a/terragrunt/modules/ecs/service-organisation.tf
+++ b/terragrunt/modules/ecs/service-organisation.tf
@@ -20,7 +20,7 @@ module "ecs_service_organisation" {
       container_port       = local.organisation.ports.container
       cpu                  = local.organisation.cpu
       conn_string_location = var.db_connection_secret_arn
-      environment          = title(var.environment)
+      environment          = local.service_environment
       host_port            = local.organisation.ports.host
       image                = "${local.ecr_urls[local.organisation.name]}:latest"
       lg_name              = aws_cloudwatch_log_group.tasks[local.organisation.name].name

--- a/terragrunt/modules/ecs/service-person.tf
+++ b/terragrunt/modules/ecs/service-person.tf
@@ -20,7 +20,7 @@ module "ecs_service_person" {
       container_port       = local.person.ports.container
       cpu                  = local.person.cpu
       conn_string_location = var.db_connection_secret_arn
-      environment          = title(var.environment)
+      environment          = local.service_environment
       host_port            = local.person.ports.host
       image                = "${local.ecr_urls[local.person.name]}:latest"
       lg_name              = aws_cloudwatch_log_group.tasks[local.person.name].name

--- a/terragrunt/modules/ecs/service-tenant.tf
+++ b/terragrunt/modules/ecs/service-tenant.tf
@@ -20,7 +20,7 @@ module "ecs_service_tenant" {
       container_port       = local.tenant.ports.container
       cpu                  = local.tenant.cpu
       conn_string_location = var.db_connection_secret_arn
-      environment          = title(var.environment)
+      environment          = local.service_environment
       host_port            = local.tenant.ports.host
       image                = "${local.ecr_urls[local.tenant.name]}:latest"
       lg_name              = aws_cloudwatch_log_group.tasks[local.tenant.name].name

--- a/terragrunt/modules/ecs/task-organisation-information-migrations.tf
+++ b/terragrunt/modules/ecs/task-organisation-information-migrations.tf
@@ -19,7 +19,7 @@ module "ecs_service_organisation_information_migrations" {
       container_port       = local.organisation_information_migrations.ports.container
       cpu                  = local.organisation_information_migrations.cpu
       conn_string_location = var.db_connection_secret_arn
-      environment          = title(var.environment)
+      environment          = local.service_environment
       host_port            = local.organisation_information_migrations.ports.host
       image                = "${local.ecr_urls["organisation-information-migrations"]}:latest"
       lg_name              = aws_cloudwatch_log_group.tasks[local.organisation_information_migrations.name].name


### PR DESCRIPTION
At the moment there is no recognition of Staging (or any other account name related) environment to allow presenting swagger UI. 
So even in the Staging account we need to mark `ASPNETCORE_ENVIRONMENT` as Development 
![image](https://github.com/cabinetoffice/GCGS-Central-Digital-Platform/assets/1422984/16ba985b-a475-4349-818b-448e6e5c48ae)
