### PR TITLE
DP-1 Use subdomains to address linked services

### DIFF
--- a/terragrunt/modules/ecs/service-organisation-app.tf
+++ b/terragrunt/modules/ecs/service-organisation-app.tf
@@ -17,20 +17,21 @@ module "ecs_service_organisation_app" {
   container_definitions = templatefile(
     "${path.module}/templates/task-definitions/${local.organisation_app.name}.json.tftpl",
     {
-      container_port       = local.organisation_app.ports.container
-      cpu                  = local.organisation_app.cpu
-      conn_string_location = var.db_connection_secret_arn
-      environment          = local.service_environment
-      host_port            = local.organisation_app.ports.host
-      image                = "${local.ecr_urls[local.organisation_app.name]}:latest"
-      lg_name              = aws_cloudwatch_log_group.tasks[local.organisation_app.name].name
-      lg_prefix            = "app"
-      lg_region            = data.aws_region.current.name
-      memory               = local.organisation_app.memory
-      name                 = local.organisation_app.name
-      oneLogin_authority   = local.one_loging.credential_locations.authority
-      oneLogin_client_id   = local.one_loging.credential_locations.client_id
-      oneLogin_private_key = local.one_loging.credential_locations.private_key
+      container_port          = local.organisation_app.ports.container
+      cpu                     = local.organisation_app.cpu
+      conn_string_location    = var.db_connection_secret_arn
+      environment             = local.service_environment
+      host_port               = local.organisation_app.ports.host
+      image                   = "${local.ecr_urls[local.organisation_app.name]}:latest"
+      lg_name                 = aws_cloudwatch_log_group.tasks[local.organisation_app.name].name
+      lg_prefix               = "app"
+      lg_region               = data.aws_region.current.name
+      memory                  = local.organisation_app.memory
+      name                    = local.organisation_app.name
+      oneLogin_authority      = local.one_loging.credential_locations.authority
+      oneLogin_client_id      = local.one_loging.credential_locations.client_id
+      oneLogin_private_key    = local.one_loging.credential_locations.private_key
+      public_hosted_zone_fqdn = var.public_hosted_zone_fqdn
     }
   )
 

--- a/terragrunt/modules/ecs/templates/task-definitions/organisation-app.json.tftpl
+++ b/terragrunt/modules/ecs/templates/task-definitions/organisation-app.json.tftpl
@@ -22,9 +22,9 @@
     "environment": [
         {"name": "ASPNETCORE_ENVIRONMENT", "value": "${environment}"},
         {"name": "ASPNETCORE_HTTP_PORTS", "value": "${host_port}"},
-        {"name": "TenantService", "value": "http://cdp-sirsi-1939052961.eu-west-2.elb.amazonaws.com:8080"},
-        {"name": "OrganisationService", "value": "http://cdp-sirsi-1939052961.eu-west-2.elb.amazonaws.com:8084"},
-        {"name": "PersonService", "value": "http://cdp-sirsi-1939052961.eu-west-2.elb.amazonaws.com:8082"}
+        {"name": "TenantService", "value": "https://tenant.${public_hosted_zone_fqdn}"},
+        {"name": "OrganisationService", "value": "https://organisation.${public_hosted_zone_fqdn}"},
+        {"name": "PersonService", "value": "https://person.${public_hosted_zone_fqdn}"}
     ],
     "secrets": [
         {"name": "OneLogin__Authority", "valueFrom": "${oneLogin_authority}"},


### PR DESCRIPTION
[DP-1](https://noticingsystem.atlassian.net/browse/DP-1) 
- Use subdomains to address linked services, instead of the load-balancer's DNS and service port