### PR TITLE
Throw a DuplicateOrganisationException if the tenant is already registered for the organisation

### DIFF
--- a/Services/CO.CDP.OrganisationInformation.Persistence.Tests/DatabaseOrganisationRepositoryTest.cs
+++ b/Services/CO.CDP.OrganisationInformation.Persistence.Tests/DatabaseOrganisationRepositoryTest.cs
@@ -38,14 +38,33 @@ public class DatabaseOrganisationRepositoryTest(PostgreSqlFixture postgreSql) : 
     {
         using var repository = OrganisationRepository();
 
-        var organisation1 = GivenOrganisation(guid: Guid.NewGuid(), name: "TheOrganisation");
-        var organisation2 = GivenOrganisation(guid: Guid.NewGuid(), name: "TheOrganisation");
+        var organisation1 =
+            GivenOrganisation(guid: Guid.NewGuid(), name: "TheOrganisation", tenant: GivenTenant(name: "T1"));
+        var organisation2 =
+            GivenOrganisation(guid: Guid.NewGuid(), name: "TheOrganisation", tenant: GivenTenant(name: "T2"));
 
         repository.Save(organisation1);
 
         repository.Invoking(r => r.Save(organisation2))
             .Should().Throw<IOrganisationRepository.OrganisationRepositoryException.DuplicateOrganisationException>()
             .WithMessage($"Organisation with name `TheOrganisation` already exists.");
+    }
+
+    [Fact]
+    public void ItRejectsTwoOrganisationsWithTheSameNameWhenCreatingTenant()
+    {
+        using var repository = OrganisationRepository();
+
+        var organisation1 =
+            GivenOrganisation(guid: Guid.NewGuid(), name: "Acme LTD", tenant: GivenTenant(name: "Acme LTD"));
+        var organisation2 =
+            GivenOrganisation(guid: Guid.NewGuid(), name: "Acme LTD", tenant: GivenTenant(name: "Acme LTD"));
+
+        repository.Save(organisation1);
+
+        repository.Invoking(r => r.Save(organisation2))
+            .Should().Throw<IOrganisationRepository.OrganisationRepositoryException.DuplicateOrganisationException>()
+            .WithMessage($"Organisation with name `Acme LTD` already exists.");
     }
 
     [Fact]

--- a/Services/CO.CDP.OrganisationInformation.Persistence.Tests/EntityFactory.cs
+++ b/Services/CO.CDP.OrganisationInformation.Persistence.Tests/EntityFactory.cs
@@ -80,7 +80,7 @@ public static class EntityFactory
         {
             Guid = theGuid,
             Name = theName,
-            Tenant = tenant ?? GivenTenant(),
+            Tenant = tenant ?? GivenTenant(name: theName),
             Identifiers = [new OrganisationIdentifier
             {
                 Primary = true,

--- a/Services/CO.CDP.OrganisationInformation.Persistence/DatabaseOrganisationRepository.cs
+++ b/Services/CO.CDP.OrganisationInformation.Persistence/DatabaseOrganisationRepository.cs
@@ -52,7 +52,11 @@ public class DatabaseOrganisationRepository(OrganisationInformationContext conte
     {
         switch (cause.InnerException)
         {
-            case { } e when e.Message.Contains("_Organisations_Name"):
+            case { } e when e.Message.Contains("_Organisations_Name") || e.Message.Contains("_Tenants_Name"):
+                // Currently the Organisation Name matches the Tenant Name.
+                // When both tenant and organisation are created at the same time, the Tenant is inserted first,
+                // and throws an error before the organisation insert is attempted.
+                // It's unexpected to get a duplicate tenant exception from the organisation repository.
                 throw new IOrganisationRepository.OrganisationRepositoryException.DuplicateOrganisationException(
                     $"Organisation with name `{organisation.Name}` already exists.", cause);
             case { } e when e.Message.Contains("_Organisations_Guid"):


### PR DESCRIPTION
Not ideal, but unblocks error handling on the UI side.