### PR TITLE
Dp 1 apigw mapping

### DIFF
--- a/terragrunt/modules/api-gateway/main.tf
+++ b/terragrunt/modules/api-gateway/main.tf
@@ -12,7 +12,7 @@ resource "aws_api_gateway_resource" "ecs_service" {
   for_each = local.services
 
   parent_id   = aws_api_gateway_rest_api.ecs_api.root_resource_id
-  path_part   = each.key
+  path_part   = each.value.name
   rest_api_id = aws_api_gateway_rest_api.ecs_api.id
 }
 

--- a/terragrunt/modules/api-gateway/main.tf
+++ b/terragrunt/modules/api-gateway/main.tf
@@ -116,7 +116,7 @@ resource "aws_api_gateway_deployment" "ecs_api" {
   depends_on  = [aws_api_gateway_integration.ecs_service_proxy, aws_api_gateway_integration.root_integration]
 }
 
-resource "aws_api_gateway_stage" "api_stage" {
+resource "aws_api_gateway_stage" "ecs_api" {
   deployment_id = aws_api_gateway_deployment.ecs_api.id
   rest_api_id   = aws_api_gateway_rest_api.ecs_api.id
   stage_name    = "v1" #var.environment

--- a/terragrunt/modules/api-gateway/route53.tf
+++ b/terragrunt/modules/api-gateway/route53.tf
@@ -3,8 +3,14 @@ resource "aws_api_gateway_domain_name" "ecs_api" {
   certificate_arn = aws_acm_certificate.ecs_api.arn
 
   depends_on = [
-    aws_acm_certificate.ecs_api
+    aws_acm_certificate_validation.ecs_api
   ]
+}
+
+resource "aws_api_gateway_base_path_mapping" "custom" {
+  domain_name = aws_api_gateway_domain_name.ecs_api.id
+  stage_name  = aws_api_gateway_stage.ecs_api.stage_name
+  api_id      = aws_api_gateway_rest_api.ecs_api.id
 }
 
 


### PR DESCRIPTION
Change the dependency to be on the certificate's validation records

This will enable calling the API via paths like:
- https://api.dev.supplier.information.findatender.codatt.net/data-sharing/swagger/index.html
- https://api.dev.supplier.information.findatender.codatt.net/forms/swagger/index.html
- https://api.dev.supplier.information.findatender.codatt.net/organisation/swagger/index.html
- https://api.dev.supplier.information.findatender.codatt.net/person/swagger/index.html
- https://api.dev.supplier.information.findatender.codatt.net/tenant/swagger/index.html