### PR TITLE
Remove the warning when generating a migration

### DIFF
--- a/Services/CO.CDP.OrganisationInformation.Persistence/Migrations/OrganisationInformationContextModelSnapshot.cs
+++ b/Services/CO.CDP.OrganisationInformation.Persistence/Migrations/OrganisationInformationContextModelSnapshot.cs
@@ -144,7 +144,7 @@ namespace CO.CDP.OrganisationInformation.Persistence.Migrations
                         .HasColumnType("timestamp with time zone")
                         .HasDefaultValueSql("CURRENT_TIMESTAMP");
 
-                    b.Property<List<string>>("Scopes")
+                    b.Property<string>("Scopes")
                         .IsRequired()
                         .HasColumnType("jsonb");
 

--- a/Services/CO.CDP.OrganisationInformation.Persistence/OrganisationInformationContext.cs
+++ b/Services/CO.CDP.OrganisationInformation.Persistence/OrganisationInformationContext.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace CO.CDP.OrganisationInformation.Persistence;
@@ -70,7 +71,8 @@ public class OrganisationInformationContext(DbContextOptions<OrganisationInforma
                 .WithMany(t => t.Organisations)
                 .UsingEntity<OrganisationPerson>(j =>
                 {
-                    j.Property(op => op.Scopes).IsRequired().HasJsonColumn([]);
+                    j.Property(op => op.Scopes).IsRequired()
+                        .HasJsonColumn([], PropertyBuilderExtensions.ListComparer<string>());
                     j.Property(op => op.CreatedOn).IsRequired().HasDefaultValueSql("CURRENT_TIMESTAMP");
                     j.Property(op => op.UpdatedOn).IsRequired().HasDefaultValueSql("CURRENT_TIMESTAMP");
                 });
@@ -129,13 +131,22 @@ public class OrganisationInformationContext(DbContextOptions<OrganisationInforma
 
 internal static class PropertyBuilderExtensions
 {
+    public static ValueComparer<List<T>> ListComparer<T>() =>
+        new(
+            (c1, c2) => c1 != null && c2 != null && c1.SequenceEqual(c2),
+            c => c.Aggregate(0, (a, v) => HashCode.Combine(a, v != null ? v.GetHashCode() : 0)),
+            c => c.ToList()
+        );
+
     public static PropertyBuilder<TProperty> HasJsonColumn<TProperty>(
         this PropertyBuilder<TProperty> propertyBuilder,
-        TProperty defaultValue
+        TProperty defaultValue,
+        ValueComparer<TProperty> valueComparer
     ) => propertyBuilder
         .HasColumnType("jsonb")
         .HasConversion(
             v => JsonSerializer.Serialize(v, JsonSerializerOptions.Default),
-            v => JsonSerializer.Deserialize<TProperty>(v, JsonSerializerOptions.Default) ?? defaultValue
+            v => JsonSerializer.Deserialize<TProperty>(v, JsonSerializerOptions.Default) ?? defaultValue,
+            valueComparer
         );
 }


### PR DESCRIPTION
```
warn: Microsoft.EntityFrameworkCore.Model.Validation[10620]
The property 'OrganisationPerson.Scopes' is a collection or enumeration type with a value converter but with no value comparer. Set a value comparer to ensure the collection/enumeration elements are compared correctly.
warn: Microsoft.EntityFrameworkCore.Model.Validation[10620]
The property 'OrganisationPerson.Scopes' is a collection or enumeration type with a value converter but with no value comparer. Set a value comparer to ensure the collection/enumeration elements are compared correctly.
The property 'OrganisationPerson.Scopes' is a collection or enumeration type with a value converter but with no value comparer. Set a value comparer to ensure the collection/enumeration elements are compared correctly.
```