### PR TITLE
DP-1 Add landing page with links to endpoints

### DIFF
--- a/terragrunt/modules/api-gateway/acm.tf
+++ b/terragrunt/modules/api-gateway/acm.tf
@@ -16,10 +16,10 @@ resource "aws_acm_certificate" "ecs_api" {
 }
 
 resource "aws_acm_certificate_validation" "ecs_api" {
-  certificate_arn         = aws_acm_certificate.ecs_api.arn
-  provider                = aws.virginia
+  certificate_arn = aws_acm_certificate.ecs_api.arn
+  provider        = aws.virginia
   validation_record_fqdns = [
-    for record in aws_acm_certificate.ecs_api.domain_validation_options :record.resource_record_name
+    for record in aws_acm_certificate.ecs_api.domain_validation_options : record.resource_record_name
   ]
 }
 

--- a/terragrunt/modules/api-gateway/api-ecs.tf
+++ b/terragrunt/modules/api-gateway/api-ecs.tf
@@ -1,0 +1,82 @@
+resource "aws_api_gateway_resource" "ecs_service" {
+  for_each = local.services
+
+  parent_id   = aws_api_gateway_rest_api.ecs_api.root_resource_id
+  path_part   = each.value.name
+  rest_api_id = aws_api_gateway_rest_api.ecs_api.id
+}
+
+resource "aws_api_gateway_method" "ecs_service" {
+  for_each = local.services
+
+  authorization = "NONE"
+  http_method   = "GET"
+  resource_id   = aws_api_gateway_resource.ecs_service[each.key].id
+  rest_api_id   = aws_api_gateway_rest_api.ecs_api.id
+}
+
+resource "aws_api_gateway_integration" "ecs_service" {
+  for_each = local.services
+
+  http_method             = aws_api_gateway_method.ecs_service[each.key].http_method
+  integration_http_method = "GET"
+  passthrough_behavior    = "WHEN_NO_MATCH"
+  resource_id             = aws_api_gateway_resource.ecs_service[each.key].id
+  rest_api_id             = aws_api_gateway_rest_api.ecs_api.id
+  type                    = "HTTP"
+  uri                     = "https://${each.value.name}.${var.public_hosted_zone_fqdn}/swagger/index.html"
+}
+
+resource "aws_api_gateway_method_response" "ecs_service" {
+  for_each = local.services
+
+  http_method = aws_api_gateway_method.ecs_service[each.key].http_method
+  resource_id = aws_api_gateway_resource.ecs_service[each.key].id
+  rest_api_id = aws_api_gateway_rest_api.ecs_api.id
+  status_code = "200"
+
+  response_parameters = {
+    "method.response.header.Content-Type" = true
+  }
+}
+
+resource "aws_api_gateway_resource" "ecs_service_proxy" {
+  for_each = local.services
+
+  rest_api_id = aws_api_gateway_rest_api.ecs_api.id
+  parent_id   = aws_api_gateway_resource.ecs_service[each.key].id
+  path_part   = "{proxy+}"
+}
+
+resource "aws_api_gateway_method" "ecs_service_proxy" {
+  for_each = local.services
+
+  authorization = "NONE"
+  http_method   = "ANY"
+  resource_id   = aws_api_gateway_resource.ecs_service_proxy[each.key].id
+  rest_api_id   = aws_api_gateway_rest_api.ecs_api.id
+
+  request_parameters = {
+    "method.request.path.proxy" = true
+  }
+}
+
+resource "aws_api_gateway_integration" "ecs_service_proxy" {
+  for_each = local.services
+
+  http_method             = aws_api_gateway_method.ecs_service_proxy[each.key].http_method
+  integration_http_method = "ANY"
+  passthrough_behavior    = "WHEN_NO_MATCH"
+  resource_id             = aws_api_gateway_resource.ecs_service_proxy[each.key].id
+  rest_api_id             = aws_api_gateway_rest_api.ecs_api.id
+  type                    = "HTTP_PROXY"
+  uri                     = "https://${each.value.name}.${var.public_hosted_zone_fqdn}/{proxy}"
+
+  request_parameters = {
+    "integration.request.path.proxy" = "method.request.path.proxy"
+  }
+
+  cache_key_parameters = [
+    "method.request.path.proxy",
+  ]
+}

--- a/terragrunt/modules/api-gateway/api-root.tf
+++ b/terragrunt/modules/api-gateway/api-root.tf
@@ -1,0 +1,59 @@
+resource "aws_api_gateway_method" "root" {
+  authorization = "NONE"
+  http_method   = "GET"
+  resource_id   = aws_api_gateway_rest_api.ecs_api.root_resource_id
+  rest_api_id   = aws_api_gateway_rest_api.ecs_api.id
+}
+
+resource "aws_api_gateway_integration" "root" {
+  http_method             = aws_api_gateway_method.root.http_method
+  integration_http_method = "GET"
+  passthrough_behavior    = "WHEN_NO_MATCH"
+  resource_id             = aws_api_gateway_rest_api.ecs_api.root_resource_id
+  rest_api_id             = aws_api_gateway_rest_api.ecs_api.id
+  type                    = "MOCK"
+
+  request_templates = {
+    "application/json" = "{\"statusCode\": 200}"
+  }
+
+  depends_on = [
+    aws_api_gateway_method.root
+  ]
+}
+
+resource "aws_api_gateway_method_response" "root" {
+  rest_api_id = aws_api_gateway_rest_api.ecs_api.id
+  resource_id = aws_api_gateway_rest_api.ecs_api.root_resource_id
+  http_method = aws_api_gateway_method.root.http_method
+  status_code = "200"
+
+  response_models = {
+    "text/html" = "Empty"
+  }
+
+  depends_on = [
+    aws_api_gateway_method.root
+  ]
+}
+
+resource "aws_api_gateway_integration_response" "root" {
+  rest_api_id = aws_api_gateway_rest_api.ecs_api.id
+  resource_id = aws_api_gateway_rest_api.ecs_api.root_resource_id
+  http_method = aws_api_gateway_method.root.http_method
+  status_code = aws_api_gateway_method_response.root.status_code
+
+  response_templates = {
+    "text/html" = templatefile("${path.module}/templates/landing-page.html.tftpl",
+      {
+        endpoints    = local.endpoints
+        frontend_url = var.public_hosted_zone_fqdn
+      }
+    )
+  }
+
+  depends_on = [
+    aws_api_gateway_integration.root,
+    aws_api_gateway_method_response.root
+  ]
+}

--- a/terragrunt/modules/api-gateway/locals.tf
+++ b/terragrunt/modules/api-gateway/locals.tf
@@ -7,4 +7,12 @@ locals {
     name => config if !contains(["organisation-information-migrations", "organisation-app"], config.name)
   }
 
+  endpoints = [
+    for service in local.services :
+    {
+      name = service.name,
+      url  = "https://${aws_api_gateway_domain_name.ecs_api.domain_name}/${service.name}/swagger/index.html"
+    }
+  ]
+
 }

--- a/terragrunt/modules/api-gateway/main.tf
+++ b/terragrunt/modules/api-gateway/main.tf
@@ -8,118 +8,20 @@ resource "aws_api_gateway_rest_api" "ecs_api" {
   tags        = var.tags
 }
 
-resource "aws_api_gateway_resource" "ecs_service" {
-  for_each = local.services
-
-  parent_id   = aws_api_gateway_rest_api.ecs_api.root_resource_id
-  path_part   = each.value.name
-  rest_api_id = aws_api_gateway_rest_api.ecs_api.id
-}
-
-resource "aws_api_gateway_method" "ecs_service" {
-  for_each = local.services
-
-  authorization = "NONE"
-  http_method   = "GET"
-  resource_id   = aws_api_gateway_resource.ecs_service[each.key].id
-  rest_api_id   = aws_api_gateway_rest_api.ecs_api.id
-}
-
-resource "aws_api_gateway_integration" "ecs_service" {
-  for_each = local.services
-
-  http_method             = aws_api_gateway_method.ecs_service[each.key].http_method
-  integration_http_method = "GET"
-  passthrough_behavior    = "WHEN_NO_MATCH"
-  resource_id             = aws_api_gateway_resource.ecs_service[each.key].id
-  rest_api_id             = aws_api_gateway_rest_api.ecs_api.id
-  type                    = "HTTP"
-  uri                     = "https://${each.value.name}.${var.public_hosted_zone_fqdn}/swagger/index.html"
-}
-
-resource "aws_api_gateway_method_response" "ecs_service" {
-  for_each = local.services
-
-  http_method = aws_api_gateway_method.ecs_service[each.key].http_method
-  resource_id = aws_api_gateway_resource.ecs_service[each.key].id
-  rest_api_id = aws_api_gateway_rest_api.ecs_api.id
-  status_code = "200"
-
-  response_parameters = {
-    "method.response.header.Content-Type" = true
-  }
-}
-
-resource "aws_api_gateway_resource" "ecs_service_proxy" {
-  for_each = local.services
-
-  rest_api_id = aws_api_gateway_rest_api.ecs_api.id
-  parent_id   = aws_api_gateway_resource.ecs_service[each.key].id
-  path_part   = "{proxy+}"
-}
-
-resource "aws_api_gateway_method" "ecs_service_proxy" {
-  for_each = local.services
-
-  authorization = "NONE"
-  http_method   = "ANY"
-  resource_id   = aws_api_gateway_resource.ecs_service_proxy[each.key].id
-  rest_api_id   = aws_api_gateway_rest_api.ecs_api.id
-
-  request_parameters = {
-    "method.request.path.proxy" = true
-  }
-}
-
-resource "aws_api_gateway_integration" "ecs_service_proxy" {
-  for_each = local.services
-
-  http_method             = aws_api_gateway_method.ecs_service_proxy[each.key].http_method
-  integration_http_method = "ANY"
-  passthrough_behavior    = "WHEN_NO_MATCH"
-  resource_id             = aws_api_gateway_resource.ecs_service_proxy[each.key].id
-  rest_api_id             = aws_api_gateway_rest_api.ecs_api.id
-  type                    = "HTTP_PROXY"
-  uri                     = "https://${each.value.name}.${var.public_hosted_zone_fqdn}/{proxy}"
-
-  request_parameters = {
-    "integration.request.path.proxy" = "method.request.path.proxy"
-  }
-
-  cache_key_parameters = [
-    "method.request.path.proxy",
-  ]
-}
-
-resource "aws_api_gateway_method" "root_method" {
-  authorization = "NONE"
-  http_method   = "ANY"
-  resource_id   = aws_api_gateway_rest_api.ecs_api.root_resource_id
-  rest_api_id   = aws_api_gateway_rest_api.ecs_api.id
-}
-
-resource "aws_api_gateway_integration" "root_integration" {
-  http_method             = aws_api_gateway_method.root_method.http_method
-  integration_http_method = "ANY"
-  passthrough_behavior    = "WHEN_NO_MATCH"
-  resource_id             = aws_api_gateway_rest_api.ecs_api.root_resource_id
-  rest_api_id             = aws_api_gateway_rest_api.ecs_api.id
-  type                    = "MOCK"
-
-  request_templates = {
-    "application/json" = "{\"statusCode\": 200}"
-  }
-}
-
 resource "aws_api_gateway_deployment" "ecs_api" {
   rest_api_id = aws_api_gateway_rest_api.ecs_api.id
-  depends_on  = [aws_api_gateway_integration.ecs_service_proxy, aws_api_gateway_integration.root_integration]
+  depends_on = [
+    aws_api_gateway_integration.root,
+    aws_api_gateway_integration_response.root,
+    aws_api_gateway_integration.ecs_service,
+    aws_api_gateway_integration.ecs_service_proxy
+  ]
 }
 
 resource "aws_api_gateway_stage" "ecs_api" {
   deployment_id = aws_api_gateway_deployment.ecs_api.id
   rest_api_id   = aws_api_gateway_rest_api.ecs_api.id
-  stage_name    = "v1" #var.environment
+  stage_name    = "v1"
 
   access_log_settings {
     destination_arn = aws_cloudwatch_log_group.ecs_api.arn
@@ -138,4 +40,8 @@ resource "aws_api_gateway_stage" "ecs_api" {
   }
 
   tags = var.tags
+
+  depends_on = [
+    aws_api_gateway_deployment.ecs_api
+  ]
 }

--- a/terragrunt/modules/api-gateway/outputs.tf
+++ b/terragrunt/modules/api-gateway/outputs.tf
@@ -1,3 +1,7 @@
-output "api_url" {
+output "api_invoke_url" {
   value = aws_api_gateway_deployment.ecs_api.invoke_url
+}
+
+output "api_domain_name" {
+  value = aws_api_gateway_domain_name.ecs_api.domain_name
 }

--- a/terragrunt/modules/api-gateway/route53.tf
+++ b/terragrunt/modules/api-gateway/route53.tf
@@ -1,5 +1,5 @@
 resource "aws_api_gateway_domain_name" "ecs_api" {
-  domain_name = "api.${var.public_hosted_zone_fqdn}"
+  domain_name     = "api.${var.public_hosted_zone_fqdn}"
   certificate_arn = aws_acm_certificate.ecs_api.arn
 
   depends_on = [

--- a/terragrunt/modules/api-gateway/templates/landing-page.html.tftpl
+++ b/terragrunt/modules/api-gateway/templates/landing-page.html.tftpl
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <link rel="icon" href="https://${frontend_url}/assets/images/favicon.ico" />
+    <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
+    <meta name="theme-color" content="#000000" />
+    <meta name="description" content="GOV.UK Central Digital Platform" />
+    <link rel="manifest" href="https://${frontend_url}/manifest.json" />
+    <link rel="stylesheet" href="https://${frontend_url}/css/govuk-frontend-5.2.0.min.css">
+    <link rel="stylesheet" href="https://${frontend_url}/css/site.css">
+    <title>Central Digital Platform - GOV.UK</title>
+</head>
+<body class="govuk-template__body">
+
+    <div class="govuk-width-container">
+        <div class="govuk-phase-banner">
+            <p class="govuk-phase-banner__content">
+                <strong class="govuk-tag govuk-phase-banner__content__tag">
+                    Prototype
+                </strong>
+                <span class="govuk-phase-banner__text">
+                    This is a prototype of a service in development.
+                </span>
+            </p>
+        </div>
+
+        <main class="govuk-main-wrapper">
+
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-two-thirds govuk-body">
+                    <h4>API Endpoints:</h4>
+                    <ul class="govuk-list govuk-list--bullet">
+                    %{ for endpoint in endpoints }
+                        <li><a href="${endpoint.url}">${endpoint.name}</a></li>
+                    %{ endfor }
+                    </ul>
+                </div>
+            </div>
+        </main>
+    </div>
+
+
+</body>
+</html>

--- a/terragrunt/modules/api-gateway/variables.tf
+++ b/terragrunt/modules/api-gateway/variables.tf
@@ -30,11 +30,11 @@ variable "product" {
 variable "service_configs" {
   description = "Map of services to their ports"
   type = map(object({
-    cpu           = number
-    memory        = number
-    name          = string
-    port          = number
-    port_host     = number
+    cpu       = number
+    memory    = number
+    name      = string
+    port      = number
+    port_host = number
   }))
 }
 

--- a/terragrunt/modules/ecs/variables.tf
+++ b/terragrunt/modules/ecs/variables.tf
@@ -105,11 +105,11 @@ variable "role_service_deployer_step_function_name" {
 variable "service_configs" {
   description = "Map of services to their ports"
   type = map(object({
-    cpu           = number
-    memory        = number
-    name          = string
-    port          = number
-    port_host     = number
+    cpu       = number
+    memory    = number
+    name      = string
+    port      = number
+    port_host = number
   }))
 }
 


### PR DESCRIPTION
Updating API Gateway:
- Add a page in root with links to all endpoints 
- split Root and ECS related resources into different files
- add an output for the API's domain
- Apply terraform format on all modules 

This has been applied in [staging](https://api.staging.supplier.information.findatender.codatt.net/).
![image](https://github.com/cabinetoffice/GCGS-Central-Digital-Platform/assets/1422984/60fff52d-0354-4033-8f65-5cbd7ed1fbd3)
