### PR TITLE
DP-168 Tenant Lookup fix URi test (windows)

### DIFF
--- a/Services/CO.CDP.Tenant.WebApi.Tests/UseCase/LookupTenantUseCaseTest.cs
+++ b/Services/CO.CDP.Tenant.WebApi.Tests/UseCase/LookupTenantUseCaseTest.cs
@@ -84,7 +84,7 @@ public class LookupTenantUseCaseTest(AutoMapperFixture mapperFixture) : IClassFi
                             Name = "Acme Ltd",
                             Roles = [PartyRole.Supplier],
                             Scopes = ["ADMIN"],
-                            Uri = new Uri("/organisations/dfd0c5d3-0740-4be4-aa42-e42ec9c00bad")
+                            Uri = new Uri($"https://cdp.cabinetoffice.gov.uk/organisations/dfd0c5d3-0740-4be4-aa42-e42ec9c00bad")
                         }
                     ]
                 }

--- a/Services/CO.CDP.Tenant.WebApi/AutoMapper/WebApiToPersistenceProfile.cs
+++ b/Services/CO.CDP.Tenant.WebApi/AutoMapper/WebApiToPersistenceProfile.cs
@@ -15,7 +15,7 @@ public class WebApiToPersistenceProfile : Profile
         CreateMap<TenantLookup.PersonUser, UserDetails>();
         CreateMap<TenantLookup.Tenant, UserTenant>();
         CreateMap<TenantLookup.Organisation, UserOrganisation>()
-            .ForMember(m => m.Uri, o => o.MapFrom(src => new Uri($"/organisations/{src.Id}")));
+            .ForMember(m => m.Uri, o => o.MapFrom(src => new Uri($"https://cdp.cabinetoffice.gov.uk/organisations/{src.Id}")));
 
         CreateMap<RegisterTenant, OrganisationInformation.Persistence.Tenant>()
             .ForMember(m => m.Guid, o => o.MapFrom((_, _, _, context) => context.Items["Guid"]))


### PR DESCRIPTION
Fix the inconsistency between Windows and Linux relating to Uri, hard-code the host URL until we decide on the best way to specify the mapping for each environment. 