### PR TITLE
Handle X-Forwarded-* headers in the organisation app

### DIFF
--- a/Frontend/CO.CDP.OrganisationApp/Program.cs
+++ b/Frontend/CO.CDP.OrganisationApp/Program.cs
@@ -5,6 +5,7 @@ using CO.CDP.Tenant.WebApiClient;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using static IdentityModel.OidcConstants;
 
@@ -17,6 +18,10 @@ var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddRazorPages()
     .AddRazorRuntimeCompilation();
+builder.Services.Configure<ForwardedHeadersOptions>(options =>
+{
+    options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
+});
 
 builder.Services.AddDistributedMemoryCache();
 
@@ -92,7 +97,7 @@ builder.Services.AddAuthentication(options =>
 builder.Services.AddHealthChecks();
 
 var app = builder.Build();
-
+app.UseForwardedHeaders();
 app.UseMiddleware<ExceptionMiddleware>();
 
 // Configure the HTTP request pipeline.


### PR DESCRIPTION
Otherwise, the app doesn't know it's behind https.