### PR TITLE
Prevent same example being added multiple times

### DIFF
--- a/Libraries/CO.CDP.Swashbuckle/Filter/ProblemDetailsOperationFilter.cs
+++ b/Libraries/CO.CDP.Swashbuckle/Filter/ProblemDetailsOperationFilter.cs
@@ -108,14 +108,11 @@ public class ProblemDetailsOperationFilter(Dictionary<string, List<string>> erro
         {
             if (errorCodes.TryGetValue(operationResponse.Key, out var codes))
             {
-                foreach (var code in codes)
+                content.Value.Examples = codes.Select(code => (code, new OpenApiExample
                 {
-                    content.Value.Examples.Add(code, new OpenApiExample
-                    {
-                        Summary = code,
-                        Value = problemDetail?.Invoke(code)
-                    });
-                }
+                    Summary = code,
+                    Value = problemDetail?.Invoke(code)
+                })).ToDictionary();
             }
             else
             {


### PR DESCRIPTION
```
2024-07-02 15:23:10.885
      An unhandled exception has occurred while executing the request.

2024-07-02 15:23:10.885
         at DotSwashbuckle.AspNetCore.SwaggerGen.SwaggerGenerator.GetSwaggerDocumentWithoutFilters(String documentName, String host, String basePath)

2024-07-02 15:23:10.885
         at DotSwashbuckle.AspNetCore.SwaggerGen.SwaggerGenerator.GenerateOperation(ApiDescription apiDescription, SchemaRepository schemaRepository)

2024-07-02 15:23:10.885
         at CO.CDP.Swashbuckle.Filter.ProblemDetailsOperationFilter.Apply(OpenApiOperation operation, OperationFilterContext context) in /src/Libraries/CO.CDP.Swashbuckle/Filter/ProblemDetailsOperationFilter.cs:line 99

2024-07-02 15:23:10.885
         at CO.CDP.Swashbuckle.Filter.ProblemDetailsOperationFilter.UpdateExamples(KeyValuePair`2 operationResponse, Func`2 problemDetail) in /src/Libraries/CO.CDP.Swashbuckle/Filter/ProblemDetailsOperationFilter.cs:line 113

2024-07-02 15:23:10.885
         at System.Collections.Generic.Dictionary`2.Add(TKey key, TValue value)

2024-07-02 15:23:10.885
         at System.Collections.Generic.Dictionary`2.TryInsert(TKey key, TValue value, InsertionBehavior behavior)

2024-07-02 15:23:10.885
       ---> System.ArgumentException: An item with the same key has already been added. Key: ORGANISATION_ALREADY_EXISTS
```