### PR TITLE
DP-230 Remove authority's public key from infra

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,13 +136,13 @@ generate-authority-keys: ## Generate authority's private and public keys and sto
 	openssl rsa -pubout -in ./terragrunt/secrets/authority-private-key.pem -outform PEM -out ./terragrunt/secrets/authority-public-key.pem
 .PHONY: generate-authority-keys
 
-aws-push-authority-keys: ## Push Authority's keys to the target AWS account
+aws-push-authority-private-key: ## Push Authority's private key to the target AWS account
 	@if aws secretsmanager describe-secret --secret-id cdp-sirsi-authority-keys > /dev/null 2>&1; then \
 		echo "Secret exists, updating..."; \
-		aws secretsmanager update-secret --secret-id cdp-sirsi-authority-keys --secret-string "$$(jq -n --arg priv "$$(cat ./terragrunt/secrets/authority-private-key.pem)" --arg pub "$$(cat ./terragrunt/secrets/authority-public-key.pem)" '{PRIVATE: $$priv, PUBLIC: $$pub}')"; \
+		aws secretsmanager update-secret --secret-id cdp-sirsi-authority-keys --secret-string "$$(jq -n --arg priv "$$(cat ./terragrunt/secrets/authority-private-key.pem)" '{PRIVATE: $$priv}')"; \
 	else \
 		echo "Secret does not exist, creating..."; \
-		aws secretsmanager create-secret --name cdp-sirsi-authority-keys --secret-string "$$(jq -n --arg priv "$$(cat ./terragrunt/secrets/authority-private-key.pem)" --arg pub "$$(cat ./terragrunt/secrets/authority-public-key.pem)" '{PRIVATE: $$priv, PUBLIC: $$pub}')"; \
+		aws secretsmanager create-secret --name cdp-sirsi-authority-keys --secret-string "$$(jq -n --arg priv "$$(cat ./terragrunt/secrets/authority-private-key.pem)" '{PRIVATE: $$priv}')"; \
 	fi
 
 aws-push-to-ecr: build-docker ## Build, tag and push Docker images to ECR

--- a/terragrunt/modules/ecs/service-authority.tf
+++ b/terragrunt/modules/ecs/service-authority.tf
@@ -5,7 +5,6 @@ module "ecs_service_authority" {
     "${path.module}/templates/task-definitions/${var.service_configs.authority.name}.json.tftpl",
     {
       authority_private_key   = "${data.aws_secretsmanager_secret.authority_keys.arn}:PRIVATE::"
-      authority_public_key    = "${data.aws_secretsmanager_secret.authority_keys.arn}:PUBLIC::"
       container_port          = var.service_configs.authority.port
       cpu                     = var.service_configs.authority.cpu
       conn_string_location    = var.db_connection_secret_arn

--- a/terragrunt/modules/ecs/templates/task-definitions/authority.json.tftpl
+++ b/terragrunt/modules/ecs/templates/task-definitions/authority.json.tftpl
@@ -29,8 +29,7 @@
         {"name": "ConnectionStrings__OrganisationInformationDatabase", "valueFrom": "${conn_string_location}"},
         {"name": "OneLogin__Authority", "valueFrom": "${onelogin_authority}"},
         {"name": "OneLogin__ClientId", "valueFrom": "${onelogin_client_id}"},
-        {"name": "PrivateKey", "valueFrom": "${authority_private_key}"},
-        {"name": "PublicKey", "valueFrom": "${authority_public_key}"}
+        {"name": "PrivateKey", "valueFrom": "${authority_private_key}"}
     ],
     "volumesFrom": [],
     "mountPoints": [],


### PR DESCRIPTION
This has been applied to [dev environment](https://dev.supplier.information.findatender.codatt.net/)
A fresh build also has been deployed to the account.
I can confirm [the authority service](https://authority.dev.supplier.information.findatender.codatt.net/swagger/index.html) is up and running 

![image](https://github.com/cabinetoffice/GCGS-Central-Digital-Platform/assets/1422984/0611f89d-e786-49f7-a47b-11dd3386402e)
 