### PR TITLE
Set up localstack for sqs and s3 services in local development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,12 @@ services:
       - "$${CDP_DB_PORT:-5432}:5432"
     deploy:
       replicas: 1
+  localstack:
+    ports:
+      - "4566:4566"
+      - "4510-4559:4510-4559"
+    deploy:
+      replicas: 1
   organisation-app:
     environment:
       ASPNETCORE_ENVIRONMENT: Development

--- a/compose.common.yml
+++ b/compose.common.yml
@@ -20,6 +20,12 @@ services:
       timeout: 5s
       retries: 5
 
+  localstack:
+    container_name: co-cdp-localstack
+    image: localstack/localstack:3.5
+    healthcheck:
+      test: [ "CMD-SHELL", "bash", "-c", "awslocal sqs list-queues && awslocal s3 ls"]
+
   organisation-information-migrations:
     container_name: co-cdp-organisation-information-migrations
     restart: no

--- a/compose.yml
+++ b/compose.yml
@@ -32,6 +32,13 @@ services:
       POSTGRES_DB: cdp
       POSTGRES_USER: cdp_user
       POSTGRES_PASSWORD: cdp123
+  localstack:
+    extends:
+      file: compose.common.yml
+      service: localstack
+    environment:
+      # LocalStack configuration: https://docs.localstack.cloud/references/configuration/
+      DEBUG: 0
   organisation-information-migrations:
     extends:
       file: compose.common.yml


### PR DESCRIPTION
The localstack service will need to be added to `compose.override.yml` to provide port mapping:

```yaml
  localstack:
    ports:
      - "4566:4566"
      - "4510-4559:4510-4559"
    deploy:
      replicas: 1
```

Once started with `docker compose up -d localstack`, it can be tested with `awslocal`:

```bash
awslocal sqs create-queue --queue-name foo
awslocal sqs list-queues

awslocal sqs send-message --queue-url http://sqs.us-east-1.localhost.localstack.cloud:4566/000000000000/foo --message-body '{"foo":"bar"}'

awslocal sqs receive-message --queue-url http://sqs.us-east-1.localhost.localstack.cloud:4566/000000000000/foo
```