### PR TITLE
Generate a version for Docker images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,10 +61,11 @@ jobs:
         run: |
           COMMIT_REF=$(if [ "$GITHUB_EVENT_NAME" == "pull_request" ]; then echo "${{ github.event.pull_request.head.sha }}"; else echo "${GITHUB_SHA:-HEAD}"; fi)
           CURRENT_COMMIT=$(make version-commit COMMIT_REF=$COMMIT_REF)
+          CURRENT_TAG=$([[ "${GITHUB_REF:0:10}" = "refs/tags/" ]] && echo ${GITHUB_REF#refs/tags/} || echo "")
           LAST_TAG=$(make last-tag)
           DATE=$(date +%Y%m%d%H%M%S)
           IMAGE_VERSION=${CURRENT_COMMIT}
-          IMAGE_VERSION_ALIASES="${DATE} ${LAST_TAG}-${CURRENT_COMMIT}"
+          IMAGE_VERSION_ALIASES="${DATE} ${LAST_TAG}-${CURRENT_COMMIT} ${CURRENT_TAG}"
           echo "Image version: $IMAGE_VERSION"
           echo "Image version aliases: $IMAGE_VERSION_ALIASES"
           echo "image_version=${IMAGE_VERSION}" >> $GITHUB_OUTPUT

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,9 +61,10 @@ jobs:
         run: |
           COMMIT_REF=$(if [ "$GITHUB_EVENT_NAME" == "pull_request" ]; then echo "${{ github.event.pull_request.head.sha }}"; else echo "${GITHUB_SHA:-HEAD}"; fi)
           CURRENT_COMMIT=$(make version-commit COMMIT_REF=$COMMIT_REF)
+          LAST_TAG=$(make last-tag)
           DATE=$(date +%Y%m%d%H%M%S)
           IMAGE_VERSION=${CURRENT_COMMIT}
-          IMAGE_VERSION_ALIASES=${DATE}
+          IMAGE_VERSION_ALIASES="${DATE} ${LAST_TAG}-${CURRENT_COMMIT}"
           echo "Image version: $IMAGE_VERSION"
           echo "Image version aliases: $IMAGE_VERSION_ALIASES"
           echo "image_version=${IMAGE_VERSION}" >> $GITHUB_OUTPUT

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,9 +63,8 @@ jobs:
           CURRENT_COMMIT=$(make version-commit COMMIT_REF=$COMMIT_REF)
           CURRENT_TAG=$([[ "${GITHUB_REF:0:10}" = "refs/tags/" ]] && echo ${GITHUB_REF#refs/tags/} || echo "")
           LAST_TAG=$(make last-tag)
-          DATE=$(date +%Y%m%d%H%M%S)
           IMAGE_VERSION=${CURRENT_COMMIT}
-          IMAGE_VERSION_ALIASES="${DATE} ${LAST_TAG}-${CURRENT_COMMIT} ${CURRENT_TAG}"
+          IMAGE_VERSION_ALIASES="${LAST_TAG}-${CURRENT_COMMIT} ${CURRENT_TAG}"
           echo "Image version: $IMAGE_VERSION"
           echo "Image version aliases: $IMAGE_VERSION_ALIASES"
           echo "image_version=${IMAGE_VERSION}" >> $GITHUB_OUTPUT

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,17 +63,19 @@ jobs:
           CURRENT_COMMIT=$(make version-commit COMMIT_REF=$COMMIT_REF)
           CURRENT_TAG=$([[ "${GITHUB_REF:0:10}" = "refs/tags/" ]] && echo ${GITHUB_REF#refs/tags/} || echo "")
           LAST_TAG=$(make last-tag)
+          VERSION=$([[ "${CURRENT_TAG}" = "" ]] && echo "${LAST_TAG}-${CURRENT_COMMIT}" || echo "$CURRENT_TAG")
           IMAGE_VERSION=${CURRENT_COMMIT}
-          IMAGE_VERSION_ALIASES="${LAST_TAG}-${CURRENT_COMMIT} ${CURRENT_TAG}"
+          echo "Version: $VERSION"
           echo "Image version: $IMAGE_VERSION"
-          echo "Image version aliases: $IMAGE_VERSION_ALIASES"
+          echo "Image version for relase: $VERSION"
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
           echo "image_version=${IMAGE_VERSION}" >> $GITHUB_OUTPUT
-          echo "image_version_aliases=${IMAGE_VERSION_ALIASES}" >> $GITHUB_OUTPUT
+          echo "image_version_for_release=${VERSION}" >> $GITHUB_OUTPUT
       - name: Build
         run: make build-docker docker-tag-images
         env:
           IMAGE_VERSION: ${{ steps.version.outputs.image_version }}
-          IMAGE_VERSION_ALIASES: ${{ steps.version.outputs.image_version_aliases }}
+          IMAGE_VERSION_ALIASES: ${{ steps.version.outputs.image_version_for_release }}
       - name: Start services
         run: make up
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,19 +62,25 @@ jobs:
           COMMIT_REF=$(if [ "$GITHUB_EVENT_NAME" == "pull_request" ]; then echo "${{ github.event.pull_request.head.sha }}"; else echo "${GITHUB_SHA:-HEAD}"; fi)
           CURRENT_COMMIT=$(make version-commit COMMIT_REF=$COMMIT_REF)
           DATE=$(date +%Y%m%d%H%M%S)
-          echo "Current commit: $CURRENT_COMMIT"
-          echo "Date: $DATE"
-          echo "date_version=${DATE}" >> $GITHUB_OUTPUT
-          echo "image_version=${CURRENT_COMMIT}" >> $GITHUB_OUTPUT
-          echo "image_additional_versions=${DATE}" >> $GITHUB_OUTPUT
+          IMAGE_VERSION=${CURRENT_COMMIT}
+          IMAGE_VERSION_ALIASES=${DATE}
+          echo "Image version: $IMAGE_VERSION"
+          echo "Image version aliases: $IMAGE_VERSION_ALIASES"
+          echo "image_version=${IMAGE_VERSION}" >> $GITHUB_OUTPUT
+          echo "image_version_aliases=${IMAGE_VERSION_ALIASES}" >> $GITHUB_OUTPUT
       - name: Build
-        run: make build-docker
+        run: make build-docker docker-tag-images
         env:
           IMAGE_VERSION: ${{ steps.version.outputs.image_version }}
+          IMAGE_VERSION_ALIASES: ${{ steps.version.outputs.image_version_aliases }}
       - name: Start services
         run: make up
+        env:
+            IMAGE_VERSION: ${{ steps.version.outputs.image_version }}
       - name: Stop services
         run: make down
+        env:
+            IMAGE_VERSION: ${{ steps.version.outputs.image_version }}
 
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,20 +70,18 @@ jobs:
           echo "Image version for relase: $VERSION"
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
           echo "image_version=${IMAGE_VERSION}" >> $GITHUB_OUTPUT
-          echo "image_version_for_release=${VERSION}" >> $GITHUB_OUTPUT
       - name: Build
-        run: make build-docker docker-tag-images
+        run: make build-docker
         env:
           IMAGE_VERSION: ${{ steps.version.outputs.image_version }}
-          IMAGE_VERSION_ALIASES: ${{ steps.version.outputs.image_version_for_release }}
       - name: Start services
         run: make up
         env:
-            IMAGE_VERSION: ${{ steps.version.outputs.image_version }}
+          IMAGE_VERSION: ${{ steps.version.outputs.image_version }}
       - name: Stop services
         run: make down
         env:
-            IMAGE_VERSION: ${{ steps.version.outputs.image_version }}
+          IMAGE_VERSION: ${{ steps.version.outputs.image_version }}
 
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,6 @@ jobs:
           IMAGE_VERSION=${CURRENT_COMMIT}
           echo "Version: $VERSION"
           echo "Image version: $IMAGE_VERSION"
-          echo "Image version for relase: $VERSION"
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
           echo "image_version=${IMAGE_VERSION}" >> $GITHUB_OUTPUT
       - name: Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,23 +64,20 @@ jobs:
           CURRENT_TAG=$([[ "${GITHUB_REF:0:10}" = "refs/tags/" ]] && echo ${GITHUB_REF#refs/tags/} || echo "")
           LAST_TAG=$(make last-tag)
           VERSION=$([[ "${CURRENT_TAG}" = "" ]] && echo "${LAST_TAG}-${CURRENT_COMMIT}" || echo "$CURRENT_TAG")
-          IMAGE_VERSION=${CURRENT_COMMIT}
           echo "Version: $VERSION"
-          echo "Image version: $IMAGE_VERSION"
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
-          echo "image_version=${IMAGE_VERSION}" >> $GITHUB_OUTPUT
       - name: Build
         run: make build-docker
         env:
-          IMAGE_VERSION: ${{ steps.version.outputs.image_version }}
+          IMAGE_VERSION: ${{ steps.version.outputs.version }}
       - name: Start services
         run: make up
         env:
-          IMAGE_VERSION: ${{ steps.version.outputs.image_version }}
+          IMAGE_VERSION: ${{ steps.version.outputs.version }}
       - name: Stop services
         run: make down
         env:
-          IMAGE_VERSION: ${{ steps.version.outputs.image_version }}
+          IMAGE_VERSION: ${{ steps.version.outputs.version }}
 
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,8 +54,23 @@ jobs:
       CDP_DATA_SHARING_PORT: 8855
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Determine the version
+        id: version
+        run: |
+          COMMIT_REF=$(if [ "$GITHUB_EVENT_NAME" == "pull_request" ]; then echo "${{ github.event.pull_request.head.sha }}"; else echo "${GITHUB_SHA:-HEAD}"; fi)
+          CURRENT_COMMIT=$(make version-commit COMMIT_REF=$COMMIT_REF)
+          DATE=$(date +%Y%m%d%H%M%S)
+          echo "Current commit: $CURRENT_COMMIT"
+          echo "Date: $DATE"
+          echo "date_version=${DATE}" >> $GITHUB_OUTPUT
+          echo "image_version=${CURRENT_COMMIT}" >> $GITHUB_OUTPUT
+          echo "image_additional_versions=${DATE}" >> $GITHUB_OUTPUT
       - name: Build
         run: make build-docker
+        env:
+          IMAGE_VERSION: ${{ steps.version.outputs.image_version }}
       - name: Start services
         run: make up
       - name: Stop services

--- a/Makefile
+++ b/Makefile
@@ -175,5 +175,5 @@ version-commit: ## Determines the last commit hash
 .PHONY: version-commit
 
 last-tag: ## Determines the last created tag on the repository
-	@git for-each-ref refs/tags --sort=-refname --format='%(refname:short)' --count=1
+	@git for-each-ref refs/tags --sort=-taggerdate --format='%(refname:short)' --count=1
 .PHONY: last-tag

--- a/Makefile
+++ b/Makefile
@@ -177,12 +177,3 @@ version-commit: ## Determines the last commit hash
 last-tag: ## Determines the last created tag on the repository
 	@git for-each-ref refs/tags --sort=-refname --format='%(refname:short)' --count=1
 .PHONY: last-tag
-
-docker-tag-images: IMAGE_VERSION ?= latest
-docker-tag-images: IMAGE_VERSION_ALIASES ?= latest
-docker-tag-images: ## Tag images
-	@$(foreach alias,$(IMAGE_VERSION_ALIASES),\
-		$(foreach image,$(IMAGES),docker tag cabinetoffice/$(image):$(IMAGE_VERSION) cabinetoffice/$(image):$(alias);))
-	@docker images | grep cabinetoffice/ | grep $(IMAGE_VERSION)
-	@$(foreach alias,$(IMAGE_VERSION_ALIASES),docker images | grep cabinetoffice/ | grep " $(alias) ";)
-.PHONY: docker-tag-images

--- a/Makefile
+++ b/Makefile
@@ -161,3 +161,8 @@ aws-push-to-ecr: build-docker ## Build, tag and push Docker images to ECR
 	aws ecr get-login-password --region eu-west-2 | docker login --username AWS --password-stdin $(REPO_URL)
 	$(foreach image,$(IMAGES),docker push $(REPO_URL)/$(image);)
 .PHONY: aws-push-to-ecr
+
+COMMIT_REF ?= "HEAD"
+version-commit: ## Determines the last commit hash
+	@git rev-parse --short "$(COMMIT_REF)"
+.PHONY: version-commit

--- a/Makefile
+++ b/Makefile
@@ -174,6 +174,10 @@ version-commit: ## Determines the last commit hash
 	@git rev-parse --short "$(COMMIT_REF)"
 .PHONY: version-commit
 
+last-tag: ## Determines the last created tag on the repository
+	@git for-each-ref refs/tags --sort=-refname --format='%(refname:short)' --count=1
+.PHONY: last-tag
+
 docker-tag-images: IMAGE_VERSION ?= latest
 docker-tag-images: IMAGE_VERSION_ALIASES ?= latest
 docker-tag-images: ## Tag images


### PR DESCRIPTION
Git commit can be used to ensure we only build each version once.

The following command can be used to generate a unique prefix of the commit (unique within the repository):

```bash
git rev-parse --short HEAD
```

We can use it for the main Docker tag, and then define additional alias tags once they are created, i.e.  `1.2.5-02e0c8b`, `1.2.5`.

The "Determine version" step [defines the main Docker tag](https://github.com/cabinetoffice/GCGS-Central-Digital-Platform/actions/runs/9909877385/job/27378962882?pr=278#step:3:20) that is tied to the git commit hash, as well the application version (that is based on the latest tag and git commit).

<img width="1509" alt="image" src="https://github.com/user-attachments/assets/d9149d48-d331-4f87-9234-dbc3f8f18702">


