### PR TITLE
Feature/dp 311 financial info file upload temp data

### DIFF
--- a/Frontend/CO.CDP.OrganisationApp.Tests/Pages/Forms/DynamicFormsPageTests.cs
+++ b/Frontend/CO.CDP.OrganisationApp.Tests/Pages/Forms/DynamicFormsPageTests.cs
@@ -23,7 +23,7 @@ public class DynamicFormsPageTests
         _tempDataServiceMock = new Mock<ITempDataService>();
         _requestMock = new Mock<HttpRequest>();
         _httpContextMock = new Mock<HttpContext>();
-        _pageModel = new DynamicFormsPageModel(_formsEngineMock.Object, _tempDataServiceMock.Object);        
+        _pageModel = new DynamicFormsPageModel(_formsEngineMock.Object, _tempDataServiceMock.Object);
         _organisationId = Guid.NewGuid();
         _formId = Guid.NewGuid();
         _sectionId = Guid.NewGuid();
@@ -136,14 +136,10 @@ public class DynamicFormsPageTests
 
         var fileMock = new Mock<IFormFile>();
         fileMock.Setup(f => f.Length).Returns(11 * 1024 * 1024);
+        fileMock.Setup(f => f.FileName).Returns("testfile.pdf");
         fileMock.Setup(f => f.Name).Returns("UploadedFile");
 
-        var formFileCollection = new FormFileCollection { fileMock.Object };
-        var formCollection = new FormCollection(new Dictionary<string, Microsoft.Extensions.Primitives.StringValues>(), formFileCollection);
-
-        _requestMock.Setup(x => x.Form).Returns(formCollection);
-
-        _pageModel.Request = _requestMock.Object;
+        _pageModel.UploadedFile = fileMock.Object;
 
         var result = _pageModel.ValidateFileUpload();
 
@@ -163,17 +159,14 @@ public class DynamicFormsPageTests
         fileMock.Setup(f => f.Length).Returns(5 * 1024 * 1024);
         fileMock.Setup(f => f.Name).Returns("UploadedFile");
         fileMock.Setup(f => f.FileName).Returns("badfile.exe");
-        var formFileCollection = new FormFileCollection { fileMock.Object };
-        var formCollection = new FormCollection(new Dictionary<string, Microsoft.Extensions.Primitives.StringValues>(), formFileCollection);
 
-        _requestMock.Setup(x => x.Form).Returns(formCollection);
-        _pageModel.Request = _requestMock.Object;
+        _pageModel.UploadedFile = fileMock.Object;
 
         var result = _pageModel.ValidateFileUpload();
 
         Assert.False(result);
         Assert.True(_pageModel.ModelState.ContainsKey("Answer"));
-        Assert.Equal("Please upload a file which has one of the following extensions: .pdf, .docx, .csv, .jpg, .bmp, .png, .tif", _pageModel.ModelState["Answer"]?.Errors?[0].ErrorMessage);
+        Assert.Equal("Please upload a file which has one of the following extensions: .pdf, .docx, .csv, .jpg, .bmp, .png, .tif, .adoc", _pageModel.ModelState["Answer"]?.Errors?[0].ErrorMessage);
     }
 
     [Fact]

--- a/Frontend/CO.CDP.OrganisationApp/Pages/Forms/FormsTemporaryIds.cs
+++ b/Frontend/CO.CDP.OrganisationApp/Pages/Forms/FormsTemporaryIds.cs
@@ -3,6 +3,6 @@ namespace CO.CDP.OrganisationApp.Pages.Forms;
 public static class FormsTemporaryIds
 {
     // TODO: This is just temporary - need to delete once we have APIs returning proper IDs
-    public const string FORMID = "6e593748-a047-403e-9ce8-6c41230410d2";
-    public const string SECTIONID = "03854031-4e1e-49a6-a950-8a5b0cd72057";
+    public const string FORMID = "21dbd462-48f2-4492-a469-a2e437543d11";
+    public const string SECTIONID = "2f5ad0f4-e44c-4574-819c-622d0f4fb73d";
 }

--- a/Frontend/CO.CDP.OrganisationApp/Pages/Forms/_FormElementFileUpload.cshtml
+++ b/Frontend/CO.CDP.OrganisationApp/Pages/Forms/_FormElementFileUpload.cshtml
@@ -24,4 +24,9 @@
         </p>
     }
     <input class="govuk-file-upload" id="@question.Id" name="UploadedFile" type="file">
+    @if (!string.IsNullOrEmpty(@answer))
+    {
+        <p class="govuk-body">@answer</p>
+    }
+
 </div>


### PR DESCRIPTION
Feature/dp 311 After the file upload validations, financial info file upload temp data storing the 
1) File Name
2) along with Question ID 

So that we can have file info in the TempData. We can expand that according to our needs for uploading the files to S3 in the other stories on the board.

