### PR TITLE
Introduce a single queue message router

### DIFF
--- a/Libraries/CO.CDP.MQ.Tests/PublisherContractTest.cs
+++ b/Libraries/CO.CDP.MQ.Tests/PublisherContractTest.cs
@@ -9,7 +9,7 @@ public abstract class PublisherContractTest
     {
         var publisher = await CreatePublisher();
 
-        publisher.Publish(new TestMessage(42, "Hello, Earth!"));
+        await publisher.Publish(new TestMessage(42, "Hello, Earth!"));
 
         var message = await waitForOneMessage<TestMessage>();
 

--- a/Libraries/CO.CDP.MQ.Tests/Sqs/SingleQueueMessageRouterTest.cs
+++ b/Libraries/CO.CDP.MQ.Tests/Sqs/SingleQueueMessageRouterTest.cs
@@ -1,0 +1,46 @@
+using System.Security.Cryptography;
+using Amazon.Runtime;
+using Amazon.SQS;
+using Amazon.SQS.Model;
+using CO.CDP.MQ.Sqs;
+using FluentAssertions;
+
+namespace CO.CDP.MQ.Tests.Sqs;
+
+public class SingleQueueMessageRouterTest(LocalStackFixture localStack) : IClassFixture<LocalStackFixture>
+{
+    [Fact]
+    public async Task ItRoutesAllMessageTypesToASingleQueue()
+    {
+        var queueUrl = await GivenQueueExists("test-queue-a");
+
+        var router = new SingleQueueMessageRouter(SqsClient(), "test-queue-a");
+
+        (await router.QueueUrl(typeof(Foo))).Should().Be(queueUrl);
+        (await router.QueueUrl(typeof(Bar))).Should().Be(queueUrl);
+    }
+
+    private async Task<string> GivenQueueExists(string queueName)
+    {
+        var queue = await SqsClient().CreateQueueAsync(new CreateQueueRequest { QueueName = queueName });
+        return queue.QueueUrl;
+    }
+
+    private AmazonSQSClient SqsClient()
+    {
+        var config = new AmazonSQSConfig
+        {
+            ServiceURL = localStack.ConnectionString,
+            UseHttp = false,
+            AuthenticationRegion = "eu-west-1"
+        };
+
+        var credentials = new BasicAWSCredentials("test", "test");
+        var sqsClient = new AmazonSQSClient(credentials, config);
+        return sqsClient;
+    }
+
+    private record Foo;
+
+    private record Bar;
+}

--- a/Libraries/CO.CDP.MQ.Tests/Sqs/SqsPublisherTest.cs
+++ b/Libraries/CO.CDP.MQ.Tests/Sqs/SqsPublisherTest.cs
@@ -39,7 +39,7 @@ public class SqsPublisherTest : PublisherContractTest, IClassFixture<LocalStackF
     {
         var queue = await _sqsClient.CreateQueueAsync(new CreateQueueRequest { QueueName = TestQueue });
         var queueUrl = queue.QueueUrl;
-        return new SqsPublisher(_sqsClient, _ => queueUrl, o => JsonSerializer.Serialize(o));
+        return new SqsPublisher(_sqsClient, _ => Task.FromResult(queueUrl), o => JsonSerializer.Serialize(o));
     }
 
     private AmazonSQSClient SqsClient()

--- a/Libraries/CO.CDP.MQ/IPublisher.cs
+++ b/Libraries/CO.CDP.MQ/IPublisher.cs
@@ -2,5 +2,5 @@ namespace CO.CDP.MQ;
 
 public interface IPublisher : IDisposable
 {
-    void Publish<TM>(TM message) where TM : notnull;
+    Task Publish<TM>(TM message) where TM : notnull;
 }

--- a/Libraries/CO.CDP.MQ/Sqs/SingleQueueMessageRouter.cs
+++ b/Libraries/CO.CDP.MQ/Sqs/SingleQueueMessageRouter.cs
@@ -1,0 +1,19 @@
+using Amazon.SQS;
+
+namespace CO.CDP.MQ.Sqs;
+
+public class SingleQueueMessageRouter(AmazonSQSClient sqsClient, string queueName)
+{
+    private string? _queueUrl = null;
+
+    public async Task<string> QueueUrl(Type type)
+    {
+        return _queueUrl ??= await GetQueueUrl();
+    }
+
+    private async Task<string> GetQueueUrl()
+    {
+        var queue = await sqsClient.GetQueueUrlAsync(queueName);
+        return queue.QueueUrl;
+    }
+}

--- a/Libraries/CO.CDP.MQ/Sqs/SqsPublisher.cs
+++ b/Libraries/CO.CDP.MQ/Sqs/SqsPublisher.cs
@@ -3,7 +3,7 @@ using Amazon.SQS.Model;
 
 namespace CO.CDP.MQ.Sqs;
 
-public delegate string MessageRouter(Type type);
+public delegate Task<string> MessageRouter(Type type);
 
 public delegate string Serializer(object message);
 
@@ -22,11 +22,11 @@ public class SqsPublisher(
     {
     }
 
-    public void Publish<TM>(TM message) where TM : notnull
+    public async Task Publish<TM>(TM message) where TM : notnull
     {
-        sqsClient.SendMessageAsync(new SendMessageRequest
+        await sqsClient.SendMessageAsync(new SendMessageRequest
         {
-            QueueUrl = messageRouter(typeof(TM)),
+            QueueUrl = await messageRouter(typeof(TM)),
             MessageBody = serializer(message),
             MessageAttributes = new Dictionary<string, MessageAttributeValue>
             {

--- a/Services/CO.CDP.EntityVerification/Extensions/ServiceCollectionExtensions.cs
+++ b/Services/CO.CDP.EntityVerification/Extensions/ServiceCollectionExtensions.cs
@@ -53,12 +53,9 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IPublisher, SqsPublisher>(s =>
         {
             var sqsClient = s.GetRequiredService<AmazonSQSClient>();
-            var queueUrl = sqsClient.GetQueueUrlAsync(config.GetValue("OutboundQueue:Name", "") ?? "")
-                .GetAwaiter()
-                .GetResult();
             var publisher = new SqsPublisher(
                 sqsClient,
-                _ => queueUrl.QueueUrl,
+                new SingleQueueMessageRouter(sqsClient, config.GetValue("OutboundQueue:Name", "") ?? "").QueueUrl,
                 o => JsonSerializer.Serialize(o)
             );
 

--- a/Services/CO.CDP.EntityVerification/Ppon/OrganisationRegisteredEventHandler.cs
+++ b/Services/CO.CDP.EntityVerification/Ppon/OrganisationRegisteredEventHandler.cs
@@ -9,15 +9,13 @@ namespace CO.CDP.EntityVerification.Ppon;
 public class OrganisationRegisteredEventHandler(IPponService pponService, IPponRepository pponRepository, IPublisher publisher)
     : IEventHandler<OrganisationRegistered>
 {
-    public Task Handle(OrganisationRegistered @event)
+    public async Task Handle(OrganisationRegistered @event)
     {
         var pponId = pponService.GeneratePponId();
 
         Persistence.Ppon newIdentifier = new() { PponId = pponId };
 
         pponRepository.Save(newIdentifier);
-        publisher.Publish(newIdentifier);
-
-        return Task.CompletedTask;
+        await publisher.Publish(newIdentifier);
     }
 }


### PR DESCRIPTION
Routes all messages to the single queue. First time it's invoked, it finds the queue url based on the configured queue name.

In order to:
* remove asking for the queue url from the boostrap phase
* delay asking for the queue url
* reuse

The publisher can now be async.