### PR TITLE
DP-308: Add db query to the health checks

### DIFF
--- a/Services/CO.CDP.Forms.WebApi/CO.CDP.Forms.WebApi.csproj
+++ b/Services/CO.CDP.Forms.WebApi/CO.CDP.Forms.WebApi.csproj
@@ -18,6 +18,7 @@
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.7" />
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.7" />
         <PackageReference Include="DotSwashbuckle.AspNetCore" Version="3.0.10" />
+        <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="8.0.1" />
         <ProjectReference Include="..\..\Libraries\CO.CDP.Authentication\CO.CDP.Authentication.csproj" />
         <ProjectReference Include="..\..\Libraries\CO.CDP.Swashbuckle\CO.CDP.Swashbuckle.csproj" />
         <ProjectReference Include="..\..\Libraries\CO.CDP.Functional\CO.CDP.Functional.csproj" />

--- a/Services/CO.CDP.Forms.WebApi/Program.cs
+++ b/Services/CO.CDP.Forms.WebApi/Program.cs
@@ -14,7 +14,8 @@ builder.ConfigureForwardedHeaders();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options => { options.DocumentFormsApi(); });
 
-builder.Services.AddHealthChecks();
+builder.Services.AddHealthChecks()
+    .AddNpgSql(builder.Configuration.GetConnectionString("OrganisationInformationDatabase") ?? "");
 builder.Services.AddAutoMapper(typeof(WebApiToPersistenceProfile));
 
 builder.Services.AddProblemDetails();

--- a/Services/CO.CDP.Organisation.Authority/CO.CDP.Organisation.Authority.csproj
+++ b/Services/CO.CDP.Organisation.Authority/CO.CDP.Organisation.Authority.csproj
@@ -13,6 +13,7 @@
         <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.0.0" />
         <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.0.0" />
         <PackageReference Include="DotSwashbuckle.AspNetCore" Version="3.0.10" />
+        <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="8.0.1" />
         <ProjectReference Include="..\..\Libraries\CO.CDP.Configuration\CO.CDP.Configuration.csproj" />
         <ProjectReference Include="..\..\Libraries\CO.CDP.Functional\CO.CDP.Functional.csproj" />
         <ProjectReference Include="..\CO.CDP.OrganisationInformation.Persistence\CO.CDP.OrganisationInformation.Persistence.csproj" />

--- a/Services/CO.CDP.Organisation.Authority/Program.cs
+++ b/Services/CO.CDP.Organisation.Authority/Program.cs
@@ -9,7 +9,8 @@ var builder = WebApplication.CreateBuilder(args);
 builder.ConfigureForwardedHeaders();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(o => { o.DocumentApi(); });
-builder.Services.AddHealthChecks();
+builder.Services.AddHealthChecks()
+    .AddNpgSql(builder.Configuration.GetConnectionString("OrganisationInformationDatabase") ?? "");
 builder.Services.AddProblemDetails();
 
 builder.Services.AddAutoMapper(typeof(WebApiToPersistenceProfile));

--- a/Services/CO.CDP.Organisation.WebApi/CO.CDP.Organisation.WebApi.csproj
+++ b/Services/CO.CDP.Organisation.WebApi/CO.CDP.Organisation.WebApi.csproj
@@ -18,6 +18,7 @@
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.7" />
         <PackageReference Include="DotSwashbuckle.AspNetCore" Version="3.0.10" />
         <PackageReference Include="AutoMapper" Version="13.0.1" />
+        <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="8.0.1" />
         <ProjectReference Include="..\..\Libraries\CO.CDP.Authentication\CO.CDP.Authentication.csproj" />
         <ProjectReference Include="..\CO.CDP.OrganisationInformation.Persistence\CO.CDP.OrganisationInformation.Persistence.csproj" />
         <ProjectReference Include="..\..\Libraries\CO.CDP.Functional\CO.CDP.Functional.csproj" />

--- a/Services/CO.CDP.Organisation.WebApi/Program.cs
+++ b/Services/CO.CDP.Organisation.WebApi/Program.cs
@@ -16,7 +16,8 @@ builder.ConfigureForwardedHeaders();
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options => { options.DocumentOrganisationApi(); });
-builder.Services.AddHealthChecks();
+builder.Services.AddHealthChecks()
+    .AddNpgSql(builder.Configuration.GetConnectionString("OrganisationInformationDatabase") ?? "");
 builder.Services.AddAutoMapper(typeof(WebApiToPersistenceProfile));
 
 builder.Services.AddDbContext<OrganisationInformationContext>(o =>

--- a/Services/CO.CDP.Person.WebApi/CO.CDP.Person.WebApi.csproj
+++ b/Services/CO.CDP.Person.WebApi/CO.CDP.Person.WebApi.csproj
@@ -15,6 +15,7 @@
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.7" />
         <PackageReference Include="DotSwashbuckle.AspNetCore" Version="3.0.10" />
         <PackageReference Include="AutoMapper" Version="13.0.1" />
+        <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="8.0.1" />
         <ProjectReference Include="..\..\Libraries\CO.CDP.Authentication\CO.CDP.Authentication.csproj" />
         <ProjectReference Include="..\CO.CDP.OrganisationInformation.Persistence\CO.CDP.OrganisationInformation.Persistence.csproj" />
         <ProjectReference Include="..\..\Libraries\CO.CDP.Functional\CO.CDP.Functional.csproj" />

--- a/Services/CO.CDP.Person.WebApi/Program.cs
+++ b/Services/CO.CDP.Person.WebApi/Program.cs
@@ -15,7 +15,8 @@ builder.ConfigureForwardedHeaders();
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options => { options.DocumentPersonApi(); });
-builder.Services.AddHealthChecks();
+builder.Services.AddHealthChecks()
+    .AddNpgSql(builder.Configuration.GetConnectionString("OrganisationInformationDatabase") ?? "");
 builder.Services.AddAutoMapper(typeof(WebApiToPersistenceProfile));
 
 builder.Services.AddDbContext<OrganisationInformationContext>(o =>

--- a/Services/CO.CDP.Tenant.WebApi/CO.CDP.Tenant.WebApi.csproj
+++ b/Services/CO.CDP.Tenant.WebApi/CO.CDP.Tenant.WebApi.csproj
@@ -17,6 +17,7 @@
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.7" />
         <PackageReference Include="DotSwashbuckle.AspNetCore" Version="3.0.10" />
         <PackageReference Include="AutoMapper" Version="13.0.1" />
+        <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="8.0.1" />
         <ProjectReference Include="..\..\Libraries\CO.CDP.Authentication\CO.CDP.Authentication.csproj" />
         <ProjectReference Include="..\CO.CDP.OrganisationInformation.Persistence\CO.CDP.OrganisationInformation.Persistence.csproj" />
         <ProjectReference Include="..\CO.CDP.OrganisationInformation\CO.CDP.OrganisationInformation.csproj" />

--- a/Services/CO.CDP.Tenant.WebApi/Program.cs
+++ b/Services/CO.CDP.Tenant.WebApi/Program.cs
@@ -18,7 +18,8 @@ builder.ConfigureForwardedHeaders();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options => { options.DocumentTenantApi(); });
 
-builder.Services.AddHealthChecks();
+builder.Services.AddHealthChecks()
+    .AddNpgSql(builder.Configuration.GetConnectionString("OrganisationInformationDatabase") ?? "");
 builder.Services.AddAutoMapper(typeof(WebApiToPersistenceProfile));
 
 builder.Services.AddDbContext<OrganisationInformationContext>(o =>


### PR DESCRIPTION
Adds a db check on health check action, a simple `SELECT 1` by default.

Testing:
1. call `/health` to confirm service is healthy
2. kill the db `docker kill co-cdp-db`
3. call `/health` to confirm service reports as unhealthy