### PR TITLE
DP-396: Do not crash the dispatcher loop in case of an exception

### DIFF
--- a/Libraries/CO.CDP.AwsServices/Sqs/SqsDispatcher.cs
+++ b/Libraries/CO.CDP.AwsServices/Sqs/SqsDispatcher.cs
@@ -58,13 +58,25 @@ public class SqsDispatcher(
 
             while (!cancellationToken.IsCancellationRequested)
             {
-                foreach (var message in await ReceiveMessagesAsync(configuration.QueueUrl, cancellationToken))
+                try
                 {
-                    await HandleMessage(message);
-                    await DeleteMessage(message);
+                    await HandleMessages(cancellationToken);
+                }
+                catch (Exception cause)
+                {
+                    logger.LogError(cause, "Message handling failed");
                 }
             }
         }, cancellationToken);
+    }
+
+    private async Task HandleMessages(CancellationToken cancellationToken)
+    {
+        foreach (var message in await ReceiveMessagesAsync(configuration.QueueUrl, cancellationToken))
+        {
+            await HandleMessage(message);
+            await DeleteMessage(message);
+        }
     }
 
     private async Task<List<Message>> ReceiveMessagesAsync(string queueUrl, CancellationToken cancellationToken)

--- a/Libraries/CO.CDP.MQ.Tests/DispatcherContractTest.cs
+++ b/Libraries/CO.CDP.MQ.Tests/DispatcherContractTest.cs
@@ -25,8 +25,8 @@ public abstract class DispatcherContractTest
 
         await task;
 
-        subscriber1.PublishedMessages.Should().Equal([new TestMessage(13, "Hello.")]);
-        subscriber2.PublishedMessages.Should().Equal([new TestMessage(13, "Hello.")]);
+        subscriber1.HandledMessages.Should().Equal([new TestMessage(13, "Hello.")]);
+        subscriber2.HandledMessages.Should().Equal([new TestMessage(13, "Hello.")]);
     }
 
     [Fact]
@@ -47,6 +47,44 @@ public abstract class DispatcherContractTest
         (await CountMessagesInQueue()).Should().Be(0);
     }
 
+    [Fact]
+    public async Task ItAttemptsToRecoverFromFailures()
+    {
+        var tokenSource = new CancellationTokenSource();
+        var failingSubscriberCallCount = 0;
+
+        var subscriber = new TestSubscriber<TestMessage>(_ => Task.CompletedTask);
+        var failingSubscriber = new TestSubscriber<TestMessage>(_ =>
+        {
+            failingSubscriberCallCount++;
+            if (failingSubscriberCallCount == 1)
+            {
+                throw new Exception("Failure in subscriber.");
+            }
+            tokenSource.Cancel();
+            return Task.CompletedTask;
+        });
+
+        var dispatcher = await CreateDispatcher();
+        dispatcher.Subscribe(subscriber);
+        dispatcher.Subscribe(failingSubscriber);
+
+        var task = dispatcher.ExecuteAsync(tokenSource.Token);
+
+        await PublishMessage(new TestMessage(13, "Hello."));
+
+        await task;
+
+        subscriber.ReceivedMessages.Should()
+            .Equal([new TestMessage(13, "Hello."), new TestMessage(13, "Hello.")]);
+        failingSubscriber.ReceivedMessages.Should()
+            .Equal([new TestMessage(13, "Hello."), new TestMessage(13, "Hello.")]);
+        subscriber.HandledMessages.Should()
+            .Equal([new TestMessage(13, "Hello."), new TestMessage(13, "Hello.")]);
+        failingSubscriber.HandledMessages.Should()
+            .Equal([new TestMessage(13, "Hello.")]);
+    }
+
     protected abstract Task<IDispatcher> CreateDispatcher();
     protected abstract Task PublishMessage<TM>(TM message) where TM : class;
     protected abstract Task<int> CountMessagesInQueue();
@@ -55,14 +93,27 @@ public abstract class DispatcherContractTest
 
     private record UnexpectedTestMessage(int Id, String Name);
 
-    private class TestSubscriber<TEvent>(CancellationTokenSource? tokenSource = null) : ISubscriber<TEvent> where TEvent : class
+    private class TestSubscriber<TEvent>(Func<TEvent, Task> handler)
+        : ISubscriber<TEvent> where TEvent : class
     {
-        public readonly ConcurrentBag<object> PublishedMessages = new();
+        public readonly ConcurrentBag<object> HandledMessages = new();
+        public readonly ConcurrentBag<object> ReceivedMessages = new();
+
+        public TestSubscriber(CancellationTokenSource? cancellationTokenSource = null) : this(
+            _ =>
+            {
+                cancellationTokenSource?.Cancel();
+                return Task.CompletedTask;
+            })
+        {
+        }
+
         public Task Handle(TEvent @event)
         {
-            PublishedMessages.Add(@event);
-            tokenSource?.Cancel();
-            return Task.CompletedTask;
+            ReceivedMessages.Add(@event);
+            var result = handler(@event);
+            HandledMessages.Add(@event);
+            return result;
         }
     }
 }


### PR DESCRIPTION
This way, in case of a problem, the background service will continue running.