### PR TITLE
Bug: DP-387

### DIFF
--- a/Frontend/CO.CDP.OrganisationApp/Pages/OrganisationOverview.cshtml
+++ b/Frontend/CO.CDP.OrganisationApp/Pages/OrganisationOverview.cshtml
@@ -41,7 +41,14 @@
                                 @identifierToShow.Scheme.SchemeDescription()
                             </p>
                             <p class="govuk-body">
-                                @identifierToShow.Id
+                                @if (@identifierToShow.Id == null)
+                                {
+                                    <p class="govuk-body">PPON generation pending.</p>
+                                }
+                                else
+                                {
+                                    @identifierToShow.Id
+                                }
                              </p>
                         </dd>
                         <dd class="govuk-summary-list__actions">


### PR DESCRIPTION
[DP-387](https://noticingsystem.atlassian.net/browse/DP-387)

Displays "PPON generation pending." in org details page when there are no identifiers (including PPON) for an organisation.