### PR TITLE
DP-529 Add post-build phase to execute migration step-functions

### DIFF
--- a/terragrunt/components/service/ecs/terragrunt.hcl
+++ b/terragrunt/components/service/ecs/terragrunt.hcl
@@ -105,9 +105,10 @@ dependency service_queue {
 
 inputs = {
 
-  account_ids     = local.global_vars.locals.account_ids
-  service_configs = local.global_vars.locals.service_configs
-  tags            = local.tags
+  account_ids            = local.global_vars.locals.account_ids
+  pinned_service_version = local.global_vars.locals.pinned_service_version
+  service_configs        = local.global_vars.locals.service_configs
+  tags                   = local.tags
 
   role_cloudwatch_events_arn               = dependency.core_iam.outputs.cloudwatch_events_arn
   role_cloudwatch_events_name              = dependency.core_iam.outputs.cloudwatch_events_name

--- a/terragrunt/components/terragrunt.hcl
+++ b/terragrunt/components/terragrunt.hcl
@@ -88,6 +88,7 @@ locals {
             cidr_block             = "10.${local.cidr_b_production}.0.0/16"
             account_id             = 471112843276
             name                   = "production"
+            pinned_service_version = null
             postgres_instance_type = "db.t4g.micro"
             private_subnets        = [
                 "10.${local.cidr_b_production}.101.0/24",
@@ -102,6 +103,8 @@ locals {
             top_level_domain = "findatender.codatt.net"
         }
     }
+
+    pinned_service_version  = try(local.environments[local.environment].pinned_service_version, null)
 
     product = {
         name               = "CDP SIRSI"
@@ -266,7 +269,6 @@ inputs = {
     environment             = local.environment
     product                 = local.product
     tags                    = local.tags
-    pinned_service_version  = try(local.environments[local.environment].pinned_service_version, null)
     postgres_engine_version = local.versions.postgres_engine
     postgres_instance_type  = local.environments[local.environment].postgres_instance_type
     vpc_cidr                = local.environments[local.environment].cidr_block

--- a/terragrunt/modules/core-iam/terraform-datasource.tf
+++ b/terragrunt/modules/core-iam/terraform-datasource.tf
@@ -507,11 +507,12 @@ data "aws_iam_policy_document" "terraform_product" {
   statement {
     actions = [
       "states:CreateStateMachine",
-      "states:UpdateStateMachine",
-      "states:TagResource",
       "states:Delete*",
       "states:Describe*",
       "states:List*",
+      "states:StartExecution",
+      "states:TagResource",
+      "states:UpdateStateMachine"
     ]
     effect = "Allow"
     resources = [

--- a/terragrunt/modules/orchestrator/ci/buildspecs/deployment.yml
+++ b/terragrunt/modules/orchestrator/ci/buildspecs/deployment.yml
@@ -16,3 +16,17 @@ phases:
       - echo "Applying updates to all components..."
       - cd $CODEBUILD_SRC_DIR/terragrunt/components
       - terragrunt run-all apply -auto-approve -terragrunt-non-interactive
+
+  post_build:
+    commands:
+      - if [ "${AWS_ACCOUNT_ID}" = "${ORCHESTRATOR_ACCOUNT_ID}" ]; then
+          echo "No Step Functions triggered as the target is the orchestrator account.";
+        else
+          echo "Deployment successful, triggering Step Functions for ECS migration tasks...";
+          STEP_FUNCTION_ARN="arn:aws:states:${AWS_REGION}:${AWS_ACCOUNT_ID}:stateMachine:cdp-sirsi-run-organisation-information-migrations";
+          aws stepfunctions start-execution --state-machine-arn ${STEP_FUNCTION_ARN};
+          echo "Step Function ${STEP_FUNCTION_NAME} triggered successfully.";
+          STEP_FUNCTION_ARN="arn:aws:states:${AWS_REGION}:${AWS_ACCOUNT_ID}:stateMachine:cdp-sirsi-run-entity-verification-migrations";
+          aws stepfunctions start-execution --state-machine-arn ${STEP_FUNCTION_ARN};
+          echo "Step Function ${STEP_FUNCTION_NAME} triggered successfully.";
+        fi

--- a/terragrunt/modules/orchestrator/ci/codebuild.tf
+++ b/terragrunt/modules/orchestrator/ci/codebuild.tf
@@ -30,6 +30,10 @@ resource "aws_codebuild_project" "this" {
       value = each.value
     }
     environment_variable {
+      name  = "ORCHESTRATOR_ACCOUNT_ID"
+      value = data.aws_caller_identity.current.account_id
+    }
+    environment_variable {
       name  = "TG_ENVIRONMENT"
       value = each.key
     }


### PR DESCRIPTION
This has been provisioned and tested in the **orchestrator** account, successfully triggering the migration tasks in **development**. 
Additional changes, including granting permissions to retrieve different account IDs, will be made in a separate PR.