### PR TITLE
DP-529 Fix EV migration lacking Org-Auth address

### DIFF
--- a/terragrunt/modules/ecs/templates/task-definitions/entity-verification-migrations.json.tftpl
+++ b/terragrunt/modules/ecs/templates/task-definitions/entity-verification-migrations.json.tftpl
@@ -15,6 +15,7 @@
     },
     "environment": [
         {"name": "ASPNETCORE_ENVIRONMENT", "value": "${aspcore_environment}"},
+        {"name": "Organisation__Authority", "value": "https://authority.${public_hosted_zone_fqdn}"},
         {"name": "EntityVerificationDatabase__Host", "value": "${db_address}"},
         {"name": "EntityVerificationDatabase__Server", "value": "${db_address}"},
         {"name": "EntityVerificationDatabase__Database", "value": "${db_name}"}

--- a/terragrunt/tools/grafana/README.md
+++ b/terragrunt/tools/grafana/README.md
@@ -28,7 +28,7 @@ docker push ${ACCOUNT_ID}.dkr.ecr.eu-west-2.amazonaws.com/cdp-grafana:latest
 ### Re-deploy Grafana service
 
 ```shell
-ave aws ecs update-service --cluster cdp-sirsi --service grafana --force-new-deployment
+ave aws ecs update-service --cluster cdp-sirsi --service grafana --force-new-deployment | jq -r '.'
 ```
 
 ## Fetch Credentials

--- a/terragrunt/tools/grafana/configs/dashboards/application/logs-entity-verification-migrations.json
+++ b/terragrunt/tools/grafana/configs/dashboards/application/logs-entity-verification-migrations.json
@@ -56,8 +56,8 @@
           "logGroups": [
             {
               "accountId": "GRAFANA_CLOUDWATCH_ACCOUNT_ID",
-              "arn": "arn:aws:logs:eu-west-2:GRAFANA_CLOUDWATCH_ACCOUNT_ID:log-group:/ecs/organisation-information-migrations:*",
-              "name": "/ecs/organisation-information-migrations"
+              "arn": "arn:aws:logs:eu-west-2:GRAFANA_CLOUDWATCH_ACCOUNT_ID:log-group:/ecs/entity-verification-migrations:*",
+              "name": "/ecs/entity-verification-migrations"
             }
           ],
           "matchExact": true,
@@ -112,8 +112,8 @@
           "logGroups": [
             {
               "accountId": "GRAFANA_CLOUDWATCH_ACCOUNT_ID",
-              "arn": "arn:aws:logs:eu-west-2:GRAFANA_CLOUDWATCH_ACCOUNT_ID:log-group:/ecs/organisation-information-migrations:*",
-              "name": "/ecs/organisation-information-migrations"
+              "arn": "arn:aws:logs:eu-west-2:GRAFANA_CLOUDWATCH_ACCOUNT_ID:log-group:/ecs/entity-verification-migrations:*",
+              "name": "/ecs/entity-verification-migrations"
             }
           ],
           "matchExact": true,
@@ -168,8 +168,8 @@
           "logGroups": [
             {
               "accountId": "GRAFANA_CLOUDWATCH_ACCOUNT_ID",
-              "arn": "arn:aws:logs:eu-west-2:GRAFANA_CLOUDWATCH_ACCOUNT_ID:log-group:/ecs/organisation-information-migrations:*",
-              "name": "/ecs/organisation-information-migrations"
+              "arn": "arn:aws:logs:eu-west-2:GRAFANA_CLOUDWATCH_ACCOUNT_ID:log-group:/ecs/entity-verification-migrations:*",
+              "name": "/ecs/entity-verification-migrations"
             }
           ],
           "matchExact": true,
@@ -201,8 +201,8 @@
   },
   "timepicker": {},
   "timezone": "browser",
-  "title": "Migrations (Organisation Information)",
-  "uid": "migrations-organisation-information",
+  "title": "Migrations (Entity Verification)",
+  "uid": "migrations-entity-verification",
   "version": 1,
   "weekStart": ""
 }


### PR DESCRIPTION
  - Bring live service in line with [DP-391](https://noticingsystem.atlassian.net/browse/DP-391) changes [here](https://github.com/cabinetoffice/GCGS-Central-Digital-Platform/commit/ea00820bc70deb959853c8aed533f8a67e0799aa#diff-3493e6b5ddf34891e572f911db893efd9e46af828e011ea778a7c1eb64763588R104)
  - Add Grafana dashboard for EV migrations
  - Rename Grafana migration dashboards 

![image](https://github.com/user-attachments/assets/770f51ce-4de2-4d19-bba0-bc1d31c92a10)

![image](https://github.com/user-attachments/assets/1093dc38-b1b2-4c31-bd69-ecac1e2dfe34)
