### PR TITLE
Fix getting the latest tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,5 +95,5 @@ version-commit: ## Determines the last commit hash
 .PHONY: version-commit
 
 last-tag: ## Determines the last created tag on the repository
-	@git for-each-ref refs/tags --sort=-taggerdate --format='%(refname:short)' --count=1
+	@git for-each-ref refs/tags --sort=-creatordate --format='%(refname:short)' --count=1
 .PHONY: last-tag


### PR DESCRIPTION
0.1.1 is always seen as latest otherwise.