### PR TITLE
Feature/dp 538 datasharing supplier information dashboard financial information documents related to past sharedconsents are displayed

### DIFF
--- a/Services/CO.CDP.Forms.WebApi/UseCase/GetFormSectionQuestionsUseCase.cs
+++ b/Services/CO.CDP.Forms.WebApi/UseCase/GetFormSectionQuestionsUseCase.cs
@@ -17,6 +17,8 @@ public class GetFormSectionQuestionsUseCase(IFormRepository formRepository, IMap
             return null;
 
         var answerSet = await formRepository.GetFormAnswerSetsAsync(sectionId, organisationId);
+        var currentSharedConsent = answerSet.Select(x => x.SharedConsent).OrderByDescending(x => x.UpdatedOn).FirstOrDefault();
+        answerSet = answerSet.Where(x => x.SharedConsent == currentSharedConsent).ToList();
 
         return new SectionQuestionsResponse
         {


### PR DESCRIPTION
This one will build and merge without any issues once DP-537 https://github.com/cabinetoffice/GCGS-Central-Digital-Platform/pull/530 gets merged in