### PR TITLE
DP-531 Add Switch for RDS Production Configuration

### DIFF
--- a/terragrunt/components/service/database/terragrunt.hcl
+++ b/terragrunt/components/service/database/terragrunt.hcl
@@ -23,7 +23,8 @@ locals {
 dependency core_iam {
   config_path = "../../core/iam"
   mock_outputs = {
-    terraform_arn                    = "mock"
+    rds_cloudwatch_arn = "mock"
+    terraform_arn      = "mock"
   }
 }
 
@@ -52,5 +53,6 @@ inputs = {
 
   db_postgres_sg_id = dependency.core_security_group.outputs.db_postgres_sg_id
 
-  role_terraform_arn = dependency.core_iam.outputs.terraform_arn
+  role_terraform_arn      = dependency.core_iam.outputs.terraform_arn
+  role_rds_cloudwatch_arn = dependency.core_iam.outputs.rds_cloudwatch_arn
 }

--- a/terragrunt/modules/core-iam/outputs.tf
+++ b/terragrunt/modules/core-iam/outputs.tf
@@ -62,6 +62,14 @@ output "notification_step_function_name" {
   value = aws_iam_role.notification_step_function.name
 }
 
+output "rds_cloudwatch_arn" {
+  value = aws_iam_role.rds_cloudwatch_role.arn
+}
+
+output "rds_cloudwatch_name" {
+  value = aws_iam_role.rds_cloudwatch_role.name
+}
+
 output "service_deployer_step_function_arn" {
   value = aws_iam_role.service_deployer_step_function.arn
 }

--- a/terragrunt/modules/core-iam/rds-datasource.tf
+++ b/terragrunt/modules/core-iam/rds-datasource.tf
@@ -1,0 +1,12 @@
+data "aws_iam_policy_document" "rds_cloudwatch_assume" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["monitoring.rds.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}

--- a/terragrunt/modules/core-iam/rds.tf
+++ b/terragrunt/modules/core-iam/rds.tf
@@ -1,0 +1,10 @@
+resource "aws_iam_role" "rds_cloudwatch_role" {
+  name = "${local.name_prefix}-rds-cloudwatch"
+
+  assume_role_policy = data.aws_iam_policy_document.rds_cloudwatch_assume.json
+}
+
+resource "aws_iam_role_policy_attachment" "rds_monitoring_role_attachment" {
+  role       = aws_iam_role.rds_cloudwatch_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole"
+}

--- a/terragrunt/modules/core-iam/terraform-datasource.tf
+++ b/terragrunt/modules/core-iam/terraform-datasource.tf
@@ -251,6 +251,8 @@ data "aws_iam_policy_document" "terraform_global" {
 
   statement {
     actions = [
+      "rds:AddTagsToResource",
+      "rds:CreateDBInstanceReadReplica",
       "rds:DescribeDBInstances",
     ]
     effect = "Allow"

--- a/terragrunt/modules/database/locals.tf
+++ b/terragrunt/modules/database/locals.tf
@@ -1,3 +1,5 @@
 locals {
   name_prefix = var.product.resource_name
+
+  is_production = contains(["production", "integration"], var.environment)
 }

--- a/terragrunt/modules/database/rds-entity-verification.tf
+++ b/terragrunt/modules/database/rds-entity-verification.tf
@@ -1,12 +1,19 @@
 module "rds_entity_verification" {
   source = "../rds"
 
-  db_name                               = "${local.name_prefix}-entity-verification"
-  db_postgres_sg_id                     = var.db_postgres_sg_id
-  environment                           = var.environment
-  postgres_engine_version               = var.postgres_engine_version
-  postgres_instance_type                = var.postgres_instance_type
-  private_subnet_ids                    = var.private_subnet_ids
-  role_terraform_arn                    = var.role_terraform_arn
-  tags                                  = var.tags
+  create_read_replica          = local.is_production
+  backup_retention_period      = local.is_production ? 14 : 0
+  db_name                      = "${local.name_prefix}-entity-verification"
+  db_postgres_sg_id            = var.db_postgres_sg_id
+  environment                  = var.environment
+  max_allocated_storage        = local.is_production ? 50 : 0
+  monitoring_interval          = local.is_production ? 30 : 0
+  monitoring_role_arn          = local.is_production ? var.role_rds_cloudwatch_arn : ""
+  multi_az                     = local.is_production
+  performance_insights_enabled = local.is_production
+  postgres_engine_version      = var.postgres_engine_version
+  postgres_instance_type       = var.postgres_instance_type
+  private_subnet_ids           = var.private_subnet_ids
+  role_terraform_arn           = var.role_terraform_arn
+  tags                         = var.tags
 }

--- a/terragrunt/modules/database/rds-sirsi.tf
+++ b/terragrunt/modules/database/rds-sirsi.tf
@@ -1,12 +1,19 @@
 module "rds_sirsi" {
   source = "../rds"
 
-  db_name                               = local.name_prefix
-  db_postgres_sg_id                     = var.db_postgres_sg_id
-  environment                           = var.environment
-  postgres_engine_version               = var.postgres_engine_version
-  postgres_instance_type                = var.postgres_instance_type
-  private_subnet_ids                    = var.private_subnet_ids
-  role_terraform_arn                    = var.role_terraform_arn
-  tags                                  = var.tags
+  create_read_replica          = local.is_production
+  backup_retention_period      = local.is_production ? 14 : 0
+  db_name                      = local.name_prefix
+  db_postgres_sg_id            = var.db_postgres_sg_id
+  environment                  = var.environment
+  max_allocated_storage        = local.is_production ? 50 : 0
+  monitoring_interval          = local.is_production ? 30 : 0
+  monitoring_role_arn          = local.is_production ? var.role_rds_cloudwatch_arn : ""
+  multi_az                     = local.is_production
+  performance_insights_enabled = local.is_production
+  postgres_engine_version      = var.postgres_engine_version
+  postgres_instance_type       = var.postgres_instance_type
+  private_subnet_ids           = var.private_subnet_ids
+  role_terraform_arn           = var.role_terraform_arn
+  tags                         = var.tags
 }

--- a/terragrunt/modules/database/variables.tf
+++ b/terragrunt/modules/database/variables.tf
@@ -32,6 +32,12 @@ variable "product" {
   })
 }
 
+variable "role_rds_cloudwatch_arn" {
+  description = "The ARN for the IAM role that permits RDS to send data to CloudWatch. Required in production accounts where enhanced monitoring is enabled"
+  type        = string
+  default     = ""
+}
+
 variable "role_terraform_arn" {
   description = "Terraform IAM role ARN"
   type        = string

--- a/terragrunt/modules/rds/rds.tf
+++ b/terragrunt/modules/rds/rds.tf
@@ -29,7 +29,7 @@ resource "aws_db_instance" "postgres" {
   allocated_storage                   = 20
   apply_immediately                   = true
   auto_minor_version_upgrade          = false
-  backup_retention_period             = var.environment == "production" ? 14 : 0
+  backup_retention_period             = var.backup_retention_period
   character_set_name                  = ""
   db_name                             = replace(var.db_name, "-", "_")
   db_subnet_group_name                = aws_db_subnet_group.postgres.name
@@ -38,11 +38,16 @@ resource "aws_db_instance" "postgres" {
   iam_database_authentication_enabled = true
   identifier                          = var.db_name
   instance_class                      = var.postgres_instance_type
+  max_allocated_storage               = var.max_allocated_storage
   manage_master_user_password         = true
   master_user_secret_kms_key_id       = module.kms.key_id
-  multi_az                            = var.environment == "production"
+  monitoring_interval                 = var.monitoring_interval
+  monitoring_role_arn                 = var.monitoring_role_arn
+  multi_az                            = var.multi_az
+  performance_insights_enabled        = var.performance_insights_enabled
   skip_final_snapshot                 = true
   storage_encrypted                   = true
+  storage_type                        = var.storage_type
   username                            = "${replace(var.db_name, "-", "_")}_user"
   vpc_security_group_ids              = [var.db_postgres_sg_id]
 
@@ -54,6 +59,26 @@ resource "aws_db_instance" "postgres" {
     var.tags,
     {
       Name = replace(var.db_name, "-", "_")
+    }
+  )
+}
+
+resource "aws_db_instance" "replica" {
+  # @TODO(ABN) decide if read replica is wanted for this project considering its limitation on Postgres
+  #            https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_PostgreSQL.Replication.ReadReplicas.html#USER_PostgreSQL.Replication.ReadReplicas.Limitations
+  # count                  = var.create_read_replica ? 1 : 0
+  count                  = 0
+
+  auto_minor_version_upgrade  = false
+  instance_class              = var.postgres_instance_type
+  manage_master_user_password = false
+  publicly_accessible         = false
+  replicate_source_db         = aws_db_instance.postgres.identifier
+
+  tags = merge(
+    var.tags,
+    {
+      Name = "${replace(var.db_name, "-", "_")}-replica"
     }
   )
 }

--- a/terragrunt/modules/rds/variables.tf
+++ b/terragrunt/modules/rds/variables.tf
@@ -1,3 +1,15 @@
+variable "backup_retention_period" {
+  description = "The number of days to retain backups for"
+  type        = number
+  default     = 7
+}
+
+variable "create_read_replica" {
+  description = "Create a read replica for this RDS instance"
+  type        = bool
+  default     = false
+}
+
 variable "db_name" {
   description = "Data base name"
   type        = string
@@ -8,9 +20,44 @@ variable "db_postgres_sg_id" {
   type        = string
 }
 
+variable "multi_az" {
+  description = "Enable Multi-AZ deployment for RDS"
+  type        = bool
+  default     = false
+}
+
 variable "environment" {
   description = "The environment we are provisioning, i.e. test, do not mistake this with the AWS account"
   type        = string
+}
+
+variable "max_allocated_storage" {
+  description = "The maximum amount of storage (in GB) that can be automatically allocated to the RDS instance."
+  type        = number
+  default     = 0
+}
+
+variable "monitoring_interval" {
+  description = "The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance. To disable collecting Enhanced Monitoring metrics, specify 0."
+  type        = number
+  default     = 0
+
+  validation {
+    condition = contains([0, 1, 5, 10, 15, 30, 60], var.monitoring_interval)
+    error_message = "Invalid value for monitoring_interval. Valid values are: 0, 1, 5, 10, 15, 30, 60 seconds."
+  }
+}
+
+variable "monitoring_role_arn" {
+  description = "The ARN for the IAM role that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. Required if monitoring_interval is greater than 0."
+  type        = string
+  default     = ""
+}
+
+variable "performance_insights_enabled" {
+  description = "Enable Performance Insights"
+  type        = bool
+  default     = false
 }
 
 variable "postgres_engine_version" {
@@ -31,6 +78,12 @@ variable "private_subnet_ids" {
 variable "role_terraform_arn" {
   description = "Terraform IAM role ARN"
   type        = string
+}
+
+variable "storage_type" {
+  description = "The storage type to use for RDS (gp2, gp3, io1)"
+  type        = string
+  default     = "gp2"
 }
 
 variable "tags" {


### PR DESCRIPTION
Enable/Control RDS Features Across Environments

- Added support for automated backups
- Enabled Multi-AZ configuration
- Introduced storage auto-scaling
- Enabled Enhanced Monitoring
- Integrated Performance Insights
- Read-replica (resource added but not activate/provisioned)
- Storage type (kept the current default)

Tested in staging; now prepared for production and integration environments.
