### PR TITLE
DP-564 Handle Version Strings with and without Hyphens

### DIFF
--- a/terragrunt/modules/orchestrator/notification/templates/state-machine/send-slack-notification.json.tftpl
+++ b/terragrunt/modules/orchestrator/notification/templates/state-machine/send-slack-notification.json.tftpl
@@ -55,17 +55,28 @@
         "parameterValue.$": "$.Parameter.Value"
       },
       "ResultPath": "$.parameterDetails",
-      "Next": "ExtractCommitRevision"
+      "Next": "SplitVersionString"
     },
-    "ExtractCommitRevision": {
+    "SplitVersionString": {
       "Type": "Pass",
       "Parameters": {
-        "commitRevision.$": "States.ArrayGetItem(States.StringSplit($.parameterDetails.parameterValue, '-'), 1)"
+        "splitResult.$": "States.StringSplit($.parameterDetails.parameterValue, '-')"
       },
-      "ResultPath": "$.commitRevisionDetails",
-      "Next": "SetServiceVersionUpdateMessage"
+      "ResultPath": "$.splitDetails",
+      "Next": "CheckIfCommitRevisionExists"
     },
-    "SetServiceVersionUpdateMessage": {
+    "CheckIfCommitRevisionExists": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Variable": "$.splitDetails.splitResult[1]",
+          "IsPresent": true,
+          "Next": "SetCommitLinkMessage"
+        }
+      ],
+      "Default": "SetTagLinkMessage"
+    },
+    "SetCommitLinkMessage": {
       "Type": "Pass",
       "Parameters": {
         "blocks": [
@@ -74,7 +85,24 @@
             "block_id": "service_version",
             "text": {
               "type": "mrkdwn",
-              "text.$": "States.Format(':abn-version: New *service-version* `{}` published. <https://github.com/cabinetoffice/GCGS-Central-Digital-Platform/commit/{}|view commit {}> :me-looking:', $.parameterDetails.parameterValue, $.commitRevisionDetails.commitRevision, $.commitRevisionDetails.commitRevision)"
+              "text.$": "States.Format(':abn-version: New *service-version* `{}` published. <https://github.com/cabinetoffice/GCGS-Central-Digital-Platform/commit/{}|view commit {}> :me-looking:', $.parameterDetails.parameterValue, $.splitDetails.splitResult[1], $.splitDetails.splitResult[1])"
+            }
+          }
+        ]
+      },
+      "ResultPath": "$.constructedMessage",
+      "Next": "SendSlackNotification"
+    },
+    "SetTagLinkMessage": {
+      "Type": "Pass",
+      "Parameters": {
+        "blocks": [
+          {
+            "type": "section",
+            "block_id": "service_version",
+            "text": {
+              "type": "mrkdwn",
+              "text.$": "States.Format(':abn-version: New *service-version* `{}` published. <https://github.com/cabinetoffice/GCGS-Central-Digital-Platform/releases/tag/{}|view release {}> :me-looking:', $.parameterDetails.parameterValue, $.parameterDetails.parameterValue, $.parameterDetails.parameterValue)"
             }
           }
         ]


### PR DESCRIPTION
  - Added logic to correctly construct Slack notification links based on version string format.
  - Implemented conditional checks for commit vs. release tag links.
  - Simplified the state machine for better readability and reliability.

This has been tested in the orchestrator account and confirmed the following two type of links:
- `https://github.com/cabinetoffice/GCGS-Central-Digital-Platform/releases/tag/0.4.0` for **0.4.0**
- `https://github.com/cabinetoffice/GCGS-Central-Digital-Platform/commit/40fd0960` for **0.4.0-40fd0960**

![image](https://github.com/user-attachments/assets/69a7b39d-48dd-432c-8f59-1350f4a8b32d)
