### PR TITLE
#dp-456 Add Authorization issue fixed for Share information

### DIFF
--- a/Libraries/CO.CDP.DataSharing.WebApiClient.Tests/DataSharingClientIntegrationTest.cs
+++ b/Libraries/CO.CDP.DataSharing.WebApiClient.Tests/DataSharingClientIntegrationTest.cs
@@ -22,7 +22,7 @@ public class DataSharingClientIntegrationTest(ITestOutputHelper testOutputHelper
 
         var exception = await act.Should().ThrowAsync<ApiException<ProblemDetails>>();
 
-        exception.And.StatusCode.Should().Be(500);
-        exception.And.Result!.Title.Should().Contain("System.InvalidOperationException");
+        exception.And.StatusCode.Should().Be(404);
+        exception.And.Result!.Title.Should().Contain("ShareCodeNotFoundException");
     }
 }

--- a/Services/CO.CDP.DataSharing.WebApi/Program.cs
+++ b/Services/CO.CDP.DataSharing.WebApi/Program.cs
@@ -39,8 +39,8 @@ builder.Services.AddScoped<IUseCase<string, SupplierInformation?>, GetSharedData
 builder.Services.AddScoped<IUseCase<string, byte[]?>, GetSharedDataPdfUseCase>();
 builder.Services.AddDataSharingProblemDetails();
 builder.Services.AddJwtBearerAndApiKeyAuthentication(builder.Configuration, builder.Environment);
-builder.Services.AddAuthorization();
-//builder.Services.AddOrganisationAuthorization();
+//builder.Services.AddAuthorization();
+builder.Services.AddOrganisationAuthorization();
 
 builder.Services
     .AddAwsConfiguration(builder.Configuration)


### PR DESCRIPTION
#dp-456 Add Authorization issue fixed for Share information

1.  500 error is in Organisation app
2.  in Data sharing Onelogin policy not found

Inside program.cs

For  replace:
builder.Services.AddAuthorization();
with:
builder.Services.AddOrganisationAuthorization();