### PR TITLE
DP-455: Cleanup the DataService

### DIFF
--- a/Services/CO.CDP.DataSharing.WebApi.Tests/DataService/DataServiceTests.cs
+++ b/Services/CO.CDP.DataSharing.WebApi.Tests/DataService/DataServiceTests.cs
@@ -2,6 +2,7 @@ using CO.CDP.DataSharing.WebApi.Model;
 using CO.CDP.OrganisationInformation.Persistence;
 using FluentAssertions;
 using Moq;
+using static DataSharing.Tests.DataSharingFactory;
 using SharedConsent = CO.CDP.OrganisationInformation.Persistence.Forms.SharedConsent;
 
 namespace DataSharing.Tests.DataService;
@@ -10,28 +11,6 @@ public class DataServiceTests
 {
     private readonly Mock<IShareCodeRepository> _shareCodeRepository = new();
     private CO.CDP.DataSharing.WebApi.DataService.DataService DataService => new(_shareCodeRepository.Object);
-
-    private SharedConsent CreateSharedConsent(
-        string? shareCode = null
-    )
-    {
-        return new SharedConsent
-        {
-            Id = 1,
-            Guid = Guid.NewGuid(),
-            OrganisationId = 1,
-            Organisation = DataSharingFactory.CreateOrganisation(),
-            FormId = 1,
-            Form = null!,
-            AnswerSets = null!,
-            SubmissionState = default,
-            SubmittedAt = null,
-            FormVersionId = string.Empty,
-            ShareCode = shareCode ?? "valid-share-code",
-            CreatedOn = DateTimeOffset.UtcNow,
-            UpdatedOn = DateTimeOffset.UtcNow
-        };
-    }
 
     [Fact]
     public async Task GetSharedSupplierInformationAsync_ShouldReturnSharedSupplierInformation_WhenOrganisationExists()

--- a/Services/CO.CDP.DataSharing.WebApi.Tests/DataService/DataServiceTests.cs
+++ b/Services/CO.CDP.DataSharing.WebApi.Tests/DataService/DataServiceTests.cs
@@ -20,7 +20,7 @@ public class DataServiceTests
             Id = 1,
             Guid = Guid.NewGuid(),
             OrganisationId = 1,
-            Organisation = DataSharingFactory.CreateMockOrganisation(),
+            Organisation = DataSharingFactory.CreateOrganisation(),
             FormId = 1,
             Form = null!,
             AnswerSets = null!,
@@ -76,21 +76,24 @@ public class DataServiceTests
     }
 
     [Fact]
-    public void MapToBasicInformation_ShouldMapOrganisationToBasicInformationCorrectly()
+    public async Task ShouldMapOrganisationToBasicInformation()
     {
-        var organisation = DataSharingFactory.CreateMockOrganisation();
+        var sharedConsent = CreateSharedConsent();
+        var organisation = sharedConsent.Organisation;
 
-        var result = DataService.MapToBasicInformation(organisation);
+        _shareCodeRepository.Setup(r => r.GetByShareCode("ABC-123")).ReturnsAsync(sharedConsent);
 
-        result.Should().NotBeNull();
-        result.SupplierType.Should().Be(organisation.SupplierInfo?.SupplierType);
-        result.RegisteredAddress.Should().NotBeNull();
-        result.PostalAddress.Should().NotBeNull();
-        result.VatNumber.Should().Be(organisation.Identifiers.FirstOrDefault(i => i.Scheme == "VAT")?.IdentifierId);
-        result.WebsiteAddress.Should().Be(organisation.ContactPoints.FirstOrDefault()?.Url);
-        result.EmailAddress.Should().Be(organisation.ContactPoints.FirstOrDefault()?.Email);
-        result.Qualifications.Should().HaveCount(1);
-        result.TradeAssurances.Should().HaveCount(1);
-        result.LegalForm.Should().NotBeNull();
+        var result = await DataService.GetSharedSupplierInformationAsync("ABC-123");
+
+        result.BasicInformation.SupplierType.Should().Be(organisation.SupplierInfo?.SupplierType);
+        result.BasicInformation.RegisteredAddress.Should().NotBeNull();
+        result.BasicInformation.PostalAddress.Should().NotBeNull();
+        result.BasicInformation.VatNumber.Should()
+            .Be(organisation.Identifiers.FirstOrDefault(i => i.Scheme == "VAT")?.IdentifierId);
+        result.BasicInformation.WebsiteAddress.Should().Be(organisation.ContactPoints.FirstOrDefault()?.Url);
+        result.BasicInformation.EmailAddress.Should().Be(organisation.ContactPoints.FirstOrDefault()?.Email);
+        result.BasicInformation.Qualifications.Should().HaveCount(1);
+        result.BasicInformation.TradeAssurances.Should().HaveCount(1);
+        result.BasicInformation.LegalForm.Should().NotBeNull();
     }
 }

--- a/Services/CO.CDP.DataSharing.WebApi.Tests/DataSharingFactory.cs
+++ b/Services/CO.CDP.DataSharing.WebApi.Tests/DataSharingFactory.cs
@@ -1,15 +1,18 @@
 using CO.CDP.OrganisationInformation;
 using CO.CDP.OrganisationInformation.Persistence;
+using CO.CDP.OrganisationInformation.Persistence.Forms;
 using static CO.CDP.OrganisationInformation.Persistence.Organisation;
+using Address = CO.CDP.OrganisationInformation.Persistence.Address;
 using ContactPoint = CO.CDP.OrganisationInformation.Persistence.Organisation.ContactPoint;
 using Identifier = CO.CDP.OrganisationInformation.Persistence.Organisation.Identifier;
 
 namespace DataSharing.Tests;
+
 public static class DataSharingFactory
 {
-    public static CO.CDP.OrganisationInformation.Persistence.Forms.SharedConsent CreateMockSharedConsent()
+    public static SharedConsent CreateMockSharedConsent()
     {
-        return new CO.CDP.OrganisationInformation.Persistence.Forms.SharedConsent
+        return new SharedConsent
         {
             Id = 1,
             Guid = Guid.NewGuid(),
@@ -39,7 +42,9 @@ public static class DataSharingFactory
         };
     }
 
-    public static Organisation CreateMockOrganisation(bool withSupplierInfo = true)
+    public static Organisation CreateMockOrganisation(
+        SupplierInformation? supplierInformation = null
+    )
     {
         return new Organisation
         {
@@ -49,10 +54,10 @@ public static class DataSharingFactory
             Tenant = new Tenant { Guid = Guid.NewGuid(), Name = "TestTenant" },
             Addresses = new List<OrganisationAddress>
             {
-                new OrganisationAddress
+                new()
                 {
                     Type = AddressType.Registered,
-                    Address = new CO.CDP.OrganisationInformation.Persistence.Address
+                    Address = new Address
                     {
                         StreetAddress = "123 Test Street",
                         Locality = "Test Locality",
@@ -61,10 +66,10 @@ public static class DataSharingFactory
                         Country = "TC"
                     }
                 },
-                    new OrganisationAddress
+                new()
                 {
                     Type = AddressType.Postal,
-                    Address = new CO.CDP.OrganisationInformation.Persistence.Address
+                    Address = new Address
                     {
                         StreetAddress = "456 Postal Street",
                         Locality = "Postal Locality",
@@ -92,48 +97,46 @@ public static class DataSharingFactory
                     Primary = true
                 }
             },
-            Roles = new List<PartyRole> { PartyRole.Tenderer },
-            SupplierInfo = withSupplierInfo
-                ? new SupplierInformation
-                {
-                    SupplierType = SupplierType.Organisation,
-                    CompletedRegAddress = true,
-                    CompletedPostalAddress = true,
-                    CompletedVat = true,
-                    CompletedWebsiteAddress = true,
-                    CompletedEmailAddress = true,
-                    CompletedQualification = true,
-                    CompletedTradeAssurance = true,
-                    CompletedLegalForm = true,
-                    Qualifications = new List<Qualification>
+            Roles = [PartyRole.Tenderer],
+            SupplierInfo = supplierInformation ?? new SupplierInformation
+            {
+                SupplierType = SupplierType.Organisation,
+                CompletedRegAddress = true,
+                CompletedPostalAddress = true,
+                CompletedVat = true,
+                CompletedWebsiteAddress = true,
+                CompletedEmailAddress = true,
+                CompletedQualification = true,
+                CompletedTradeAssurance = true,
+                CompletedLegalForm = true,
+                Qualifications =
+                [
+                    new()
                     {
-                            new Qualification
-                            {
-                                Guid = Guid.NewGuid(),
-                                AwardedByPersonOrBodyName = "Certifying Authority",
-                                DateAwarded = DateTimeOffset.UtcNow.AddYears(-2),
-                                Name = "ISO 9001"
-                            }
-                    },
-                    TradeAssurances = new List<TradeAssurance>
-                    {
-                            new TradeAssurance
-                            {
-                                Guid = Guid.NewGuid(),
-                                AwardedByPersonOrBodyName = "Trade Assurance Authority",
-                                ReferenceNumber = "TA123456",
-                                DateAwarded = DateTimeOffset.UtcNow.AddYears(-1)
-                            }
-                    },
-                    LegalForm = new Organisation.LegalForm
-                    {
-                        RegisteredUnderAct2006 = true,
-                        RegisteredLegalForm = "Private Limited",
-                        LawRegistered = "UK",
-                        RegistrationDate = DateTimeOffset.UtcNow.AddYears(-10)
+                        Guid = Guid.NewGuid(),
+                        AwardedByPersonOrBodyName = "Certifying Authority",
+                        DateAwarded = DateTimeOffset.UtcNow.AddYears(-2),
+                        Name = "ISO 9001"
                     }
+                ],
+                TradeAssurances =
+                [
+                    new TradeAssurance
+                    {
+                        Guid = Guid.NewGuid(),
+                        AwardedByPersonOrBodyName = "Trade Assurance Authority",
+                        ReferenceNumber = "TA123456",
+                        DateAwarded = DateTimeOffset.UtcNow.AddYears(-1)
+                    }
+                ],
+                LegalForm = new LegalForm
+                {
+                    RegisteredUnderAct2006 = true,
+                    RegisteredLegalForm = "Private Limited",
+                    LawRegistered = "UK",
+                    RegistrationDate = DateTimeOffset.UtcNow.AddYears(-10)
                 }
-                : null,
+            },
             CreatedOn = DateTimeOffset.UtcNow,
             UpdatedOn = DateTimeOffset.UtcNow
         };

--- a/Services/CO.CDP.DataSharing.WebApi.Tests/DataSharingFactory.cs
+++ b/Services/CO.CDP.DataSharing.WebApi.Tests/DataSharingFactory.cs
@@ -10,39 +10,31 @@ namespace DataSharing.Tests;
 
 public static class DataSharingFactory
 {
-    public static SharedConsent CreateMockSharedConsent()
+    public static SharedConsent CreateSharedConsent(
+        string? shareCode = null,
+        Organisation? organisation = null
+    )
     {
+        var theOrganisation = organisation ?? CreateOrganisation();
         return new SharedConsent
         {
             Id = 1,
             Guid = Guid.NewGuid(),
-            OrganisationId = 1,
-            Organisation = new Organisation
-            {
-                Id = 1,
-                Guid = Guid.NewGuid(),
-                Name = "Test Organisation",
-                Tenant = new Tenant { Guid = Guid.NewGuid(), Name = "TestTenant" },
-                Addresses = new List<OrganisationAddress>(),
-                ContactPoints = new List<ContactPoint>(),
-                Identifiers = new List<Identifier>(),
-                Roles = new List<PartyRole>(),
-                CreatedOn = DateTimeOffset.UtcNow,
-                UpdatedOn = DateTimeOffset.UtcNow
-            },
+            OrganisationId = theOrganisation.Id,
+            Organisation = theOrganisation,
             FormId = 1,
             Form = null!,
             AnswerSets = null!,
             SubmissionState = default,
             SubmittedAt = null,
             FormVersionId = string.Empty,
-            ShareCode = "valid-sharecode",
+            ShareCode = shareCode ?? "valid-sharecode",
             CreatedOn = DateTimeOffset.UtcNow,
             UpdatedOn = DateTimeOffset.UtcNow
         };
     }
 
-    public static Organisation CreateMockOrganisation(
+    public static Organisation CreateOrganisation(
         SupplierInformation? supplierInformation = null
     )
     {

--- a/Services/CO.CDP.DataSharing.WebApi.Tests/UseCase/GetSharedDataPdfUseCaseTests.cs
+++ b/Services/CO.CDP.DataSharing.WebApi.Tests/UseCase/GetSharedDataPdfUseCaseTests.cs
@@ -2,35 +2,29 @@ using CO.CDP.DataSharing.WebApi;
 using CO.CDP.DataSharing.WebApi.DataService;
 using CO.CDP.DataSharing.WebApi.Model;
 using CO.CDP.DataSharing.WebApi.UseCase;
-using CO.CDP.OrganisationInformation.Persistence;
 using FluentAssertions;
 using Moq;
 
 namespace DataSharing.Tests.UseCase;
+
 public class GetSharedDataPdfUseCaseTests
 {
-    private readonly Mock<IShareCodeRepository> _shareCodeRepository = new();
     private readonly Mock<IDataService> _dataService = new();
     private readonly Mock<IPdfGenerator> _pdfGenerator = new();
 
-    private GetSharedDataPdfUseCase UseCase => new(
-        _shareCodeRepository.Object, _pdfGenerator.Object, _dataService.Object);
+    private GetSharedDataPdfUseCase UseCase => new(_pdfGenerator.Object, _dataService.Object);
 
     [Fact]
     public async Task Execute_ShouldReturnPdfBytes_WhenShareCodeExists()
     {
         var sharecode = "valid-sharecode";
-        var sharedConsent = DataSharingFactory.CreateMockSharedConsent();
         var sharedSupplierInformation = new SharedSupplierInformation
         {
             BasicInformation = new BasicInformation()
         };
         var pdfBytes = new byte[] { 1, 2, 3 };
 
-        _shareCodeRepository.Setup(repo => repo.GetByShareCode(sharecode))
-            .ReturnsAsync(sharedConsent);
-
-        _dataService.Setup(service => service.GetSharedSupplierInformationAsync(sharedConsent))
+        _dataService.Setup(service => service.GetSharedSupplierInformationAsync(sharecode))
             .ReturnsAsync(sharedSupplierInformation);
 
         _pdfGenerator.Setup(generator => generator.GenerateBasicInformationPdf(sharedSupplierInformation))
@@ -42,34 +36,16 @@ public class GetSharedDataPdfUseCaseTests
     }
 
     [Fact]
-    public async Task Execute_ShouldThrowShareCodeNotFoundException_WhenShareCodeDoesNotExist()
-    {
-        var sharecode = "invalid-sharecode";
-
-        _shareCodeRepository.Setup(repo => repo.GetByShareCode(sharecode))
-            .ReturnsAsync((CO.CDP.OrganisationInformation.Persistence.Forms.SharedConsent?)null);
-
-        Func<Task> act = async () => await UseCase.Execute(sharecode);
-
-        await act.Should().ThrowAsync<ShareCodeNotFoundException>()
-            .WithMessage(Constants.ShareCodeNotFoundExceptionMessage);
-    }
-
-    [Fact]
     public async Task Execute_ShouldCallDataServiceAndPdfGenerator_WhenShareCodeExists()
     {
         var sharecode = "valid-sharecode";
-        var sharedConsent = DataSharingFactory.CreateMockSharedConsent();
         var sharedSupplierInformation = new SharedSupplierInformation
         {
             BasicInformation = new BasicInformation()
         };
         var pdfBytes = new byte[] { 1, 2, 3 };
 
-        _shareCodeRepository.Setup(repo => repo.GetByShareCode(sharecode))
-            .ReturnsAsync(sharedConsent);
-
-        _dataService.Setup(service => service.GetSharedSupplierInformationAsync(sharedConsent))
+        _dataService.Setup(service => service.GetSharedSupplierInformationAsync(sharecode))
             .ReturnsAsync(sharedSupplierInformation);
 
         _pdfGenerator.Setup(generator => generator.GenerateBasicInformationPdf(sharedSupplierInformation))
@@ -77,7 +53,6 @@ public class GetSharedDataPdfUseCaseTests
 
         var result = await UseCase.Execute(sharecode);
 
-        _dataService.Verify(service => service.GetSharedSupplierInformationAsync(sharedConsent), Times.Once);
-        _pdfGenerator.Verify(generator => generator.GenerateBasicInformationPdf(sharedSupplierInformation), Times.Once);
+        result.Should().BeEquivalentTo(pdfBytes);
     }
 }

--- a/Services/CO.CDP.DataSharing.WebApi/DataService/IDataService.cs
+++ b/Services/CO.CDP.DataSharing.WebApi/DataService/IDataService.cs
@@ -1,10 +1,8 @@
 using CO.CDP.DataSharing.WebApi.Model;
-using CO.CDP.OrganisationInformation.Persistence;
 
 namespace CO.CDP.DataSharing.WebApi.DataService;
 
 public interface IDataService
 {
     Task<SharedSupplierInformation> GetSharedSupplierInformationAsync(string shareCode);
-    BasicInformation MapToBasicInformation(Organisation organisation);
 }

--- a/Services/CO.CDP.DataSharing.WebApi/DataService/IDataService.cs
+++ b/Services/CO.CDP.DataSharing.WebApi/DataService/IDataService.cs
@@ -1,11 +1,10 @@
 using CO.CDP.DataSharing.WebApi.Model;
 using CO.CDP.OrganisationInformation.Persistence;
-using SharedConsent = CO.CDP.OrganisationInformation.Persistence.Forms.SharedConsent;
 
 namespace CO.CDP.DataSharing.WebApi.DataService;
 
 public interface IDataService
 {
-    Task<SharedSupplierInformation> GetSharedSupplierInformationAsync(SharedConsent sharedConsent);
+    Task<SharedSupplierInformation> GetSharedSupplierInformationAsync(string shareCode);
     BasicInformation MapToBasicInformation(Organisation organisation);
 }

--- a/Services/CO.CDP.DataSharing.WebApi/UseCase/GetSharedDataPdfUseCase.cs
+++ b/Services/CO.CDP.DataSharing.WebApi/UseCase/GetSharedDataPdfUseCase.cs
@@ -1,27 +1,16 @@
 using CO.CDP.DataSharing.WebApi.DataService;
-using CO.CDP.DataSharing.WebApi.Model;
-using CO.CDP.OrganisationInformation.Persistence;
 
 namespace CO.CDP.DataSharing.WebApi.UseCase;
 
-public class GetSharedDataPdfUseCase(
-    IShareCodeRepository shareCodeRepository,
-    IPdfGenerator pdfGenerator, IDataService dataService)
+public class GetSharedDataPdfUseCase(IPdfGenerator pdfGenerator, IDataService dataService)
     : IUseCase<string, byte[]?>
 {
     public async Task<byte[]?> Execute(string sharecode)
     {
-        var sharedConsent = await shareCodeRepository.GetByShareCode(sharecode);
-        if (sharedConsent == null)
-        {
-            throw new ShareCodeNotFoundException(Constants.ShareCodeNotFoundExceptionMessage);
-        }
-
-        var sharedSupplierInfo = await dataService.GetSharedSupplierInformationAsync(sharedConsent);
+        var sharedSupplierInfo = await dataService.GetSharedSupplierInformationAsync(sharecode);
 
         var pdfBytes = pdfGenerator.GenerateBasicInformationPdf(sharedSupplierInfo);
 
         return pdfBytes;
     }
-
 }


### PR DESCRIPTION
## Make DataService requires the shareCode rather than a SharedConsent

This way clients of DataService will have less collaborators to work with as there's no need for them to use the repository to fetch SharedConsent first. Makes tests and client code simpler.

This:

```csharp
Task<SharedSupplierInformation> GetSharedSupplierInformationAsync(SharedConsent sharedConsent);
```

becomes:

```csharp
Task<SharedSupplierInformation> GetSharedSupplierInformationAsync(string shareCode);
```

This:

```csharp
var sharedConsent = await shareCodeRepository.GetByShareCode(sharecode);
if (sharedConsent == null)
{
    throw new ShareCodeNotFoundException(Constants.ShareCodeNotFoundExceptionMessage);
}

var sharedSupplierInfo = await dataService.GetSharedSupplierInformationAsync(sharedConsent);
```


becomes:

```csharp
var sharedSupplierInfo = await dataService.GetSharedSupplierInformationAsync(sharecode);
```

## Remove implementation details from the IDataService interface

`IDataService.MapToBasicInformation` is only used in `DataService` and the test. It is an implementation detail of `DataService`. It's only required by this specific implementation, so putting it on the interface isn't desired.

This method should be made private and tested through the public `GetSharedSupplierInformationAsync` method.

Alternatively, to be tested in isolation, behaviour provided by this method should be extracted to its own class.

For now, I removed `MapToBasicInformation` from `IDataService`, but kept the mapping behaviours in `DataService`. As we add more mapping, it might turn out it's best to extract the mapper and test it in isolation.


