### PR TITLE
DP-222: Use RenderedCompactJsonFormatter for logging

### DIFF
--- a/Libraries/CO.CDP.AwsServices/CloudWatchExtensions.cs
+++ b/Libraries/CO.CDP.AwsServices/CloudWatchExtensions.cs
@@ -37,7 +37,7 @@ public static class CloudWatchExtensions
             return awsConfiguration.CloudWatch is not null ? new CloudWatchSinkOptions
             {
                 LogGroupName = awsConfiguration.CloudWatch.LogGroup,
-                TextFormatter = new CompactJsonFormatter(),
+                TextFormatter = new RenderedCompactJsonFormatter(),
                 LogStreamNameProvider = new ConfigurableLogStreamNameProvider(awsConfiguration.CloudWatch.LogStream),
                 MinimumLogEventLevel = LogEventLevel.Verbose
             } : throw new ConfigurationException("Missing CloudWatch configuration.");


### PR DESCRIPTION
Uses `RenderedCompactJsonFormatter` instead of `CompactJsonFormatter` to log a rendered message, rather than a template message.