### PR TITLE
DP-532 Allow different schedual for different accounts

### DIFF
--- a/terragrunt/components/core/networking/terragrunt.hcl
+++ b/terragrunt/components/core/networking/terragrunt.hcl
@@ -8,7 +8,7 @@ include {
 
 locals {
   global_vars = read_terragrunt_config(find_in_parent_folders("terragrunt.hcl"))
-  core_vars   = read_terragrunt_config(find_in_parent_folders("core.hcl"))
+  core_vars = read_terragrunt_config(find_in_parent_folders("core.hcl"))
 
   tags = merge(
     local.global_vars.inputs.tags,

--- a/terragrunt/components/core/security-groups/terragrunt.hcl
+++ b/terragrunt/components/core/security-groups/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source ="../../../modules//core-security-groups"
+  source = "../../../modules//core-security-groups"
 }
 
 include {
@@ -8,7 +8,7 @@ include {
 
 locals {
   global_vars = read_terragrunt_config(find_in_parent_folders("terragrunt.hcl"))
-  core_vars   = read_terragrunt_config(find_in_parent_folders("core.hcl"))
+  core_vars = read_terragrunt_config(find_in_parent_folders("core.hcl"))
 
   tags = merge(
     local.global_vars.inputs.tags,

--- a/terragrunt/components/orchestrator/canary/terragrunt.hcl
+++ b/terragrunt/components/orchestrator/canary/terragrunt.hcl
@@ -14,11 +14,12 @@ locals {
 
   canary_configs = {
     for key, env in local.global_vars.locals.environments :
-      key => {
-        name                   = env.name
-        pinned_service_version = try(env.pinned_service_version, null)
-        api_url                = "https://api.${env.name}.supplier.information.${env.top_level_domain}"
-      } if !(contains(local.canary_exclude_list, env.name))
+    key => {
+      name                = env.name
+      pinned_service_version = try(env.pinned_service_version, null)
+      api_url             = "https://api.${env.name}.supplier.information.${env.top_level_domain}"
+      schedule_expression = env.canary_schedule_expression
+    } if !(contains(local.canary_exclude_list, env.name))
   }
 
   tags = merge(

--- a/terragrunt/components/orchestrator/ecr/terragrunt.hcl
+++ b/terragrunt/components/orchestrator/ecr/terragrunt.hcl
@@ -9,7 +9,7 @@ include {
 locals {
 
   global_vars = read_terragrunt_config(find_in_parent_folders("terragrunt.hcl"))
-  orchestrator_vars   = read_terragrunt_config(find_in_parent_folders("orchestrator.hcl"))
+  orchestrator_vars = read_terragrunt_config(find_in_parent_folders("orchestrator.hcl"))
 
   tags = merge(
     local.global_vars.inputs.tags,

--- a/terragrunt/components/service/api-gateway/terragrunt.hcl
+++ b/terragrunt/components/service/api-gateway/terragrunt.hcl
@@ -7,7 +7,7 @@ include {
 }
 
 locals {
-  global_vars  = read_terragrunt_config(find_in_parent_folders("terragrunt.hcl"))
+  global_vars = read_terragrunt_config(find_in_parent_folders("terragrunt.hcl"))
   service_vars = read_terragrunt_config(find_in_parent_folders("service.hcl"))
 
   tags = merge(
@@ -50,8 +50,8 @@ inputs = {
   service_configs        = local.global_vars.locals.service_configs
   tags                   = local.tags
 
-  role_api_gateway_cloudwatch_arn = dependency.core_iam.outputs.api_gateway_cloudwatch_arn
-  role_api_gateway_deployer_step_function_arn = dependency.core_iam.outputs.api_gateway_deployer_step_function_arn
+  role_api_gateway_cloudwatch_arn              = dependency.core_iam.outputs.api_gateway_cloudwatch_arn
+  role_api_gateway_deployer_step_function_arn  = dependency.core_iam.outputs.api_gateway_deployer_step_function_arn
   role_api_gateway_deployer_step_function_name = dependency.core_iam.outputs.api_gateway_deployer_step_function_name
 
   public_hosted_zone_fqdn = dependency.core_networking.outputs.public_hosted_zone_fqdn

--- a/terragrunt/components/service/auth/terragrunt.hcl
+++ b/terragrunt/components/service/auth/terragrunt.hcl
@@ -7,7 +7,7 @@ include {
 }
 
 locals {
-  global_vars  = read_terragrunt_config(find_in_parent_folders("terragrunt.hcl"))
+  global_vars = read_terragrunt_config(find_in_parent_folders("terragrunt.hcl"))
   service_vars = read_terragrunt_config(find_in_parent_folders("service.hcl"))
 
   tags = merge(
@@ -23,13 +23,13 @@ locals {
 dependency core_networking {
   config_path = "../../core/networking"
   mock_outputs = {
-    public_hosted_zone_fqdn     = "mock"
+    public_hosted_zone_fqdn = "mock"
   }
 }
 
 
 inputs = {
-  tags            = local.tags
+  tags = local.tags
 
-  public_hosted_zone_fqdn     = dependency.core_networking.outputs.public_hosted_zone_fqdn
+  public_hosted_zone_fqdn = dependency.core_networking.outputs.public_hosted_zone_fqdn
 }

--- a/terragrunt/components/service/database/terragrunt.hcl
+++ b/terragrunt/components/service/database/terragrunt.hcl
@@ -7,7 +7,7 @@ include {
 }
 
 locals {
-  global_vars  = read_terragrunt_config(find_in_parent_folders("terragrunt.hcl"))
+  global_vars = read_terragrunt_config(find_in_parent_folders("terragrunt.hcl"))
   service_vars = read_terragrunt_config(find_in_parent_folders("service.hcl"))
 
   tags = merge(

--- a/terragrunt/components/service/ecs/terragrunt.hcl
+++ b/terragrunt/components/service/ecs/terragrunt.hcl
@@ -81,14 +81,14 @@ dependency service_auth {
 dependency service_database {
   config_path = "../../service/database"
   mock_outputs = {
-    entity_verification_address               = "mock"
-    entity_verification_credentials_arn       = "mock"
-    entity_verification_kms_arn               = "mock"
-    entity_verification_name                  = "mock"
-    sirsi_address                             = "mock"
-    sirsi_credentials_arn                     = "mock"
-    sirsi_kms_arn                             = "mock"
-    sirsi_name                                = "mock"
+    entity_verification_address         = "mock"
+    entity_verification_credentials_arn = "mock"
+    entity_verification_kms_arn         = "mock"
+    entity_verification_name            = "mock"
+    sirsi_address                       = "mock"
+    sirsi_credentials_arn               = "mock"
+    sirsi_kms_arn                       = "mock"
+    sirsi_name                          = "mock"
 
   }
 }
@@ -146,14 +146,14 @@ inputs = {
   user_pool_client_id = dependency.service_auth.outputs.organisation_app_user_pool_client_id
   user_pool_domain    = dependency.service_auth.outputs.user_pool_domain
 
-  db_entity_verification_address               = dependency.service_database.outputs.entity_verification_address
-  db_entity_verification_credentials_arn       = dependency.service_database.outputs.entity_verification_credentials_arn
-  db_entity_verification_kms_arn               = dependency.service_database.outputs.entity_verification_kms_arn
-  db_entity_verification_name                  = dependency.service_database.outputs.entity_verification_name
-  db_sirsi_address                             = dependency.service_database.outputs.sirsi_address
-  db_sirsi_credentials_arn                     = dependency.service_database.outputs.sirsi_credentials_arn
-  db_sirsi_kms_arn                             = dependency.service_database.outputs.sirsi_kms_arn
-  db_sirsi_name                                = dependency.service_database.outputs.sirsi_name
+  db_entity_verification_address         = dependency.service_database.outputs.entity_verification_address
+  db_entity_verification_credentials_arn = dependency.service_database.outputs.entity_verification_credentials_arn
+  db_entity_verification_kms_arn         = dependency.service_database.outputs.entity_verification_kms_arn
+  db_entity_verification_name            = dependency.service_database.outputs.entity_verification_name
+  db_sirsi_address                       = dependency.service_database.outputs.sirsi_address
+  db_sirsi_credentials_arn               = dependency.service_database.outputs.sirsi_credentials_arn
+  db_sirsi_kms_arn                       = dependency.service_database.outputs.sirsi_kms_arn
+  db_sirsi_name                          = dependency.service_database.outputs.sirsi_name
 
 
   queue_entity_verification_queue_arn = dependency.service_queue.outputs.entity_verification_queue_arn

--- a/terragrunt/components/service/queue/terragrunt.hcl
+++ b/terragrunt/components/service/queue/terragrunt.hcl
@@ -7,7 +7,7 @@ include {
 }
 
 locals {
-  global_vars  = read_terragrunt_config(find_in_parent_folders("terragrunt.hcl"))
+  global_vars = read_terragrunt_config(find_in_parent_folders("terragrunt.hcl"))
   service_vars = read_terragrunt_config(find_in_parent_folders("service.hcl"))
 
   tags = merge(

--- a/terragrunt/components/service/telemetry/terragrunt.hcl
+++ b/terragrunt/components/service/telemetry/terragrunt.hcl
@@ -7,7 +7,7 @@ include {
 }
 
 locals {
-  global_vars  = read_terragrunt_config(find_in_parent_folders("terragrunt.hcl"))
+  global_vars = read_terragrunt_config(find_in_parent_folders("terragrunt.hcl"))
   service_vars = read_terragrunt_config(find_in_parent_folders("service.hcl"))
 
   tags = merge(
@@ -64,7 +64,7 @@ inputs = {
   tags            = local.tags
 
   role_ecs_task_arn      = dependency.core_iam.outputs.ecs_task_arn
-  role_ecs_task_name      = dependency.core_iam.outputs.ecs_task_name
+  role_ecs_task_name     = dependency.core_iam.outputs.ecs_task_name
   role_ecs_task_exec_arn = dependency.core_iam.outputs.ecs_task_exec_arn
   role_telemetry_arn     = dependency.core_iam.outputs.telemetry_arn
 

--- a/terragrunt/components/terragrunt.hcl
+++ b/terragrunt/components/terragrunt.hcl
@@ -1,387 +1,392 @@
 locals {
 
-    account_ids = {
-        for name, env in local.environments : name => env.account_id
+  account_ids = {
+    for name, env in local.environments : name => env.account_id
+  }
+
+  cidr_b_development  = 3
+  cidr_b_integration  = 4
+  cidr_b_orchestrator = 5
+  cidr_b_production   = 1
+  cidr_b_staging      = 2
+
+  environment = get_env("TG_ENVIRONMENT", "development")
+
+  is_production = contains(["production", "integration"], local.environment)
+
+  environments = {
+    orchestrator = {
+      cidr_block             = "10.${local.cidr_b_orchestrator}.0.0/16"
+      account_id             = 891377225335
+      name                   = "orchestrator"
+      postgres_instance_type = "db.t4g.micro"
+      private_subnets = [
+        "10.${local.cidr_b_orchestrator}.101.0/24",
+        "10.${local.cidr_b_orchestrator}.102.0/24",
+        "10.${local.cidr_b_orchestrator}.103.0/24"
+      ]
+      public_subnets = [
+        "10.${local.cidr_b_orchestrator}.1.0/24",
+        "10.${local.cidr_b_orchestrator}.2.0/24",
+        "10.${local.cidr_b_orchestrator}.3.0/24"
+      ]
+      top_level_domain = "findatender.codatt.net"
     }
-
-    cidr_b_development = 3
-    cidr_b_integration = 4
-    cidr_b_orchestrator = 5
-    cidr_b_production = 1
-    cidr_b_staging = 2
-
-    environment = get_env("TG_ENVIRONMENT", "development")
-
-    is_production = contains(["production", "integration"], local.environment)
-
-    environments = {
-        orchestrator = {
-            cidr_block             = "10.${local.cidr_b_orchestrator}.0.0/16"
-            account_id             = 891377225335
-            name                   = "orchestrator"
-            postgres_instance_type = "db.t4g.micro"
-            private_subnets        = [
-                "10.${local.cidr_b_orchestrator}.101.0/24",
-                "10.${local.cidr_b_orchestrator}.102.0/24",
-                "10.${local.cidr_b_orchestrator}.103.0/24"
-            ]
-            public_subnets = [
-                "10.${local.cidr_b_orchestrator}.1.0/24",
-                "10.${local.cidr_b_orchestrator}.2.0/24",
-                "10.${local.cidr_b_orchestrator}.3.0/24"
-            ]
-            top_level_domain = "findatender.codatt.net"
-        }
-        development = {
-            cidr_block             = "10.${local.cidr_b_development}.0.0/16"
-            account_id             = 471112892058
-            name                   = "dev"
-            pinned_service_version = null
-            postgres_instance_type = "db.t4g.micro"
-            private_subnets        = [
-                "10.${local.cidr_b_development}.101.0/24",
-                "10.${local.cidr_b_development}.102.0/24",
-                "10.${local.cidr_b_development}.103.0/24"
-            ]
-            public_subnets = [
-                "10.${local.cidr_b_development}.1.0/24",
-                "10.${local.cidr_b_development}.2.0/24",
-                "10.${local.cidr_b_development}.3.0/24"
-            ]
-            top_level_domain = "findatender.codatt.net"
-        }
-        staging = {
-            cidr_block             = "10.${local.cidr_b_staging}.0.0/16"
-            account_id             = 905418042182
-            name                   = "staging"
-            pinned_service_version = null
-            postgres_instance_type = "db.t4g.micro"
-            private_subnets        = [
-                "10.${local.cidr_b_staging}.101.0/24",
-                "10.${local.cidr_b_staging}.102.0/24",
-                "10.${local.cidr_b_staging}.103.0/24"
-            ]
-            public_subnets = [
-                "10.${local.cidr_b_staging}.1.0/24",
-                "10.${local.cidr_b_staging}.2.0/24",
-                "10.${local.cidr_b_staging}.3.0/24"
-            ]
-            top_level_domain = "findatender.codatt.net"
-        }
-        integration = {
-            cidr_block             = "10.${local.cidr_b_integration}.0.0/16"
-            account_id             = 767397666448
-            name                   = "integration"
-            pinned_service_version = "0.4.0"
-            postgres_instance_type = "db.t4g.micro"
-            private_subnets        = [
-                "10.${local.cidr_b_integration}.101.0/24",
-                "10.${local.cidr_b_integration}.102.0/24",
-                "10.${local.cidr_b_integration}.103.0/24"
-            ]
-            public_subnets = [
-                "10.${local.cidr_b_integration}.1.0/24",
-                "10.${local.cidr_b_integration}.2.0/24",
-                "10.${local.cidr_b_integration}.3.0/24"
-            ]
-            top_level_domain = "findatender.codatt.net"
-        }
-        production = {
-            cidr_block             = "10.${local.cidr_b_production}.0.0/16"
-            account_id             = 471112843276
-            name                   = "production"
-            pinned_service_version = null
-            postgres_instance_type = "db.t4g.micro"
-            private_subnets        = [
-                "10.${local.cidr_b_production}.101.0/24",
-                "10.${local.cidr_b_production}.102.0/24",
-                "10.${local.cidr_b_production}.103.0/24"
-            ]
-            public_subnets = [
-                "10.${local.cidr_b_production}.1.0/24",
-                "10.${local.cidr_b_production}.2.0/24",
-                "10.${local.cidr_b_production}.3.0/24"
-            ]
-            top_level_domain = "findatender.codatt.net"
-        }
+    development = {
+      cidr_block             = "10.${local.cidr_b_development}.0.0/16"
+      account_id             = 471112892058
+      canary_schedule_expression = "rate(5 minutes)" # "cron(15 7,11,15 ? * MON-FRI)" # UTC+0
+      name                   = "dev"
+      pinned_service_version = null
+      postgres_instance_type = "db.t4g.micro"
+      private_subnets = [
+        "10.${local.cidr_b_development}.101.0/24",
+        "10.${local.cidr_b_development}.102.0/24",
+        "10.${local.cidr_b_development}.103.0/24"
+      ]
+      public_subnets = [
+        "10.${local.cidr_b_development}.1.0/24",
+        "10.${local.cidr_b_development}.2.0/24",
+        "10.${local.cidr_b_development}.3.0/24"
+      ]
+      top_level_domain = "findatender.codatt.net"
     }
-
-    pinned_service_version  = try(local.environments[local.environment].pinned_service_version, null)
-
-    product = {
-        name               = "CDP SIRSI"
-        resource_name      = "cdp-sirsi"
-        public_hosted_zone = "${local.environments[local.environment].name}.supplier.information.${local.environments[local.environment].top_level_domain}"
+    staging = {
+      cidr_block             = "10.${local.cidr_b_staging}.0.0/16"
+      account_id             = 905418042182
+      canary_schedule_expression = "rate(30 minutes)"
+      name                   = "staging"
+      pinned_service_version = null
+      postgres_instance_type = "db.t4g.micro"
+      private_subnets = [
+        "10.${local.cidr_b_staging}.101.0/24",
+        "10.${local.cidr_b_staging}.102.0/24",
+        "10.${local.cidr_b_staging}.103.0/24"
+      ]
+      public_subnets = [
+        "10.${local.cidr_b_staging}.1.0/24",
+        "10.${local.cidr_b_staging}.2.0/24",
+        "10.${local.cidr_b_staging}.3.0/24"
+      ]
+      top_level_domain = "findatender.codatt.net"
     }
-
-    service_configs_scaling_non_production = {
-        authority = {
-            cpu           = 256
-            desired_count = 1
-            memory        = 512
-        }
-        data_sharing = {
-            cpu           = 256
-            desired_count = 1
-            memory        = 512
-        }
-        entity_verification = {
-            cpu           = 256
-            desired_count = 1
-            memory        = 512
-        }
-        entity_verification_migrations = {
-            cpu           = 256
-            desired_count = 1
-            memory        = 512
-        }
-        forms = {
-            cpu           = 256
-            desired_count = 1
-            memory        = 512
-        }
-        organisation = {
-            cpu           = 256
-            desired_count = 1
-            memory        = 512
-        }
-        organisation_app = {
-            cpu           = 256
-            desired_count = 1
-            memory        = 512
-        }
-        organisation_information_migrations = {
-            cpu           = 256
-            desired_count = 1
-            memory        = 512
-        }
-        person = {
-            cpu           = 256
-            desired_count = 1
-            memory        = 512
-        }
-        tenant = {
-            cpu           = 256
-            desired_count = 1
-            memory        = 512
-        }
+    integration = {
+      cidr_block                 = "10.${local.cidr_b_integration}.0.0/16"
+      account_id                 = 767397666448
+      canary_schedule_expression = "rate(30 minutes)"
+      name                       = "integration"
+      pinned_service_version     = "0.4.0"
+      postgres_instance_type     = "db.t4g.micro"
+      private_subnets = [
+        "10.${local.cidr_b_integration}.101.0/24",
+        "10.${local.cidr_b_integration}.102.0/24",
+        "10.${local.cidr_b_integration}.103.0/24"
+      ]
+      public_subnets = [
+        "10.${local.cidr_b_integration}.1.0/24",
+        "10.${local.cidr_b_integration}.2.0/24",
+        "10.${local.cidr_b_integration}.3.0/24"
+      ]
+      top_level_domain = "findatender.codatt.net"
     }
-
-    service_configs_scaling_production = {
-        authority = {
-            cpu           = 256
-            desired_count = 2
-            memory        = 512
-        }
-        data_sharing = {
-            cpu           = 256
-            desired_count = 2
-            memory        = 512
-        }
-        entity_verification = {
-            cpu           = 256
-            desired_count = 2
-            memory        = 512
-        }
-        entity_verification_migrations = {
-            cpu           = 256
-            desired_count = 2
-            memory        = 512
-        }
-        forms = {
-            cpu           = 256
-            desired_count = 2
-            memory        = 512
-        }
-        organisation = {
-            cpu           = 256
-            desired_count = 2
-            memory        = 512
-        }
-        organisation_app = {
-            cpu           = 256
-            desired_count = 2
-            memory        = 512
-        }
-        organisation_information_migrations = {
-            cpu           = 256
-            desired_count = 2
-            memory        = 512
-        }
-        person = {
-            cpu           = 256
-            desired_count = 2
-            memory        = 512
-        }
-        tenant = {
-            cpu           = 256
-            desired_count = 2
-            memory        = 512
-        }
+    production = {
+      cidr_block                 = "10.${local.cidr_b_production}.0.0/16"
+      account_id                 = 471112843276
+      canary_schedule_expression = "rate(15 minutes)"
+      name                       = "production"
+      pinned_service_version     = null
+      postgres_instance_type     = "db.t4g.micro"
+      private_subnets = [
+        "10.${local.cidr_b_production}.101.0/24",
+        "10.${local.cidr_b_production}.102.0/24",
+        "10.${local.cidr_b_production}.103.0/24"
+      ]
+      public_subnets = [
+        "10.${local.cidr_b_production}.1.0/24",
+        "10.${local.cidr_b_production}.2.0/24",
+        "10.${local.cidr_b_production}.3.0/24"
+      ]
+      top_level_domain = "findatender.codatt.net"
     }
+  }
 
+  pinned_service_version = try(local.environments[local.environment].pinned_service_version, null)
 
-    service_configs_scaling = {
-        development = local.service_configs_scaling_non_production
-        staging     = local.service_configs_scaling_non_production
-        integration = local.service_configs_scaling_production
+  product = {
+    name               = "CDP SIRSI"
+    resource_name      = "cdp-sirsi"
+    public_hosted_zone = "${local.environments[local.environment].name}.supplier.information.${local.environments[local.environment].top_level_domain}"
+  }
+
+  service_configs_scaling_non_production = {
+    authority = {
+      cpu           = 256
+      desired_count = 1
+      memory        = 512
     }
-
-    service_configs_common = {
-        authority = {
-            name          = "authority"
-            port          = 8092
-            port_host     = 8092
-        }
-        data_sharing = {
-            name          = "data-sharing"
-            port          = 8088
-            port_host     = 8088
-        }
-        entity_verification = {
-            name          = "entity-verification"
-            port          = 8094
-            port_host     = 8094
-        }
-        entity_verification_migrations = {
-            name          = "entity-verification-migrations"
-            port          = 9191
-            port_host     = null
-        }
-        forms = {
-            name          = "forms"
-            port          = 8086
-            port_host     = 8086
-        }
-        organisation = {
-            name          = "organisation"
-            port          = 8082
-            port_host     = 8082
-        }
-        organisation_app = {
-            name          = "organisation-app"
-            port          = 8090
-            port_host     = 80
-        }
-        organisation_information_migrations = {
-            name          = "organisation-information-migrations"
-            port          = 9090
-            port_host     = null
-        }
-        person = {
-            name          = "person"
-            port          = 8084
-            port_host     = 8084
-        }
-        tenant = {
-            name          = "tenant"
-            port          = 8080
-            port_host     = 8080
-        }
+    data_sharing = {
+      cpu           = 256
+      desired_count = 1
+      memory        = 512
     }
-
-    service_configs = { for key, value in try(local.service_configs_scaling[local.environment], local.service_configs_scaling_non_production) :
-        key => merge(value, local.service_configs_common[key])
+    entity_verification = {
+      cpu           = 256
+      desired_count = 1
+      memory        = 512
     }
-
-    tags = {
-        environment    = local.environment
-        managed_by     = "terragrunt"
+    entity_verification_migrations = {
+      cpu           = 256
+      desired_count = 1
+      memory        = 512
     }
-
-    tools_configs = {
-        grafana = {
-            cpu       = 256
-            memory    = 512
-            name      = "grafana"
-            port      = 3000
-            port_host = 3000
-        }
-        healthcheck = {
-            cpu       = 256
-            memory    = 512
-            name      = "healthcheck"
-            port      = 3030
-            port_host = 3030
-        }
-        pgadmin = {
-            cpu       = 256
-            memory    = 512
-            name      = "pgadmin"
-            port      = 5050
-            port_host = 5050
-        }
+    forms = {
+      cpu           = 256
+      desired_count = 1
+      memory        = 512
     }
-
-    pen_testing = {
-        allowed_ips = [
-            "212.139.19.138", #GOACO
-            "94.174.71.0/24", # Ali Bahman
-            "82.38.3.0/24", # Dorian Stefan
-        ]
-        user_arns = [
-            "arn:aws:iam::525593800265:user/ali.bahman@goaco.com",
-            "arn:aws:iam::525593800265:user/dorian.stefan@goaco.com",
-        ]
-        external_user_arns = [
-            "arn:aws:iam::495599741725:user/gdavies"
-        ]
+    organisation = {
+      cpu           = 256
+      desired_count = 1
+      memory        = 512
     }
+    organisation_app = {
+      cpu           = 256
+      desired_count = 1
+      memory        = 512
+    }
+    organisation_information_migrations = {
+      cpu           = 256
+      desired_count = 1
+      memory        = 512
+    }
+    person = {
+      cpu           = 256
+      desired_count = 1
+      memory        = 512
+    }
+    tenant = {
+      cpu           = 256
+      desired_count = 1
+      memory        = 512
+    }
+  }
+
+  service_configs_scaling_production = {
+    authority = {
+      cpu           = 256
+      desired_count = 2
+      memory        = 512
+    }
+    data_sharing = {
+      cpu           = 256
+      desired_count = 2
+      memory        = 512
+    }
+    entity_verification = {
+      cpu           = 256
+      desired_count = 2
+      memory        = 512
+    }
+    entity_verification_migrations = {
+      cpu           = 256
+      desired_count = 2
+      memory        = 512
+    }
+    forms = {
+      cpu           = 256
+      desired_count = 2
+      memory        = 512
+    }
+    organisation = {
+      cpu           = 256
+      desired_count = 2
+      memory        = 512
+    }
+    organisation_app = {
+      cpu           = 256
+      desired_count = 2
+      memory        = 512
+    }
+    organisation_information_migrations = {
+      cpu           = 256
+      desired_count = 2
+      memory        = 512
+    }
+    person = {
+      cpu           = 256
+      desired_count = 2
+      memory        = 512
+    }
+    tenant = {
+      cpu           = 256
+      desired_count = 2
+      memory        = 512
+    }
+  }
 
 
-    terraform_operators = [
-        "arn:aws:iam::525593800265:user/ali.bahman@goaco.com",
-        "arn:aws:iam::525593800265:user/jakub.zalas@goaco.com",
+  service_configs_scaling = {
+    development = local.service_configs_scaling_non_production
+    staging     = local.service_configs_scaling_non_production
+    integration = local.service_configs_scaling_production
+  }
+
+  service_configs_common = {
+    authority = {
+      name      = "authority"
+      port      = 8092
+      port_host = 8092
+    }
+    data_sharing = {
+      name      = "data-sharing"
+      port      = 8088
+      port_host = 8088
+    }
+    entity_verification = {
+      name      = "entity-verification"
+      port      = 8094
+      port_host = 8094
+    }
+    entity_verification_migrations = {
+      name      = "entity-verification-migrations"
+      port      = 9191
+      port_host = null
+    }
+    forms = {
+      name      = "forms"
+      port      = 8086
+      port_host = 8086
+    }
+    organisation = {
+      name      = "organisation"
+      port      = 8082
+      port_host = 8082
+    }
+    organisation_app = {
+      name      = "organisation-app"
+      port      = 8090
+      port_host = 80
+    }
+    organisation_information_migrations = {
+      name      = "organisation-information-migrations"
+      port      = 9090
+      port_host = null
+    }
+    person = {
+      name      = "person"
+      port      = 8084
+      port_host = 8084
+    }
+    tenant = {
+      name      = "tenant"
+      port      = 8080
+      port_host = 8080
+    }
+  }
+
+  service_configs = {
+    for key, value in try(local.service_configs_scaling[local.environment], local.service_configs_scaling_non_production) :
+    key => merge(value, local.service_configs_common[key])
+  }
+
+  tags = {
+    environment = local.environment
+    managed_by  = "terragrunt"
+  }
+
+  tools_configs = {
+    grafana = {
+      cpu       = 256
+      memory    = 512
+      name      = "grafana"
+      port      = 3000
+      port_host = 3000
+    }
+    healthcheck = {
+      cpu       = 256
+      memory    = 512
+      name      = "healthcheck"
+      port      = 3030
+      port_host = 3030
+    }
+    pgadmin = {
+      cpu       = 256
+      memory    = 512
+      name      = "pgadmin"
+      port      = 5050
+      port_host = 5050
+    }
+  }
+
+  pen_testing = {
+    allowed_ips = [
+      "212.139.19.138", #GOACO
+      "94.174.71.0/24", # Ali Bahman
+      "82.38.3.0/24", # Dorian Stefan
     ]
+    user_arns = [
+      "arn:aws:iam::525593800265:user/ali.bahman@goaco.com",
+      "arn:aws:iam::525593800265:user/dorian.stefan@goaco.com",
+    ]
+    external_user_arns = [
+      "arn:aws:iam::495599741725:user/gdavies"
+    ]
+  }
 
-    tg = {
-        state_bucket = "tfstate-${local.product.resource_name}-${local.environment}-${get_aws_account_id()}"
-        state_key    = "${path_relative_to_include()}/terraform.tfstate"
-    }
 
-    versions = {
-        postgres_engine = "16.3"
-    }
+  terraform_operators = [
+    "arn:aws:iam::525593800265:user/ali.bahman@goaco.com",
+    "arn:aws:iam::525593800265:user/jakub.zalas@goaco.com",
+  ]
+
+  tg = {
+    state_bucket = "tfstate-${local.product.resource_name}-${local.environment}-${get_aws_account_id()}"
+    state_key    = "${path_relative_to_include()}/terraform.tfstate"
+  }
+
+  versions = {
+    postgres_engine = "16.3"
+  }
 
 }
 
 remote_state {
-    backend = "s3"
-    config = {
-        bucket                = local.tg.state_bucket
-        disable_bucket_update = true
-        dynamodb_table        = "terraform-locks"
-        encrypt               = true
-        key                   = local.tg.state_key
-        region                = "eu-west-2"
-    }
-    generate = {
-        path      = "remote_state.tf"
-        if_exists = "overwrite"
-    }
+  backend = "s3"
+  config = {
+    bucket                = local.tg.state_bucket
+    disable_bucket_update = true
+    dynamodb_table        = "terraform-locks"
+    encrypt               = true
+    key                   = local.tg.state_key
+    region                = "eu-west-2"
+  }
+  generate = {
+    path      = "remote_state.tf"
+    if_exists = "overwrite"
+  }
 }
 
 generate provider {
-    path      = "temp_providers.tf"
-    if_exists = "overwrite_terragrunt"
-    contents  = file("../providers.tf")
+  path      = "temp_providers.tf"
+  if_exists = "overwrite_terragrunt"
+  contents = file("../providers.tf")
 }
 
 inputs = {
-    environment             = local.environment
-    is_production           = local.is_production
-    product                 = local.product
-    tags                    = local.tags
-    postgres_engine_version = local.versions.postgres_engine
-    postgres_instance_type  = local.environments[local.environment].postgres_instance_type
-    vpc_cidr                = local.environments[local.environment].cidr_block
-    vpc_private_subnets     = local.environments[local.environment].private_subnets
-    vpc_public_subnets      = local.environments[local.environment].public_subnets
+  environment             = local.environment
+  is_production           = local.is_production
+  product                 = local.product
+  tags                    = local.tags
+  postgres_engine_version = local.versions.postgres_engine
+  postgres_instance_type  = local.environments[local.environment].postgres_instance_type
+  vpc_cidr                = local.environments[local.environment].cidr_block
+  vpc_private_subnets     = local.environments[local.environment].private_subnets
+  vpc_public_subnets      = local.environments[local.environment].public_subnets
 }
 
 terraform {
-    extra_arguments disable_input {
-        commands  = get_terraform_commands_that_need_input()
-        arguments = ["-input=false"]
-    }
+  extra_arguments disable_input {
+    commands = get_terraform_commands_that_need_input()
+    arguments = ["-input=false"]
+  }
 }

--- a/terragrunt/modules/ecs-service/listeners.tf
+++ b/terragrunt/modules/ecs-service/listeners.tf
@@ -12,7 +12,7 @@ resource "aws_lb_target_group" "this" {
     for_each = var.name == "organisation-app" ? [1] : []
     content {
       type            = "lb_cookie"
-      cookie_duration = 3600  # 1 hour
+      cookie_duration = 3600 # 1 hour
     }
   }
 

--- a/terragrunt/modules/ecs/service-organisation-app.tf
+++ b/terragrunt/modules/ecs/service-organisation-app.tf
@@ -9,7 +9,7 @@ resource "aws_secretsmanager_secret" "cdp_sirsi_diagnostic_path" {
   description = "Stores the frontend diagnostic path"
 
   lifecycle {
-    prevent_destroy = true  # Prevent the secret from being destroyed
+    prevent_destroy = true # Prevent the secret from being destroyed
   }
 
   tags = var.tags

--- a/terragrunt/modules/orchestrator/canary/datasource.tf
+++ b/terragrunt/modules/orchestrator/canary/datasource.tf
@@ -13,15 +13,15 @@ data "aws_vpc_endpoint" "s3" {
 
 data "aws_iam_policy_document" "canary" {
   statement {
-    sid    = "AllowPutCloudwatchMetricData"
-    actions = ["cloudwatch:PutMetricData"]
-    effect = "Allow"
+    sid       = "AllowPutCloudwatchMetricData"
+    actions   = ["cloudwatch:PutMetricData"]
+    effect    = "Allow"
     resources = ["*"]
 
     condition {
       test     = "StringEquals"
       variable = "cloudwatch:namespace"
-      values = ["CloudWatchSynthetics"]
+      values   = ["CloudWatchSynthetics"]
     }
   }
 
@@ -32,14 +32,14 @@ data "aws_iam_policy_document" "canary" {
       "logs:CreateLogGroup",
       "logs:PutLogEvents"
     ]
-    effect = "Allow"
+    effect    = "Allow"
     resources = ["*"]
   }
 
   statement {
-    sid    = "AllowXRay"
-    actions = ["xray:PutTraceSegments"]
-    effect = "Allow"
+    sid       = "AllowXRay"
+    actions   = ["xray:PutTraceSegments"]
+    effect    = "Allow"
     resources = ["*"]
   }
 
@@ -50,21 +50,21 @@ data "aws_iam_policy_document" "canary" {
       "ec2:DescribeNetworkInterfaces",
       "ec2:DeleteNetworkInterface"
     ]
-    effect = "Allow"
+    effect    = "Allow"
     resources = ["*"]
   }
 
   statement {
-    sid    = "AllowListBucketLocation"
-    actions = ["s3:ListAllMyBuckets"]
-    effect = "Allow"
+    sid       = "AllowListBucketLocation"
+    actions   = ["s3:ListAllMyBuckets"]
+    effect    = "Allow"
     resources = ["*"]
   }
 
   statement {
-    sid    = "AllowGetBucketLocation"
-    actions = ["s3:GetBucketLocation"]
-    effect = "Allow"
+    sid       = "AllowGetBucketLocation"
+    actions   = ["s3:GetBucketLocation"]
+    effect    = "Allow"
     resources = [module.s3_bucket_canary.arn]
   }
 

--- a/terragrunt/modules/orchestrator/canary/locals.tf
+++ b/terragrunt/modules/orchestrator/canary/locals.tf
@@ -1,4 +1,4 @@
 locals {
   aws_endpoint_sgs = [var.vpce_secretsmanager_sg_id]
-  name_prefix = var.product.resource_name
+  name_prefix      = var.product.resource_name
 }

--- a/terragrunt/modules/orchestrator/canary/main.tf
+++ b/terragrunt/modules/orchestrator/canary/main.tf
@@ -7,7 +7,7 @@ resource "aws_synthetics_canary" "canary" {
   delete_lambda        = true
   execution_role_arn   = var.role_canary_arn
   handler              = "canary_check_api.handler"
-  name                 = "${local.name_prefix}-ver-${substr(each.key, 0 ,3)}"
+  name                 = "${local.name_prefix}-ver-${substr(each.key, 0, 3)}"
   runtime_version      = "syn-python-selenium-4.0"
   s3_bucket            = module.s3_bucket_canary.id
   s3_key               = "lambda_package.zip"
@@ -22,11 +22,11 @@ resource "aws_synthetics_canary" "canary" {
       VERSION_PARAM_NAME   = aws_ssm_parameter.expected_service_versions[each.key].name
       WEB_DRIVER_LOG_LEVEL = "WARNING"
     }
-    timeout_in_seconds    = var.canary_timeout_seconds
-    memory_in_mb          = var.memory_in_mb
+    timeout_in_seconds = var.canary_timeout_seconds
+    memory_in_mb       = var.memory_in_mb
   }
   schedule {
-    expression = "rate(1 minute)"
+    expression = each.value.schedule_expression
   }
 
   vpc_config {

--- a/terragrunt/modules/orchestrator/canary/variables.tf
+++ b/terragrunt/modules/orchestrator/canary/variables.tf
@@ -6,9 +6,10 @@ variable "alb_sg_id" {
 variable "canary_configs" {
   description = "Configuration for each environment's canary, including the name and pinned service version."
   type = map(object({
+    api_url                = string
     name                   = string
     pinned_service_version = string
-    api_url                = string
+    schedule_expression    = string
   }))
 }
 
@@ -32,17 +33,6 @@ variable "datapoints_to_alarm" {
 variable "environment" {
   description = "The environment we are provisioning"
   type        = string
-}
-
-variable "environment_variables" {
-  description = "Map of environment variables to pass to the Canary"
-  type        = map(string)
-  default     = {
-    API_LANDING_PAGE_URL = "https://api.dev.supplier.information.findatender.codatt.net/"
-    AUTH_SECRET_NAME     = "cdp-sirsi-canary-dev-credentials"
-    EXPECTED_VERSION     = "0.4.0-a5b1c239"
-    WEB_DRIVER_LOG_LEVEL = "WARNING"
-  }
 }
 
 variable "evaluation_periods" {

--- a/terragrunt/modules/rds/rds.tf
+++ b/terragrunt/modules/rds/rds.tf
@@ -68,7 +68,7 @@ resource "aws_db_instance" "replica" {
   # @TODO(ABN) decide if read replica is wanted for this project considering its limitation on Postgres
   #            https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_PostgreSQL.Replication.ReadReplicas.html#USER_PostgreSQL.Replication.ReadReplicas.Limitations
   # count                  = var.create_read_replica ? 1 : 0
-  count                  = 0
+  count = 0
 
   auto_minor_version_upgrade  = false
   instance_class              = var.postgres_instance_type

--- a/terragrunt/modules/rds/variables.tf
+++ b/terragrunt/modules/rds/variables.tf
@@ -43,7 +43,7 @@ variable "monitoring_interval" {
   default     = 0
 
   validation {
-    condition = contains([0, 1, 5, 10, 15, 30, 60], var.monitoring_interval)
+    condition     = contains([0, 1, 5, 10, 15, 30, 60], var.monitoring_interval)
     error_message = "Invalid value for monitoring_interval. Valid values are: 0, 1, 5, 10, 15, 30, 60 seconds."
   }
 }

--- a/terragrunt/tools/canary/src/python/canary_check_api.py
+++ b/terragrunt/tools/canary/src/python/canary_check_api.py
@@ -85,7 +85,8 @@ def check_api_version(browser, api_url, expected_version):
         logger.info("Version element found on API landing page.")
 
         logger.debug("Verify the version")
-        deployed_version = re.search(r"V([\d\.]+-[\da-f]+)", version_element.text).group(1)
+        # Updated regex to match both '0.4.0-abcdef' and '0.4.0'
+        deployed_version = re.search(r"V([\d\.]+(?:-[\da-f]+)?)", version_element.text).group(1)
         if deployed_version != expected_version:
             raise Exception(
                 f"Version mismatch on API landing page: expected {expected_version}, but found {deployed_version}")
@@ -95,6 +96,10 @@ def check_api_version(browser, api_url, expected_version):
     except TimeoutException as e:
         logger.error(f"Timeout while trying to find the version element on the API landing page: {e}")
         take_screenshot(browser, "api_landing_page_error")
+        raise
+    except AttributeError:
+        logger.error("No version information found in the expected format.")
+        take_screenshot(browser, "api_landing_page_version_check_failed")
         raise
     except Exception as e:
         logger.error(f"Failed to verify version on API landing page: {e}")
@@ -199,7 +204,7 @@ def main():
 
 def handler(event, context):
     log_level = os.getenv("WEB_DRIVER_LOG_LEVEL", "WARNING")
-    logger.info("Running Canary to validate frontend and API landing page. v 0.1.6")
+    logger.info("Running Canary to validate frontend and API landing page. v 0.1.7")
     logger.info(f"Current Log Level is '{logger.get_level()}'")
     logger.info(f"Setting Log Level to '{log_level}'")
     logger.set_level(log_level)


### PR DESCRIPTION
- `canary_schedule_expression` for each account is the only addition in the root's terragrunt configuration
- Reformat