### PR TITLE
Check if running services are healthy (unless they are stopped)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ up: compose.override.yml ## Start Docker containers
 .PHONY: up
 
 verify-up: compose.override.yml ## Verify if all Docker containers have run
-	@docker compose ps -a --format json | jq --exit-status 'select(.ExitCode != 0)' && exit 1 || echo "All services up"
+	@docker compose ps -a --format json | jq --exit-status 'select(.ExitCode != 0 or (.Health != "healthy" and .Health != ""))' && exit 1 || echo "All services up"
 .PHONY: verify-up
 
 down: ## Destroy Docker containers


### PR DESCRIPTION
We were only checking if a service has exited with non-zero exit code. Now we also check if it's actually healthy when running.