### PR TITLE
DP-589 Add temporary secret for support admin email address

### DIFF
--- a/terragrunt/README.md
+++ b/terragrunt/README.md
@@ -10,6 +10,7 @@ This code base is responsible for provisioning the AWS infrastructure needed to 
    - [Update Companies House Secrets](#update-companies-house-secrets)
    - [Update FtsService URL](#update-ftsservice-url)
    - [Update GOVUKNotify ApiKey](#update-govuknotify-apikey)
+   - [Update GOVUKNotify Support Admin Email](#update-govuknotify-support-admin-email)
    - [Update OneLogin Secrets](#update-onelogin-secrets)
    - [Update Slack Configuration](#update-slack-configuration)
 4. [Pin Service Version](#pin-service-version)
@@ -144,6 +145,22 @@ ave aws secretsmanager put-secret-value --secret-id cdp-sirsi-fts-service-url --
 # ave aws secretsmanager create-secret --name cdp-sirsi-govuknotify-apikey --secret-string "<GOV UK Notify API Key>" | jq .
 # or update using:
 ave aws secretsmanager put-secret-value --secret-id cdp-sirsi-govuknotify-apikey --secret-string "<GOV UK Notify API Key>" | jq .
+```
+
+3. Redeploy the `organisation` service.
+
+### Update GOVUKNotify Support Admin Email
+
+_this is a temporary solution while we are managing such user in the database_
+1. Identify the `GOV UK Notify Support Admin Email` for the specified AWS account.
+2. Set your AWS profile to target the specified AWS account, and use the AWS CLI to update the secret.
+
+```shell
+# ave is alias for `aws-vault exec` command
+# add using:
+# ave aws secretsmanager create-secret --name cdp-sirsi-govuknotify-support-admin-email --secret-string "<GOV UK Notify API Key>" | jq .
+# or update using:
+ave aws secretsmanager put-secret-value --secret-id cdp-sirsi-govuknotify-support-admin-email --secret-string "<GOV UK Notify API Key>" | jq .
 ```
 
 3. Redeploy the `organisation` service.

--- a/terragrunt/modules/ecs/datasource.tf
+++ b/terragrunt/modules/ecs/datasource.tf
@@ -36,6 +36,10 @@ data "aws_secretsmanager_secret_version" "govuknotify_apikey" {
   secret_id = "${local.name_prefix}-govuknotify-apikey"
 }
 
+data "aws_secretsmanager_secret_version" "govuknotify_support_admin_email" {
+  secret_id = "${local.name_prefix}-govuknotify-support-admin-email"
+}
+
 data "aws_secretsmanager_secret" "one_login" {
   name = "${local.name_prefix}-one-login-credentials"
 }

--- a/terragrunt/modules/ecs/service-organisation.tf
+++ b/terragrunt/modules/ecs/service-organisation.tf
@@ -8,6 +8,7 @@ module "ecs_service_organisation" {
       container_port                      = var.service_configs.organisation.port
       cpu                                 = var.service_configs.organisation.cpu
       govuknotify_apikey                  = data.aws_secretsmanager_secret_version.govuknotify_apikey.arn
+      govuknotify_support_admin_email     = data.aws_secretsmanager_secret_version.govuknotify_support_admin_email.arn
       host_port                           = var.service_configs.organisation.port
       image                               = local.ecr_urls[var.service_configs.organisation.name]
       lg_name                             = aws_cloudwatch_log_group.tasks[var.service_configs.organisation.name].name

--- a/terragrunt/modules/ecs/templates/task-definitions/organisation.json.tftpl
+++ b/terragrunt/modules/ecs/templates/task-definitions/organisation.json.tftpl
@@ -37,6 +37,7 @@
     ],
     "secrets": [
         {"name": "GOVUKNotify__ApiKey", "valueFrom": "${govuknotify_apikey}"},
+        {"name": "GOVUKNotify__SupportAdminEmailAddress", "valueFrom": "${govuknotify_support_admin_email}"},
         {"name": "OrganisationInformationDatabase__Password", "valueFrom": "${oi_db_username}"},
         {"name": "OrganisationInformationDatabase__Username", "valueFrom": "${oi_db_password}"}
     ],


### PR DESCRIPTION
  - Pass it to the the organisation service
  - 
![image](https://github.com/user-attachments/assets/a76fd557-c483-44c6-b037-d895cdbe4217)
