### PR TITLE
API Permission - No need for organisation id match for organisation key

### DIFF
--- a/Frontend/CO.CDP.OrganisationApp.Tests/CustomScopeHandlerTests.cs
+++ b/Frontend/CO.CDP.OrganisationApp.Tests/CustomScopeHandlerTests.cs
@@ -4,7 +4,6 @@ using Microsoft.AspNetCore.Authorization;
 using Moq;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
-using Xunit;
 
 namespace CO.CDP.OrganisationApp.Tests.Authorization;
 

--- a/Frontend/CO.CDP.OrganisationApp.Tests/TagHelpers/GovukButtonTagHelperTests.cs
+++ b/Frontend/CO.CDP.OrganisationApp.Tests/TagHelpers/GovukButtonTagHelperTests.cs
@@ -1,7 +1,5 @@
 using CO.CDP.OrganisationApp.TagHelpers;
 using FluentAssertions;
-using Microsoft.AspNetCore.Razor.TagHelpers;
-using System.Text.Encodings.Web;
 using static CO.CDP.OrganisationApp.Tests.TagHelpers.TagHelperTestKit;
 
 namespace CO.CDP.OrganisationApp.Tests.TagHelpers;

--- a/Libraries/CO.CDP.DataSharing.WebApiClient.Tests/DataSharingClientIntegrationTest.cs
+++ b/Libraries/CO.CDP.DataSharing.WebApiClient.Tests/DataSharingClientIntegrationTest.cs
@@ -1,18 +1,12 @@
-using CO.CDP.Authentication;
 using CO.CDP.OrganisationInformation.Persistence;
 using CO.CDP.TestKit.Mvc;
 using FluentAssertions;
-using Microsoft.Extensions.DependencyInjection;
-using Moq;
 using Xunit.Abstractions;
 
 namespace CO.CDP.DataSharing.WebApiClient.Tests;
 
 public class DataSharingClientIntegrationTest
 {
-    private readonly Mock<IShareCodeRepository> _shareCodeRepository = new();
-    private readonly Mock<IClaimService> _claimService = new();
-
     private readonly HttpClient _httpClient;
 
     public DataSharingClientIntegrationTest(ITestOutputHelper testOutputHelper)
@@ -21,11 +15,6 @@ public class DataSharingClientIntegrationTest
         {
             builder.ConfigureInMemoryDbContext<OrganisationInformationContext>();
             builder.ConfigureLogging(testOutputHelper);
-            builder.ConfigureServices((_, s) =>
-            {
-                s.AddScoped(_ => _shareCodeRepository.Object);
-                s.AddScoped(_ => _claimService.Object);
-            });
         });
 
         _httpClient = _factory.CreateClient();
@@ -37,9 +26,6 @@ public class DataSharingClientIntegrationTest
         IDataSharingClient client = new DataSharingClient("https://localhost", _httpClient);
 
         var shareCode = "HDJ2123F";
-        var organisationId = Guid.NewGuid();
-        _claimService.Setup(c => c.GetOrganisationId()).Returns(organisationId);
-        _shareCodeRepository.Setup(s => s.OrganisationShareCodeExistsAsync(organisationId, shareCode)).ReturnsAsync(true);
 
         Func<Task> act = async () => { await client.GetSharedDataAsync(shareCode); };
 

--- a/Services/CO.CDP.DataSharing.WebApi.Tests/DataSharingFactory.cs
+++ b/Services/CO.CDP.DataSharing.WebApi.Tests/DataSharingFactory.cs
@@ -1,4 +1,3 @@
-using Amazon.CloudWatch;
 using CO.CDP.DataSharing.WebApi.Model;
 using CO.CDP.OrganisationInformation;
 using CO.CDP.OrganisationInformation.Persistence;

--- a/Services/CO.CDP.DataSharing.WebApi.Tests/UseCase/GetShareCodeVerifyUseCaseTest.cs
+++ b/Services/CO.CDP.DataSharing.WebApi.Tests/UseCase/GetShareCodeVerifyUseCaseTest.cs
@@ -5,51 +5,19 @@ using CO.CDP.OrganisationInformation.Persistence;
 using FluentAssertions;
 using Moq;
 using CO.CDP.DataSharing.WebApi.Extensions;
-using CO.CDP.Authentication;
 
 namespace CO.CDP.DataSharing.WebApi.Tests.UseCase;
 
 public class GetShareCodeVerifyUseCaseTest : IClassFixture<AutoMapperFixture>
 {
     private readonly Mock<IShareCodeRepository> _shareCodeRepository = new();
-    private readonly Mock<IClaimService> _claimService = new();
-    private GetShareCodeVerifyUseCase UseCase => new(_shareCodeRepository.Object, _claimService.Object);
-
-    [Fact]
-    public async Task ThrowsUserUnauthorizedException_WhenRequestedUserOrganisationAndShareCodeRequestedNotFound()
-    {
-        var shareCode = "dummy_code";
-
-        var organisationId = Guid.NewGuid();
-        _claimService.Setup(c => c.GetOrganisationId()).Returns(organisationId);
-        _shareCodeRepository.Setup(s => s.OrganisationShareCodeExistsAsync(organisationId, shareCode)).ReturnsAsync(false);
-
-        var response = async () => await UseCase.Execute(
-            new ShareVerificationRequest { FormVersionId = "1.0", ShareCode = shareCode });
-
-        await response.Should().ThrowAsync<UserUnauthorizedException>();
-    }
-
-    [Fact]
-    public async Task ThrowsUserUnauthorizedException_WhenRequestedUserOrganisationInNotInTheClaim()
-    {
-        _claimService.Setup(c => c.GetOrganisationId()).Returns((Guid?)null);
-
-        var response = async () => await UseCase.Execute(
-            new ShareVerificationRequest { FormVersionId = "1.0", ShareCode = "dummy_code" });
-
-        await response.Should().ThrowAsync<UserUnauthorizedException>();
-    }
+    private GetShareCodeVerifyUseCase UseCase => new(_shareCodeRepository.Object);
 
     [Fact]
     public async Task ThrowsSharedConsentNotFoundException_WhenShareCodeRequestedNotFound()
     {
         var formVersionId = "default";
         var shareCode = ShareCodeExtensions.GenerateShareCode();
-
-        var organisationId = Guid.NewGuid();
-        _claimService.Setup(c => c.GetOrganisationId()).Returns(organisationId);
-        _shareCodeRepository.Setup(s => s.OrganisationShareCodeExistsAsync(organisationId, shareCode)).ReturnsAsync(true);
 
         var shareVerificationRequest = EntityFactory.GetShareVerificationRequest(formVersionId: formVersionId, shareCode: shareCode);
 
@@ -63,10 +31,6 @@ public class GetShareCodeVerifyUseCaseTest : IClassFixture<AutoMapperFixture>
     {
         var formVersionId = "V1.0";
         var shareCode = ShareCodeExtensions.GenerateShareCode();
-
-        var organisationId = Guid.NewGuid();
-        _claimService.Setup(c => c.GetOrganisationId()).Returns(organisationId);
-        _shareCodeRepository.Setup(s => s.OrganisationShareCodeExistsAsync(organisationId, shareCode)).ReturnsAsync(true);
 
         var shareVerificationRequest = EntityFactory.GetShareVerificationRequest(formVersionId: formVersionId, shareCode: shareCode);
 

--- a/Services/CO.CDP.DataSharing.WebApi.Tests/UseCase/GetSharedDataDocumentDownloadUrlUseCaseTests.cs
+++ b/Services/CO.CDP.DataSharing.WebApi.Tests/UseCase/GetSharedDataDocumentDownloadUrlUseCaseTests.cs
@@ -1,6 +1,4 @@
-using CO.CDP.Authentication;
 using CO.CDP.AwsServices;
-using CO.CDP.DataSharing.WebApi.Model;
 using CO.CDP.DataSharing.WebApi.UseCase;
 using CO.CDP.OrganisationInformation.Persistence;
 using FluentAssertions;
@@ -11,7 +9,6 @@ namespace CO.CDP.DataSharing.WebApi.Tests.UseCase;
 public class GetSharedDataDocumentDownloadUrlUseCaseTests
 {
     private readonly Mock<IShareCodeRepository> _shareCodeRepositoryMock = new();
-    private readonly Mock<IClaimService> _claimServiceMock = new();
     private readonly Mock<IFileHostManager> _fileHostManagerMock = new();
     private readonly GetSharedDataDocumentDownloadUrlUseCase _useCase;
 
@@ -19,38 +16,12 @@ public class GetSharedDataDocumentDownloadUrlUseCaseTests
     {
         _useCase = new GetSharedDataDocumentDownloadUrlUseCase(
             _shareCodeRepositoryMock.Object,
-            _claimServiceMock.Object,
             _fileHostManagerMock.Object);
-    }
-
-    [Fact]
-    public async Task Execute_ShouldThrowUserUnauthorizedException_WhenOrganisationIdIsNull()
-    {
-        _claimServiceMock.Setup(x => x.GetOrganisationId()).Returns((Guid?)null);
-
-        Func<Task> act = async () => await _useCase.Execute(("shareCode1", "documentId1"));
-
-        await act.Should().ThrowAsync<UserUnauthorizedException>();
-    }
-
-    [Fact]
-    public async Task Execute_ShouldThrowUserUnauthorizedException_WhenOrganisationShareCodeDoesNotExist()
-    {
-        var organisationId = Guid.NewGuid();
-        _claimServiceMock.Setup(x => x.GetOrganisationId()).Returns(organisationId);
-        _shareCodeRepositoryMock.Setup(x => x.OrganisationShareCodeExistsAsync(organisationId, "shareCode1")).ReturnsAsync(false);
-
-        Func<Task> act = async () => await _useCase.Execute(("shareCode1", "documentId1"));
-
-        await act.Should().ThrowAsync<UserUnauthorizedException>();
     }
 
     [Fact]
     public async Task Execute_ShouldReturnNull_WhenDocumentDoesNotExist()
     {
-        var organisationId = Guid.NewGuid();
-        _claimServiceMock.Setup(x => x.GetOrganisationId()).Returns(organisationId);
-        _shareCodeRepositoryMock.Setup(x => x.OrganisationShareCodeExistsAsync(organisationId, "shareCode1")).ReturnsAsync(true);
         _shareCodeRepositoryMock.Setup(x => x.ShareCodeDocumentExistsAsync("shareCode1", "documentId1")).ReturnsAsync(false);
 
         var result = await _useCase.Execute(("shareCode1", "documentId1"));
@@ -61,9 +32,6 @@ public class GetSharedDataDocumentDownloadUrlUseCaseTests
     [Fact]
     public async Task Execute_ShouldReturnPresignedUrl_WhenDocumentExists()
     {
-        var organisationId = Guid.NewGuid();
-        _claimServiceMock.Setup(x => x.GetOrganisationId()).Returns(organisationId);
-        _shareCodeRepositoryMock.Setup(x => x.OrganisationShareCodeExistsAsync(organisationId, "shareCode1")).ReturnsAsync(true);
         _shareCodeRepositoryMock.Setup(x => x.ShareCodeDocumentExistsAsync("shareCode1", "documentId1")).ReturnsAsync(true);
         _fileHostManagerMock.Setup(x => x.GeneratePresignedUrl("documentId1", 10080)).ReturnsAsync("https://example.com/presignedurl");
 

--- a/Services/CO.CDP.DataSharing.WebApi.Tests/UseCase/GetSharedDataUseCaseTest.cs
+++ b/Services/CO.CDP.DataSharing.WebApi.Tests/UseCase/GetSharedDataUseCaseTest.cs
@@ -1,4 +1,3 @@
-using CO.CDP.Authentication;
 using CO.CDP.DataSharing.WebApi.Model;
 using CO.CDP.DataSharing.WebApi.Tests.AutoMapper;
 using CO.CDP.DataSharing.WebApi.UseCase;
@@ -15,42 +14,13 @@ public class GetSharedDataUseCaseTest : IClassFixture<AutoMapperFixture>
 {
     private readonly Mock<IShareCodeRepository> _shareCodeRepository = new();
     private readonly Mock<IOrganisationRepository> _organisationRepository = new();
-    private readonly Mock<IClaimService> _claimService = new();
     private readonly Mock<IConfiguration> _configuration = new();
     private readonly GetSharedDataUseCase _useCase;
 
     public GetSharedDataUseCaseTest(AutoMapperFixture mapperFixture)
     {
-        var organisationId = Guid.NewGuid();
-        _claimService.Setup(c => c.GetOrganisationId()).Returns(organisationId);
-        _shareCodeRepository.Setup(s => s.OrganisationShareCodeExistsAsync(organisationId, It.IsAny<string>())).ReturnsAsync(true);
-
         _useCase = new GetSharedDataUseCase(_shareCodeRepository.Object, _organisationRepository.Object,
-            _claimService.Object, mapperFixture.Mapper, _configuration.Object);
-    }
-
-    [Fact]
-    public async Task ThrowsUserUnauthorizedException_WhenRequestedUserOrganisationAndShareCodeRequested_NotFound()
-    {
-        var shareCode = "dummy_code";
-
-        var organisationId = Guid.NewGuid();
-        _claimService.Setup(c => c.GetOrganisationId()).Returns(organisationId);
-        _shareCodeRepository.Setup(s => s.OrganisationShareCodeExistsAsync(organisationId, shareCode)).ReturnsAsync(false);
-
-        var response = async () => await _useCase.Execute(shareCode);
-
-        await response.Should().ThrowAsync<UserUnauthorizedException>();
-    }
-
-    [Fact]
-    public async Task ThrowsUserUnauthorizedException_WhenRequestedUserOrganisation_NotInTheClaim()
-    {
-        _claimService.Setup(c => c.GetOrganisationId()).Returns((Guid?)null);
-
-        var response = async () => await _useCase.Execute("dummy_code");
-
-        await response.Should().ThrowAsync<UserUnauthorizedException>();
+            mapperFixture.Mapper, _configuration.Object);
     }
 
     [Fact]

--- a/Services/CO.CDP.DataSharing.WebApi/UseCase/GetShareCodeVerifyUseCase.cs
+++ b/Services/CO.CDP.DataSharing.WebApi/UseCase/GetShareCodeVerifyUseCase.cs
@@ -1,23 +1,15 @@
-using CO.CDP.Authentication;
 using CO.CDP.DataSharing.WebApi.Model;
 using CO.CDP.OrganisationInformation.Persistence;
 
 namespace CO.CDP.DataSharing.WebApi.UseCase;
 
 public class GetShareCodeVerifyUseCase(
-    IShareCodeRepository shareCodeRepository,
-    IClaimService claimService)
+    IShareCodeRepository shareCodeRepository)
     : IUseCase<ShareVerificationRequest,
         ShareVerificationReceipt>
 {
     public async Task<ShareVerificationReceipt> Execute(ShareVerificationRequest shareRequest)
     {
-        var organisationId = claimService.GetOrganisationId();
-        if (organisationId == null || await shareCodeRepository.OrganisationShareCodeExistsAsync(organisationId.Value, shareRequest.ShareCode) == false)
-        {
-            throw new UserUnauthorizedException();
-        }
-
         var details = await shareCodeRepository.GetShareCodeVerifyAsync(shareRequest.FormVersionId, shareRequest.ShareCode);
 
         if (details == null)

--- a/Services/CO.CDP.DataSharing.WebApi/UseCase/GetSharedDataDocumentDownloadUrlUseCase.cs
+++ b/Services/CO.CDP.DataSharing.WebApi/UseCase/GetSharedDataDocumentDownloadUrlUseCase.cs
@@ -1,24 +1,16 @@
-using CO.CDP.Authentication;
 using CO.CDP.AwsServices;
-using CO.CDP.DataSharing.WebApi.Model;
 using CO.CDP.OrganisationInformation.Persistence;
 
 namespace CO.CDP.DataSharing.WebApi.UseCase;
 
 public class GetSharedDataDocumentDownloadUrlUseCase(
     IShareCodeRepository shareCodeRepository,
-    IClaimService claimService,
     IFileHostManager fileHostManager)
     : IUseCase<(string, string), string?>
 {
     public async Task<string?> Execute((string, string) command)
     {
         var (sharecode, documentId) = command;
-        var organisationId = claimService.GetOrganisationId();
-        if (organisationId == null || await shareCodeRepository.OrganisationShareCodeExistsAsync(organisationId.Value, sharecode) == false)
-        {
-            throw new UserUnauthorizedException();
-        }
 
         var exists = await shareCodeRepository.ShareCodeDocumentExistsAsync(sharecode, documentId);
         if (exists)

--- a/Services/CO.CDP.DataSharing.WebApi/UseCase/GetSharedDataUseCase.cs
+++ b/Services/CO.CDP.DataSharing.WebApi/UseCase/GetSharedDataUseCase.cs
@@ -1,5 +1,4 @@
 using AutoMapper;
-using CO.CDP.Authentication;
 using CO.CDP.DataSharing.WebApi.Model;
 using CO.CDP.OrganisationInformation;
 using CO.CDP.OrganisationInformation.Persistence;
@@ -11,19 +10,12 @@ namespace CO.CDP.DataSharing.WebApi.UseCase;
 public class GetSharedDataUseCase(
     IShareCodeRepository shareCodeRepository,
     IOrganisationRepository organisationRepository,
-    IClaimService claimService,
     IMapper mapper,
     IConfiguration configuration)
     : IUseCase<string, SupplierInformation?>
 {
     public async Task<SupplierInformation?> Execute(string sharecode)
     {
-        var organisationId = claimService.GetOrganisationId();
-        if (organisationId == null || await shareCodeRepository.OrganisationShareCodeExistsAsync(organisationId.Value, sharecode) == false)
-        {
-            throw new UserUnauthorizedException();
-        }
-
         var sharedConsent = await shareCodeRepository.GetByShareCode(sharecode)
                             ?? throw new ShareCodeNotFoundException(Constants.ShareCodeNotFoundExceptionMessage);
 

--- a/Services/CO.CDP.OrganisationInformation.Persistence/DatabaseShareCodeRepository.cs
+++ b/Services/CO.CDP.OrganisationInformation.Persistence/DatabaseShareCodeRepository.cs
@@ -5,13 +5,6 @@ namespace CO.CDP.OrganisationInformation.Persistence;
 
 public class DatabaseShareCodeRepository(OrganisationInformationContext context) : IShareCodeRepository
 {
-    public async Task<bool> OrganisationShareCodeExistsAsync(Guid organisationId, string shareCode)
-    {
-        return await context.Set<SharedConsent>()
-            .Where(x => x.Organisation.Guid == organisationId && x.ShareCode == shareCode)
-            .AnyAsync();
-    }
-
     public async Task<bool> ShareCodeDocumentExistsAsync(string shareCode, string documentId)
     {
         return await context.Set<FormAnswer>()

--- a/Services/CO.CDP.OrganisationInformation.Persistence/IShareCodeRepository.cs
+++ b/Services/CO.CDP.OrganisationInformation.Persistence/IShareCodeRepository.cs
@@ -4,7 +4,6 @@ namespace CO.CDP.OrganisationInformation.Persistence;
 
 public interface IShareCodeRepository : IDisposable
 {
-    Task<bool> OrganisationShareCodeExistsAsync(Guid organisationId, string shareCode);
     Task<bool> ShareCodeDocumentExistsAsync(string shareCode, string documentId);
     Task<IEnumerable<SharedConsent>> GetShareCodesAsync(Guid organisationId);
     Task<SharedConsent?> GetSharedConsentDraftAsync(Guid formId, Guid organisationId);


### PR DESCRIPTION
API Permission - No need for organisation id match for organisation key 