### PR TITLE
Make repository tests less likely to fail due to parallel runs

### DIFF
--- a/Services/CO.CDP.OrganisationInformation.Persistence.Tests/DatabaseAuthenticationKeyRepositoryTest.cs
+++ b/Services/CO.CDP.OrganisationInformation.Persistence.Tests/DatabaseAuthenticationKeyRepositoryTest.cs
@@ -35,12 +35,12 @@ public class DatabaseAuthenticationKeyRepositoryTest(PostgreSqlFixture postgreSq
         using var repository = AuthenticationKeyRepository();
         var organisation = GivenOrganisation();
         var authenticationKey = GivenAuthenticationKey(key: Guid.NewGuid().ToString(), organisation: organisation);
-        authenticationKey.Organisation = GivenOrganisation();
 
         await repository.Save(authenticationKey);
 
         var found = await repository.Find(authenticationKey.Key);
-        found.As<AuthenticationKey>().OrganisationId.Should().Be(authenticationKey.Organisation.Id);
+        found.As<AuthenticationKey>().OrganisationId.Should().NotBeNull();
+        found.As<AuthenticationKey>().OrganisationId.Should().Be(authenticationKey.Organisation?.Id);
     }
 
     [Fact]
@@ -62,10 +62,10 @@ public class DatabaseAuthenticationKeyRepositoryTest(PostgreSqlFixture postgreSq
         using var repository = AuthenticationKeyRepository();
         var organisation = GivenOrganisation();
         var key = Guid.NewGuid().ToString();
-        var authenticationKey = GivenAuthenticationKey(key: key, organisation: organisation);
+        var authenticationKey = GivenAuthenticationKey(name: "fts-key", key: key, organisation: organisation);
         await repository.Save(authenticationKey);
 
-        var found = await repository.FindByKeyNameAndOrganisationId("fts", organisation.Guid);
+        var found = await repository.FindByKeyNameAndOrganisationId("fts-key", organisation.Guid);
         found.As<AuthenticationKey>().Should().NotBeNull();
         found.As<AuthenticationKey>().Key.Should().BeSameAs(key);
     }
@@ -76,27 +76,27 @@ public class DatabaseAuthenticationKeyRepositoryTest(PostgreSqlFixture postgreSq
         using var repository = AuthenticationKeyRepository();
         var organisation = GivenOrganisation();
         var key = Guid.NewGuid().ToString();
-        var authenticationKey1 = GivenAuthenticationKey(key: key, organisation: organisation);
-        var authenticationKey2 = GivenAuthenticationKey(key: key, organisation: organisation);
+        var authenticationKey1 = GivenAuthenticationKey(name: "fts", key: key, organisation: organisation);
+        var authenticationKey2 = GivenAuthenticationKey(name: "fts", key: key, organisation: organisation);
 
         repository.Save(authenticationKey1);
-        
-        repository.Invoking(r => r.Save(authenticationKey2))
+
+        repository.Invoking(async r => await r.Save(authenticationKey2))
             .Should().ThrowAsync<IAuthenticationKeyRepository.AuthenticationKeyRepositoryException.DuplicateAuthenticationKeyNameException>()
             .WithMessage($"Authentication Key with name `fts` already exists.");
     }
 
     private static AuthenticationKey GivenAuthenticationKey(
-        string name = "fts",
-        string key = "api-key",
+        string? name = null,
+        string? key = null,
         Organisation? organisation = null,
         List<string>? scopes = null
     )
     {
         return new AuthenticationKey
         {
-            Name = name,
-            Key = key,
+            Name = name ?? $"key {Guid.NewGuid()}",
+            Key = key ?? Guid.NewGuid().ToString(),
             Organisation = organisation,
             Scopes = scopes ?? []
         };


### PR DESCRIPTION
I noticed these tests sometimes fail.

It turns out it's due to one missing `await` call and fixtures shared between test cases.

Testcontainers are only started once per test class. It's a compromise that make tests run faster. The drawback is data created in a previous test case can affect next ones. It's important each test case creates a unique data set. We do have a solution for this (starting a transaction that's rolled back at the end), but we only use it as a last resort.