### PR TITLE
DP-712: Make more frequent calls to check if new messages were published

### DIFF
--- a/Services/CO.CDP.EntityVerification/appsettings.json
+++ b/Services/CO.CDP.EntityVerification/appsettings.json
@@ -22,7 +22,7 @@
       "MessageGroupId": "EntityVerification",
       "Outbox": {
         "BatchSize": 10,
-        "ExecutionInterval": "00:00:30"
+        "ExecutionInterval": "00:00:10"
       }
     },
     "CloudWatch": {

--- a/Services/CO.CDP.Organisation.WebApi/appsettings.json
+++ b/Services/CO.CDP.Organisation.WebApi/appsettings.json
@@ -40,7 +40,7 @@
       "MessageGroupId": "Organisation",
       "Outbox": {
         "BatchSize": 10,
-        "ExecutionInterval": "00:00:30"
+        "ExecutionInterval": "00:00:10"
       }
     },
     "CloudWatch": {


### PR DESCRIPTION
Otherwise it takes too long for the message to be published.

We will explore using LISTEN/NOTIFY later to reduce the need for pulling the messages.