### PR TITLE
Add a missing await call to let the call finish before the test completes

### DIFF
--- a/Services/CO.CDP.OrganisationInformation.Persistence.Tests/DatabaseAuthenticationKeyRepositoryTest.cs
+++ b/Services/CO.CDP.OrganisationInformation.Persistence.Tests/DatabaseAuthenticationKeyRepositoryTest.cs
@@ -71,7 +71,7 @@ public class DatabaseAuthenticationKeyRepositoryTest(PostgreSqlFixture postgreSq
     }
 
     [Fact]
-    public void ItRejectsTwoApiKeyWithTheSameName()
+    public async Task ItRejectsTwoApiKeyWithTheSameName()
     {
         using var repository = AuthenticationKeyRepository();
         var organisation = GivenOrganisation();
@@ -79,9 +79,9 @@ public class DatabaseAuthenticationKeyRepositoryTest(PostgreSqlFixture postgreSq
         var authenticationKey1 = GivenAuthenticationKey(name: "fts", key: key, organisation: organisation);
         var authenticationKey2 = GivenAuthenticationKey(name: "fts", key: key, organisation: organisation);
 
-        repository.Save(authenticationKey1);
+        await repository.Save(authenticationKey1);
 
-        repository.Invoking(async r => await r.Save(authenticationKey2))
+        await repository.Invoking(async r => await r.Save(authenticationKey2))
             .Should().ThrowAsync<IAuthenticationKeyRepository.AuthenticationKeyRepositoryException.DuplicateAuthenticationKeyNameException>()
             .WithMessage($"Authentication Key with name `fts` already exists.");
     }


### PR DESCRIPTION
Otherwise, the test might fail randomly if the method returns before the `Save` call completes.

<img width="1434" alt="image" src="https://github.com/user-attachments/assets/82caa12e-4fa2-4a25-aae4-c1fb7c59e8bf">
