### PR TITLE
DP-505 Accomodate different domain delegation for production account

### DIFF
--- a/terragrunt/components/service/api-gateway/terragrunt.hcl
+++ b/terragrunt/components/service/api-gateway/terragrunt.hcl
@@ -1,5 +1,5 @@
 terraform {
-  source = local.global_vars.locals.environment != "orchestrator" ? "../../../modules//api-gateway" : null
+  source = contains(["development", "staging", "integration"], local.global_vars.locals.environment) ? "../../../modules//api-gateway" : null
 }
 
 include {

--- a/terragrunt/components/service/auth/terragrunt.hcl
+++ b/terragrunt/components/service/auth/terragrunt.hcl
@@ -23,7 +23,7 @@ locals {
 dependency core_networking {
   config_path = "../../core/networking"
   mock_outputs = {
-    public_hosted_zone_fqdn = "mock"
+    public_domain = "mock"
   }
 }
 
@@ -31,5 +31,5 @@ dependency core_networking {
 inputs = {
   tags = local.tags
 
-  public_hosted_zone_fqdn = dependency.core_networking.outputs.public_hosted_zone_fqdn
+  public_domain = dependency.core_networking.outputs.public_domain
 }

--- a/terragrunt/components/service/ecs/terragrunt.hcl
+++ b/terragrunt/components/service/ecs/terragrunt.hcl
@@ -41,7 +41,7 @@ dependency core_networking {
   mock_outputs = {
     private_subnet_ids          = "mock"
     private_subnets_cidr_blocks = "mock"
-    public_hosted_zone_fqdn     = "mock"
+    public_domain               = "mock"
     public_hosted_zone_id       = "mock"
     public_subnet_ids           = "mock"
     public_subnets_cidr_blocks  = "mock"
@@ -125,7 +125,7 @@ inputs = {
 
   private_subnet_ids          = dependency.core_networking.outputs.private_subnet_ids
   private_subnets_cidr_blocks = dependency.core_networking.outputs.private_subnets_cidr_blocks
-  public_hosted_zone_fqdn     = dependency.core_networking.outputs.public_hosted_zone_fqdn
+  public_domain               = dependency.core_networking.outputs.public_domain
   public_hosted_zone_id       = dependency.core_networking.outputs.public_hosted_zone_id
   public_subnet_ids           = dependency.core_networking.outputs.public_subnet_ids
   public_subnets_cidr_blocks  = dependency.core_networking.outputs.public_subnets_cidr_blocks

--- a/terragrunt/components/service/telemetry/terragrunt.hcl
+++ b/terragrunt/components/service/telemetry/terragrunt.hcl
@@ -33,10 +33,10 @@ dependency core_iam {
 dependency core_networking {
   config_path = "../../core/networking"
   mock_outputs = {
-    private_subnet_ids      = "mock"
-    public_hosted_zone_fqdn = "mock"
-    public_hosted_zone_id   = "mock"
-    vpc_id                  = "mock"
+    private_subnet_ids    = "mock"
+    public_domain         = "mock"
+    public_hosted_zone_id = "mock"
+    vpc_id                = "mock"
   }
 }
 
@@ -68,10 +68,10 @@ inputs = {
   role_ecs_task_exec_arn = dependency.core_iam.outputs.ecs_task_exec_arn
   role_telemetry_arn     = dependency.core_iam.outputs.telemetry_arn
 
-  private_subnet_ids      = dependency.core_networking.outputs.private_subnet_ids
-  public_hosted_zone_fqdn = dependency.core_networking.outputs.public_hosted_zone_fqdn
-  public_hosted_zone_id   = dependency.core_networking.outputs.public_hosted_zone_id
-  vpc_id                  = dependency.core_networking.outputs.vpc_id
+  private_subnet_ids    = dependency.core_networking.outputs.private_subnet_ids
+  public_domain         = dependency.core_networking.outputs.public_domain
+  public_hosted_zone_id = dependency.core_networking.outputs.public_hosted_zone_id
+  vpc_id                = dependency.core_networking.outputs.vpc_id
 
   ecs_alb_sg_id = dependency.core_security_groups.outputs.alb_sg_id
   ecs_sg_id     = dependency.core_security_groups.outputs.ecs_sg_id

--- a/terragrunt/components/service/tools/terragrunt.hcl
+++ b/terragrunt/components/service/tools/terragrunt.hcl
@@ -32,10 +32,10 @@ dependency core_iam {
 dependency core_networking {
   config_path = "../../core/networking"
   mock_outputs = {
-    private_subnet_ids      = "mock"
-    public_hosted_zone_fqdn = "mock"
-    public_hosted_zone_id   = "mock"
-    vpc_id                  = "mock"
+    private_subnet_ids    = "mock"
+    public_domain         = "mock"
+    public_hosted_zone_id = "mock"
+    vpc_id                = "mock"
   }
 }
 
@@ -99,10 +99,10 @@ inputs = {
   role_ecs_task_name     = dependency.core_iam.outputs.ecs_task_name
   role_ecs_task_exec_arn = dependency.core_iam.outputs.ecs_task_exec_arn
 
-  private_subnet_ids      = dependency.core_networking.outputs.private_subnet_ids
-  public_hosted_zone_fqdn = dependency.core_networking.outputs.public_hosted_zone_fqdn
-  public_hosted_zone_id   = dependency.core_networking.outputs.public_hosted_zone_id
-  vpc_id                  = dependency.core_networking.outputs.vpc_id
+  private_subnet_ids    = dependency.core_networking.outputs.private_subnet_ids
+  public_domain         = dependency.core_networking.outputs.public_domain
+  public_hosted_zone_id = dependency.core_networking.outputs.public_hosted_zone_id
+  vpc_id                = dependency.core_networking.outputs.vpc_id
 
   ecs_alb_sg_id = dependency.core_security_groups.outputs.alb_sg_id
   ecs_sg_id     = dependency.core_security_groups.outputs.ecs_sg_id

--- a/terragrunt/components/terragrunt.hcl
+++ b/terragrunt/components/terragrunt.hcl
@@ -94,7 +94,7 @@ locals {
       account_id                 = 471112843276
       canary_schedule_expression = "rate(15 minutes)"
       name                       = "production"
-      pinned_service_version     = null
+      pinned_service_version     = "0.6.0"
       postgres_instance_type     = "db.t4g.micro"
       private_subnets = [
         "10.${local.cidr_b_production}.101.0/24",

--- a/terragrunt/components/terragrunt.hcl
+++ b/terragrunt/components/terragrunt.hcl
@@ -12,7 +12,7 @@ locals {
 
   environment = get_env("TG_ENVIRONMENT", "development")
 
-  is_production = contains(["production", "integration"], local.environment)
+  is_production = contains(["production"], local.environment)
 
   environments = {
     orchestrator = {

--- a/terragrunt/modules/auth/locals.tf
+++ b/terragrunt/modules/auth/locals.tf
@@ -2,7 +2,7 @@ locals {
   name_prefix             = var.product.resource_name
   auth_domain             = "${local.name_prefix}-${var.environment}"
   organisation_app_domain = "${local.name_prefix}-${var.environment}-organisatino-app"
-  organisation_app_url    = "https://${var.public_hosted_zone_fqdn}"
+  organisation_app_url    = "https://${var.public_domain}"
   healthcheck_domain      = "${local.name_prefix}-${var.environment}-healthcheck"
-  healthcheck_url         = "https://healthcheck.${var.public_hosted_zone_fqdn}"
+  healthcheck_url         = "https://healthcheck.${var.public_domain}"
 }

--- a/terragrunt/modules/auth/main.tf
+++ b/terragrunt/modules/auth/main.tf
@@ -6,11 +6,12 @@ resource "aws_cognito_user_pool" "auth" {
   }
 
   password_policy {
-    minimum_length    = 8
-    require_lowercase = true
-    require_numbers   = true
-    require_symbols   = true
-    require_uppercase = true
+    minimum_length                   = 8
+    require_lowercase                = true
+    require_numbers                  = true
+    require_symbols                  = true
+    require_uppercase                = true
+    temporary_password_validity_days = 1
   }
 
   username_configuration {

--- a/terragrunt/modules/auth/variables.tf
+++ b/terragrunt/modules/auth/variables.tf
@@ -13,11 +13,10 @@ variable "product" {
   })
 }
 
-variable "public_hosted_zone_fqdn" {
-  description = "Fully qualified domain name of the public hosted zone"
+variable "public_domain" {
+  description = "The fully qualified domain name (FQDN) that may differ from the main delegated domain specified by 'public_hosted_zone_fqdn'. This domain represents the public-facing endpoint."
   type        = string
 }
-
 
 variable "tags" {
   description = "Tags to apply to all resources in this module"

--- a/terragrunt/modules/core-networking/locals.tf
+++ b/terragrunt/modules/core-networking/locals.tf
@@ -1,3 +1,4 @@
 locals {
-  tags = merge(var.tags, { Name = var.product.resource_name })
+  production_subdomain = "supplier-information"
+  tags                 = merge(var.tags, { Name = var.product.resource_name })
 }

--- a/terragrunt/modules/core-networking/outputs.tf
+++ b/terragrunt/modules/core-networking/outputs.tf
@@ -21,7 +21,6 @@ output "private_subnets_cidr_blocks" {
   value       = aws_subnet.private.*.cidr_block
 }
 
-
 output "public_domain" {
   value = var.is_production ? "${local.production_subdomain}.${aws_route53_zone.public.name}" : aws_route53_zone.public.name
 }

--- a/terragrunt/modules/core-networking/outputs.tf
+++ b/terragrunt/modules/core-networking/outputs.tf
@@ -21,6 +21,11 @@ output "private_subnets_cidr_blocks" {
   value       = aws_subnet.private.*.cidr_block
 }
 
+
+output "public_domain" {
+  value = var.is_production ? "${local.production_subdomain}.${aws_route53_zone.public.name}" : aws_route53_zone.public.name
+}
+
 output "public_hosted_zone_fqdn" {
   value = aws_route53_zone.public.name
 }

--- a/terragrunt/modules/core-networking/variables.tf
+++ b/terragrunt/modules/core-networking/variables.tf
@@ -1,3 +1,8 @@
+variable "is_production" {
+  description = "Indicates whether the target account is configured with production-level settings"
+  type        = bool
+}
+
 variable "product" {
   description = "product's common attributes"
   type = object({

--- a/terragrunt/modules/ecs-service/locals.tf
+++ b/terragrunt/modules/ecs-service/locals.tf
@@ -1,4 +1,4 @@
 locals {
-  tg_host_header            = ["${var.name}.${var.product.public_hosted_zone}"]
-  tg_host_header_with_alias = ["${var.name}.${var.product.public_hosted_zone}", var.product.public_hosted_zone]
+  tg_host_header            = ["${var.name}.${var.public_domain}"]
+  tg_host_header_with_alias = ["${var.name}.${var.public_domain}", var.public_domain]
 }

--- a/terragrunt/modules/ecs-service/variables.tf
+++ b/terragrunt/modules/ecs-service/variables.tf
@@ -111,6 +111,11 @@ variable "product" {
   })
 }
 
+variable "public_domain" {
+  description = "The fully qualified domain name (FQDN) that may differ from the main delegated domain specified by 'public_hosted_zone_fqdn'. This domain represents the public-facing endpoint."
+  type        = string
+}
+
 variable "role_ecs_task_arn" {
   description = "Task IAM role ARN"
   type        = string

--- a/terragrunt/modules/ecs/acm.tf
+++ b/terragrunt/modules/ecs/acm.tf
@@ -1,9 +1,9 @@
 resource "aws_acm_certificate" "this" {
-  domain_name               = var.public_hosted_zone_fqdn
-  subject_alternative_names = ["*.${var.public_hosted_zone_fqdn}"] # @todo (ABN) Restrict to service sub-domains
+  domain_name               = var.public_domain
+  subject_alternative_names = ["*.${var.public_domain}"]
   validation_method         = "DNS"
 
-  tags = merge(var.tags, { Name = var.public_hosted_zone_fqdn })
+  tags = merge(var.tags, { Name = var.public_domain })
 
   lifecycle {
     create_before_destroy = true

--- a/terragrunt/modules/ecs/locals.tf
+++ b/terragrunt/modules/ecs/locals.tf
@@ -20,6 +20,8 @@ locals {
 
   orchestrator_service_version = data.aws_ssm_parameter.orchestrator_service_version.value
 
+  production_subdomain = "supplier-information"
+
   service_version = var.pinned_service_version == null ? data.aws_ssm_parameter.orchestrator_service_version.value : var.pinned_service_version
 
   migrations = ["organisation-information-migrations", "entity-verification-migrations"]

--- a/terragrunt/modules/ecs/route53.tf
+++ b/terragrunt/modules/ecs/route53.tf
@@ -1,17 +1,17 @@
-resource "aws_route53_record" "ecs_alb" {
+resource "aws_route53_record" "service_to_entrypoint_alias" {
   for_each = local.service_configs
 
   zone_id = var.public_hosted_zone_id
-  name    = each.value.name
+  name    = var.environment == "production" ? "${each.value.name}.${local.production_subdomain}" : each.value.name
   type    = "CNAME"
   ttl     = 60
 
-  records = [aws_lb.ecs.dns_name]
+  records = [aws_route53_record.entrypoint_alias.name]
 }
 
-resource "aws_route53_record" "ecs_alb_frontend_alias" {
+resource "aws_route53_record" "entrypoint_alias" {
 
-  name    = var.product.public_hosted_zone
+  name    = var.public_domain
   type    = "A"
   zone_id = var.public_hosted_zone_id
 

--- a/terragrunt/modules/ecs/service-authority.tf
+++ b/terragrunt/modules/ecs/service-authority.tf
@@ -4,27 +4,27 @@ module "ecs_service_authority" {
   container_definitions = templatefile(
     "${path.module}/templates/task-definitions/${var.service_configs.authority.name}.json.tftpl",
     {
-      aspcore_environment     = local.aspcore_environment
-      authority_private_key   = "${data.aws_secretsmanager_secret.authority_keys.arn}:PRIVATE::"
-      container_port          = var.service_configs.authority.port
-      cpu                     = var.service_configs.authority.cpu
-      host_port               = var.service_configs.authority.port
-      image                   = local.ecr_urls[var.service_configs.authority.name]
-      lg_name                 = aws_cloudwatch_log_group.tasks[var.service_configs.authority.name].name
-      lg_prefix               = "app"
-      lg_region               = data.aws_region.current.name
-      memory                  = var.service_configs.authority.memory
-      name                    = var.service_configs.authority.name
-      oi_db_address           = var.db_sirsi_address
-      oi_db_name              = var.db_sirsi_name
-      oi_db_password          = "${var.db_sirsi_credentials_arn}:username::"
-      oi_db_username          = "${var.db_sirsi_credentials_arn}:password::"
-      onelogin_authority      = local.one_loging.credential_locations.authority
-      onelogin_client_id      = local.one_loging.credential_locations.client_id
-      onelogin_private_key    = local.one_loging.credential_locations.private_key
-      public_hosted_zone_fqdn = var.public_hosted_zone_fqdn
-      service_version         = local.service_version
-      vpc_cidr                = var.vpc_cider
+      aspcore_environment   = local.aspcore_environment
+      authority_private_key = "${data.aws_secretsmanager_secret.authority_keys.arn}:PRIVATE::"
+      container_port        = var.service_configs.authority.port
+      cpu                   = var.service_configs.authority.cpu
+      host_port             = var.service_configs.authority.port
+      image                 = local.ecr_urls[var.service_configs.authority.name]
+      lg_name               = aws_cloudwatch_log_group.tasks[var.service_configs.authority.name].name
+      lg_prefix             = "app"
+      lg_region             = data.aws_region.current.name
+      memory                = var.service_configs.authority.memory
+      name                  = var.service_configs.authority.name
+      oi_db_address         = var.db_sirsi_address
+      oi_db_name            = var.db_sirsi_name
+      oi_db_password        = "${var.db_sirsi_credentials_arn}:username::"
+      oi_db_username        = "${var.db_sirsi_credentials_arn}:password::"
+      onelogin_authority    = local.one_loging.credential_locations.authority
+      onelogin_client_id    = local.one_loging.credential_locations.client_id
+      onelogin_private_key  = local.one_loging.credential_locations.private_key
+      public_domain         = var.public_domain
+      service_version       = local.service_version
+      vpc_cidr              = var.vpc_cider
     }
   )
 
@@ -41,6 +41,7 @@ module "ecs_service_authority" {
   name                   = var.service_configs.authority.name
   private_subnet_ids     = var.private_subnet_ids
   product                = var.product
+  public_domain          = var.public_domain
   role_ecs_task_arn      = var.role_ecs_task_arn
   role_ecs_task_exec_arn = var.role_ecs_task_exec_arn
   tags                   = var.tags

--- a/terragrunt/modules/ecs/service-data-sharing.tf
+++ b/terragrunt/modules/ecs/service-data-sharing.tf
@@ -4,25 +4,25 @@ module "ecs_service_data_sharing" {
   container_definitions = templatefile(
     "${path.module}/templates/task-definitions/${var.service_configs.data_sharing.name}.json.tftpl",
     {
-      aspcore_environment     = local.aspcore_environment
-      container_port          = var.service_configs.data_sharing.port
-      cpu                     = var.service_configs.data_sharing.cpu
-      host_port               = var.service_configs.data_sharing.port
-      image                   = local.ecr_urls[var.service_configs.data_sharing.name]
-      lg_name                 = aws_cloudwatch_log_group.tasks[var.service_configs.data_sharing.name].name
-      lg_prefix               = "app"
-      lg_region               = data.aws_region.current.name
-      memory                  = var.service_configs.data_sharing.memory
-      name                    = var.service_configs.data_sharing.name
-      oi_db_address           = var.db_sirsi_address
-      oi_db_name              = var.db_sirsi_name
-      oi_db_password          = "${var.db_sirsi_credentials_arn}:username::"
-      oi_db_username          = "${var.db_sirsi_credentials_arn}:password::"
-      public_hosted_zone_fqdn = var.public_hosted_zone_fqdn
-      s3_permanent_bucket     = module.s3_bucket_permanent.bucket
-      s3_staging_bucket       = module.s3_bucket_staging.bucket
-      service_version         = local.service_version
-      vpc_cidr                = var.vpc_cider
+      aspcore_environment = local.aspcore_environment
+      container_port      = var.service_configs.data_sharing.port
+      cpu                 = var.service_configs.data_sharing.cpu
+      host_port           = var.service_configs.data_sharing.port
+      image               = local.ecr_urls[var.service_configs.data_sharing.name]
+      lg_name             = aws_cloudwatch_log_group.tasks[var.service_configs.data_sharing.name].name
+      lg_prefix           = "app"
+      lg_region           = data.aws_region.current.name
+      memory              = var.service_configs.data_sharing.memory
+      name                = var.service_configs.data_sharing.name
+      oi_db_address       = var.db_sirsi_address
+      oi_db_name          = var.db_sirsi_name
+      oi_db_password      = "${var.db_sirsi_credentials_arn}:username::"
+      oi_db_username      = "${var.db_sirsi_credentials_arn}:password::"
+      public_domain       = var.public_domain
+      s3_permanent_bucket = module.s3_bucket_permanent.bucket
+      s3_staging_bucket   = module.s3_bucket_staging.bucket
+      service_version     = local.service_version
+      vpc_cidr            = var.vpc_cider
     }
   )
 
@@ -39,6 +39,7 @@ module "ecs_service_data_sharing" {
   name                   = var.service_configs.data_sharing.name
   private_subnet_ids     = var.private_subnet_ids
   product                = var.product
+  public_domain          = var.public_domain
   role_ecs_task_arn      = var.role_ecs_task_arn
   role_ecs_task_exec_arn = var.role_ecs_task_exec_arn
   tags                   = var.tags

--- a/terragrunt/modules/ecs/service-entity-verification.tf
+++ b/terragrunt/modules/ecs/service-entity-verification.tf
@@ -18,7 +18,7 @@ module "ecs_service_entity_verification" {
       ev_db_name                          = var.db_entity_verification_name
       ev_db_password                      = "${var.db_entity_verification_credentials_arn}:username::"
       ev_db_username                      = "${var.db_entity_verification_credentials_arn}:password::"
-      public_hosted_zone_fqdn             = var.public_hosted_zone_fqdn
+      public_domain                       = var.public_domain
       queue_entity_verification_queue_url = var.queue_entity_verification_queue_url
       queue_organisation_queue_url        = var.queue_organisation_queue_url
       service_version                     = local.service_version
@@ -39,6 +39,7 @@ module "ecs_service_entity_verification" {
   name                   = var.service_configs.entity_verification.name
   private_subnet_ids     = var.private_subnet_ids
   product                = var.product
+  public_domain          = var.public_domain
   role_ecs_task_arn      = var.role_ecs_task_arn
   role_ecs_task_exec_arn = var.role_ecs_task_exec_arn
   tags                   = var.tags

--- a/terragrunt/modules/ecs/service-forms.tf
+++ b/terragrunt/modules/ecs/service-forms.tf
@@ -4,25 +4,25 @@ module "ecs_service_forms" {
   container_definitions = templatefile(
     "${path.module}/templates/task-definitions/${var.service_configs.forms.name}.json.tftpl",
     {
-      aspcore_environment     = local.aspcore_environment
-      container_port          = var.service_configs.forms.port
-      cpu                     = var.service_configs.forms.cpu
-      host_port               = var.service_configs.forms.port
-      image                   = local.ecr_urls[var.service_configs.forms.name]
-      lg_name                 = aws_cloudwatch_log_group.tasks[var.service_configs.forms.name].name
-      lg_prefix               = "app"
-      lg_region               = data.aws_region.current.name
-      memory                  = var.service_configs.forms.memory
-      name                    = var.service_configs.forms.name
-      oi_db_address           = var.db_sirsi_address
-      oi_db_name              = var.db_sirsi_name
-      oi_db_password          = "${var.db_sirsi_credentials_arn}:username::"
-      oi_db_username          = "${var.db_sirsi_credentials_arn}:password::"
-      public_hosted_zone_fqdn = var.public_hosted_zone_fqdn
-      s3_permanent_bucket     = module.s3_bucket_permanent.bucket
-      s3_staging_bucket       = module.s3_bucket_staging.bucket
-      service_version         = local.service_version
-      vpc_cidr                = var.vpc_cider
+      aspcore_environment = local.aspcore_environment
+      container_port      = var.service_configs.forms.port
+      cpu                 = var.service_configs.forms.cpu
+      host_port           = var.service_configs.forms.port
+      image               = local.ecr_urls[var.service_configs.forms.name]
+      lg_name             = aws_cloudwatch_log_group.tasks[var.service_configs.forms.name].name
+      lg_prefix           = "app"
+      lg_region           = data.aws_region.current.name
+      memory              = var.service_configs.forms.memory
+      name                = var.service_configs.forms.name
+      oi_db_address       = var.db_sirsi_address
+      oi_db_name          = var.db_sirsi_name
+      oi_db_password      = "${var.db_sirsi_credentials_arn}:username::"
+      oi_db_username      = "${var.db_sirsi_credentials_arn}:password::"
+      public_domain       = var.public_domain
+      s3_permanent_bucket = module.s3_bucket_permanent.bucket
+      s3_staging_bucket   = module.s3_bucket_staging.bucket
+      service_version     = local.service_version
+      vpc_cidr            = var.vpc_cider
     }
   )
 
@@ -39,6 +39,7 @@ module "ecs_service_forms" {
   name                   = var.service_configs.forms.name
   private_subnet_ids     = var.private_subnet_ids
   product                = var.product
+  public_domain          = var.public_domain
   role_ecs_task_arn      = var.role_ecs_task_arn
   role_ecs_task_exec_arn = var.role_ecs_task_exec_arn
   tags                   = var.tags

--- a/terragrunt/modules/ecs/service-organisation-app.tf
+++ b/terragrunt/modules/ecs/service-organisation-app.tf
@@ -45,7 +45,7 @@ module "ecs_service_organisation_app" {
       onelogin_authority       = local.one_loging.credential_locations.authority
       onelogin_client_id       = local.one_loging.credential_locations.client_id
       onelogin_private_key     = local.one_loging.credential_locations.private_key
-      public_hosted_zone_fqdn  = var.public_hosted_zone_fqdn
+      public_domain            = var.public_domain
       s3_permanent_bucket      = module.s3_bucket_permanent.bucket
       s3_staging_bucket        = module.s3_bucket_staging.bucket
       service_version          = local.service_version
@@ -67,6 +67,7 @@ module "ecs_service_organisation_app" {
   name                   = var.service_configs.organisation_app.name
   private_subnet_ids     = var.private_subnet_ids
   product                = var.product
+  public_domain          = var.public_domain
   role_ecs_task_arn      = var.role_ecs_task_arn
   role_ecs_task_exec_arn = var.role_ecs_task_exec_arn
   tags                   = var.tags

--- a/terragrunt/modules/ecs/service-organisation.tf
+++ b/terragrunt/modules/ecs/service-organisation.tf
@@ -20,7 +20,7 @@ module "ecs_service_organisation" {
       oi_db_name                          = var.db_sirsi_name
       oi_db_password                      = "${var.db_sirsi_credentials_arn}:username::"
       oi_db_username                      = "${var.db_sirsi_credentials_arn}:password::"
-      public_hosted_zone_fqdn             = var.public_hosted_zone_fqdn
+      public_domain                       = var.public_domain
       queue_entity_verification_queue_url = var.queue_entity_verification_queue_url
       queue_organisation_queue_url        = var.queue_organisation_queue_url
       service_version                     = local.service_version
@@ -40,6 +40,7 @@ module "ecs_service_organisation" {
   name                   = var.service_configs.organisation.name
   private_subnet_ids     = var.private_subnet_ids
   product                = var.product
+  public_domain          = var.public_domain
   role_ecs_task_arn      = var.role_ecs_task_arn
   role_ecs_task_exec_arn = var.role_ecs_task_exec_arn
   tags                   = var.tags

--- a/terragrunt/modules/ecs/service-person.tf
+++ b/terragrunt/modules/ecs/service-person.tf
@@ -4,23 +4,23 @@ module "ecs_service_person" {
   container_definitions = templatefile(
     "${path.module}/templates/task-definitions/${var.service_configs.person.name}.json.tftpl",
     {
-      aspcore_environment     = local.aspcore_environment
-      container_port          = var.service_configs.person.port
-      cpu                     = var.service_configs.person.cpu
-      host_port               = var.service_configs.person.port
-      image                   = local.ecr_urls[var.service_configs.person.name]
-      lg_name                 = aws_cloudwatch_log_group.tasks[var.service_configs.person.name].name
-      lg_prefix               = "app"
-      lg_region               = data.aws_region.current.name
-      memory                  = var.service_configs.person.memory
-      name                    = var.service_configs.person.name
-      oi_db_address           = var.db_sirsi_address
-      oi_db_name              = var.db_sirsi_name
-      oi_db_password          = "${var.db_sirsi_credentials_arn}:username::"
-      oi_db_username          = "${var.db_sirsi_credentials_arn}:password::"
-      public_hosted_zone_fqdn = var.public_hosted_zone_fqdn
-      service_version         = local.service_version
-      vpc_cidr                = var.vpc_cider
+      aspcore_environment = local.aspcore_environment
+      container_port      = var.service_configs.person.port
+      cpu                 = var.service_configs.person.cpu
+      host_port           = var.service_configs.person.port
+      image               = local.ecr_urls[var.service_configs.person.name]
+      lg_name             = aws_cloudwatch_log_group.tasks[var.service_configs.person.name].name
+      lg_prefix           = "app"
+      lg_region           = data.aws_region.current.name
+      memory              = var.service_configs.person.memory
+      name                = var.service_configs.person.name
+      oi_db_address       = var.db_sirsi_address
+      oi_db_name          = var.db_sirsi_name
+      oi_db_password      = "${var.db_sirsi_credentials_arn}:username::"
+      oi_db_username      = "${var.db_sirsi_credentials_arn}:password::"
+      public_domain       = var.public_domain
+      service_version     = local.service_version
+      vpc_cidr            = var.vpc_cider
     }
   )
 
@@ -37,6 +37,7 @@ module "ecs_service_person" {
   name                   = var.service_configs.person.name
   private_subnet_ids     = var.private_subnet_ids
   product                = var.product
+  public_domain          = var.public_domain
   role_ecs_task_arn      = var.role_ecs_task_arn
   role_ecs_task_exec_arn = var.role_ecs_task_exec_arn
   tags                   = var.tags

--- a/terragrunt/modules/ecs/service-tenant.tf
+++ b/terragrunt/modules/ecs/service-tenant.tf
@@ -4,23 +4,23 @@ module "ecs_service_tenant" {
   container_definitions = templatefile(
     "${path.module}/templates/task-definitions/${var.service_configs.tenant.name}.json.tftpl",
     {
-      aspcore_environment     = local.aspcore_environment
-      container_port          = var.service_configs.tenant.port
-      cpu                     = var.service_configs.tenant.cpu
-      host_port               = var.service_configs.tenant.port
-      image                   = local.ecr_urls[var.service_configs.tenant.name]
-      lg_name                 = aws_cloudwatch_log_group.tasks[var.service_configs.tenant.name].name
-      lg_prefix               = "app"
-      lg_region               = data.aws_region.current.name
-      memory                  = var.service_configs.tenant.memory
-      name                    = var.service_configs.tenant.name
-      oi_db_address           = var.db_sirsi_address
-      oi_db_name              = var.db_sirsi_name
-      oi_db_password          = "${var.db_sirsi_credentials_arn}:username::"
-      oi_db_username          = "${var.db_sirsi_credentials_arn}:password::"
-      public_hosted_zone_fqdn = var.public_hosted_zone_fqdn
-      service_version         = local.service_version
-      vpc_cidr                = var.vpc_cider
+      aspcore_environment = local.aspcore_environment
+      container_port      = var.service_configs.tenant.port
+      cpu                 = var.service_configs.tenant.cpu
+      host_port           = var.service_configs.tenant.port
+      image               = local.ecr_urls[var.service_configs.tenant.name]
+      lg_name             = aws_cloudwatch_log_group.tasks[var.service_configs.tenant.name].name
+      lg_prefix           = "app"
+      lg_region           = data.aws_region.current.name
+      memory              = var.service_configs.tenant.memory
+      name                = var.service_configs.tenant.name
+      oi_db_address       = var.db_sirsi_address
+      oi_db_name          = var.db_sirsi_name
+      oi_db_password      = "${var.db_sirsi_credentials_arn}:username::"
+      oi_db_username      = "${var.db_sirsi_credentials_arn}:password::"
+      public_domain       = var.public_domain
+      service_version     = local.service_version
+      vpc_cidr            = var.vpc_cider
     }
   )
 
@@ -37,6 +37,7 @@ module "ecs_service_tenant" {
   name                   = var.service_configs.tenant.name
   private_subnet_ids     = var.private_subnet_ids
   product                = var.product
+  public_domain          = var.public_domain
   role_ecs_task_arn      = var.role_ecs_task_arn
   role_ecs_task_exec_arn = var.role_ecs_task_exec_arn
   tags                   = var.tags

--- a/terragrunt/modules/ecs/task-migrations.tf
+++ b/terragrunt/modules/ecs/task-migrations.tf
@@ -6,20 +6,20 @@ module "ecs_migration_tasks" {
   container_definitions = templatefile(
     "${path.module}/templates/task-definitions/${each.value.name}.json.tftpl",
     {
-      cpu                     = var.service_configs.entity_verification_migrations.cpu
-      aspcore_environment     = local.aspcore_environment
-      image                   = local.ecr_urls[each.value.name]
-      lg_name                 = aws_cloudwatch_log_group.tasks[each.value.name].name
-      lg_prefix               = "db"
-      lg_region               = data.aws_region.current.name
-      memory                  = each.value.memory
-      name                    = each.value.name
-      db_address              = each.value.name == "entity-verification-migrations" ? var.db_entity_verification_address : var.db_sirsi_address
-      db_name                 = each.value.name == "entity-verification-migrations" ? var.db_entity_verification_name : var.db_sirsi_name
-      db_password             = each.value.name == "entity-verification-migrations" ? "${var.db_entity_verification_credentials_arn}:username::" : "${var.db_sirsi_credentials_arn}:username::"
-      db_username             = each.value.name == "entity-verification-migrations" ? "${var.db_entity_verification_credentials_arn}:password::" : "${var.db_sirsi_credentials_arn}:password::"
-      public_hosted_zone_fqdn = var.public_hosted_zone_fqdn
-      service_version         = local.service_version
+      cpu                 = var.service_configs.entity_verification_migrations.cpu
+      aspcore_environment = local.aspcore_environment
+      image               = local.ecr_urls[each.value.name]
+      lg_name             = aws_cloudwatch_log_group.tasks[each.value.name].name
+      lg_prefix           = "db"
+      lg_region           = data.aws_region.current.name
+      memory              = each.value.memory
+      name                = each.value.name
+      db_address          = each.value.name == "entity-verification-migrations" ? var.db_entity_verification_address : var.db_sirsi_address
+      db_name             = each.value.name == "entity-verification-migrations" ? var.db_entity_verification_name : var.db_sirsi_name
+      db_password         = each.value.name == "entity-verification-migrations" ? "${var.db_entity_verification_credentials_arn}:username::" : "${var.db_sirsi_credentials_arn}:username::"
+      db_username         = each.value.name == "entity-verification-migrations" ? "${var.db_entity_verification_credentials_arn}:password::" : "${var.db_sirsi_credentials_arn}:password::"
+      public_domain       = var.public_domain
+      service_version     = local.service_version
     }
   )
 
@@ -34,6 +34,7 @@ module "ecs_migration_tasks" {
   name                   = each.value.name
   private_subnet_ids     = var.private_subnet_ids
   product                = var.product
+  public_domain          = var.public_domain
   role_ecs_task_arn      = var.role_ecs_task_arn
   role_ecs_task_exec_arn = var.role_ecs_task_exec_arn
   tags                   = var.tags

--- a/terragrunt/modules/ecs/templates/task-definitions/authority.json.tftpl
+++ b/terragrunt/modules/ecs/templates/task-definitions/authority.json.tftpl
@@ -25,7 +25,7 @@
         {"name": "Aws__CloudWatch__LogGroup", "value": "${lg_name}"},
         {"name": "Aws__CloudWatch__LogStream", "value": "${lg_prefix}-serilog"},
         {"name": "ForwardedHeaders__KnownNetwork", "value": "${vpc_cidr}"},
-        {"name": "Issuer", "value": "https://authority.${public_hosted_zone_fqdn}"},
+        {"name": "Issuer", "value": "https://authority.${public_domain}"},
         {"name": "OrganisationInformationDatabase__Database", "value": "${oi_db_name}"},
         {"name": "OrganisationInformationDatabase__Host", "value": "${oi_db_address}"},
         {"name": "OrganisationInformationDatabase__Server", "value": "${oi_db_address}"}

--- a/terragrunt/modules/ecs/templates/task-definitions/data-sharing.json.tftpl
+++ b/terragrunt/modules/ecs/templates/task-definitions/data-sharing.json.tftpl
@@ -26,12 +26,12 @@
         {"name": "Aws__Buckets__StagingBucket", "value": "${s3_staging_bucket}"},
         {"name": "Aws__CloudWatch__LogGroup", "value": "${lg_name}"},
         {"name": "Aws__CloudWatch__LogStream", "value": "${lg_prefix}-serilog"},
-        {"name": "DataSharingApiUrl", "value": "https://data-sharing.${public_hosted_zone_fqdn}"},
+        {"name": "DataSharingApiUrl", "value": "https://data-sharing.${public_domain}"},
         {"name": "ForwardedHeaders__KnownNetwork", "value": "${vpc_cidr}"},
         {"name": "OrganisationInformationDatabase__Database", "value": "${oi_db_name}"},
         {"name": "OrganisationInformationDatabase__Host", "value": "${oi_db_address}"},
         {"name": "OrganisationInformationDatabase__Server", "value": "${oi_db_address}"},
-        {"name": "Organisation__Authority", "value": "https://authority.${public_hosted_zone_fqdn}"}
+        {"name": "Organisation__Authority", "value": "https://authority.${public_domain}"}
     ],
     "secrets": [
         {"name": "OrganisationInformationDatabase__Password", "valueFrom": "${oi_db_username}"},

--- a/terragrunt/modules/ecs/templates/task-definitions/entity-verification-migrations.json.tftpl
+++ b/terragrunt/modules/ecs/templates/task-definitions/entity-verification-migrations.json.tftpl
@@ -20,7 +20,7 @@
         {"name": "EntityVerificationDatabase__Database", "value": "${db_name}"},
         {"name": "EntityVerificationDatabase__Host", "value": "${db_address}"},
         {"name": "EntityVerificationDatabase__Server", "value": "${db_address}"},
-        {"name": "Organisation__Authority", "value": "https://authority.${public_hosted_zone_fqdn}"}
+        {"name": "Organisation__Authority", "value": "https://authority.${public_domain}"}
     ],
     "secrets": [
         {"name": "EntityVerificationDatabase__Password", "valueFrom": "${db_username}"},

--- a/terragrunt/modules/ecs/templates/task-definitions/entity-verification.json.tftpl
+++ b/terragrunt/modules/ecs/templates/task-definitions/entity-verification.json.tftpl
@@ -31,7 +31,7 @@
         {"name": "EntityVerificationDatabase__Host", "value": "${ev_db_address}"},
         {"name": "EntityVerificationDatabase__Server", "value": "${ev_db_address}"},
         {"name": "ForwardedHeaders__KnownNetwork", "value": "${vpc_cidr}"},
-        {"name": "Organisation__Authority", "value": "https://authority.${public_hosted_zone_fqdn}"}
+        {"name": "Organisation__Authority", "value": "https://authority.${public_domain}"}
     ],
     "secrets": [
         {"name": "EntityVerificationDatabase__Password", "valueFrom": "${ev_db_username}"},

--- a/terragrunt/modules/ecs/templates/task-definitions/forms.json.tftpl
+++ b/terragrunt/modules/ecs/templates/task-definitions/forms.json.tftpl
@@ -31,7 +31,7 @@
         {"name": "OrganisationInformationDatabase__Database", "value": "${oi_db_name}"},
         {"name": "OrganisationInformationDatabase__Host", "value": "${oi_db_address}"},
         {"name": "OrganisationInformationDatabase__Server", "value": "${oi_db_address}"},
-        {"name": "Organisation__Authority", "value": "https://authority.${public_hosted_zone_fqdn}"}
+        {"name": "Organisation__Authority", "value": "https://authority.${public_domain}"}
     ],
     "secrets": [
         {"name": "OrganisationInformationDatabase__Password", "valueFrom": "${oi_db_username}"},

--- a/terragrunt/modules/ecs/templates/task-definitions/organisation-app.json.tftpl
+++ b/terragrunt/modules/ecs/templates/task-definitions/organisation-app.json.tftpl
@@ -26,15 +26,15 @@
         {"name": "Aws__Buckets__StagingBucket", "value": "${s3_staging_bucket}"},
         {"name": "Aws__CloudWatch__LogGroup", "value": "${lg_name}"},
         {"name": "Aws__CloudWatch__LogStream", "value": "${lg_prefix}-serilog"},
-        {"name": "DataSharingService", "value": "https://data-sharing.${public_hosted_zone_fqdn}"},
-        {"name": "EntityVerificationService", "value": "https://entity-verification.${public_hosted_zone_fqdn}"},
+        {"name": "DataSharingService", "value": "https://data-sharing.${public_domain}"},
+        {"name": "EntityVerificationService", "value": "https://entity-verification.${public_domain}"},
         {"name": "Features__DiagnosticPage__Enabled", "value": "${diagnostic_page_enabled}"},
-        {"name": "FormsService", "value": "https://forms.${public_hosted_zone_fqdn}"},
+        {"name": "FormsService", "value": "https://forms.${public_domain}"},
         {"name": "ForwardedHeaders__KnownNetwork", "value": "${vpc_cidr}"},
-        {"name": "OrganisationService", "value": "https://organisation.${public_hosted_zone_fqdn}"},
-        {"name": "Organisation__Authority", "value": "https://authority.${public_hosted_zone_fqdn}"},
-        {"name": "PersonService", "value": "https://person.${public_hosted_zone_fqdn}"},
-        {"name": "TenantService", "value": "https://tenant.${public_hosted_zone_fqdn}"}
+        {"name": "OrganisationService", "value": "https://organisation.${public_domain}"},
+        {"name": "Organisation__Authority", "value": "https://authority.${public_domain}"},
+        {"name": "PersonService", "value": "https://person.${public_domain}"},
+        {"name": "TenantService", "value": "https://tenant.${public_domain}"}
     ],
     "secrets": [
         {"name": "CompaniesHouse__Password", "valueFrom": "${companies_house_password}"},

--- a/terragrunt/modules/ecs/templates/task-definitions/organisation-information-migrations.json.tftpl
+++ b/terragrunt/modules/ecs/templates/task-definitions/organisation-information-migrations.json.tftpl
@@ -20,7 +20,7 @@
         {"name": "OrganisationInformationDatabase__Database", "value": "${db_name}"},
         {"name": "OrganisationInformationDatabase__Host", "value": "${db_address}"},
         {"name": "OrganisationInformationDatabase__Server", "value": "${db_address}"},
-        {"name": "Organisation__Authority", "value": "https://authority.${public_hosted_zone_fqdn}"}
+        {"name": "Organisation__Authority", "value": "https://authority.${public_domain}"}
     ],
     "secrets": [
         {"name": "OrganisationInformationDatabase__Password", "valueFrom": "${db_username}"},

--- a/terragrunt/modules/ecs/templates/task-definitions/organisation.json.tftpl
+++ b/terragrunt/modules/ecs/templates/task-definitions/organisation.json.tftpl
@@ -28,12 +28,12 @@
         {"name": "Aws__SqsPublisher__QueueUrl", "value": "${queue_organisation_queue_url}"},
         {"name": "CdpApiKeys__0", "value": "a955a529-1433-4acf-92b2-342a3e5e8086"},
         {"name": "ForwardedHeaders__KnownNetwork", "value": "${vpc_cidr}"},
-        {"name": "OrganisationApiUrl", "value": "https://organisation.${public_hosted_zone_fqdn}"},
-        {"name": "OrganisationAppUrl", "value": "https://${public_hosted_zone_fqdn}"},
+        {"name": "OrganisationApiUrl", "value": "https://organisation.${public_domain}"},
+        {"name": "OrganisationAppUrl", "value": "https://${public_domain}"},
         {"name": "OrganisationInformationDatabase__Database", "value": "${oi_db_name}"},
         {"name": "OrganisationInformationDatabase__Host", "value": "${oi_db_address}"},
         {"name": "OrganisationInformationDatabase__Server", "value": "${oi_db_address}"},
-        {"name": "Organisation__Authority", "value": "https://authority.${public_hosted_zone_fqdn}"}
+        {"name": "Organisation__Authority", "value": "https://authority.${public_domain}"}
     ],
     "secrets": [
         {"name": "GOVUKNotify__ApiKey", "valueFrom": "${govuknotify_apikey}"},

--- a/terragrunt/modules/ecs/templates/task-definitions/person.json.tftpl
+++ b/terragrunt/modules/ecs/templates/task-definitions/person.json.tftpl
@@ -29,7 +29,7 @@
         {"name": "OrganisationInformationDatabase__Database", "value": "${oi_db_name}"},
         {"name": "OrganisationInformationDatabase__Host", "value": "${oi_db_address}"},
         {"name": "OrganisationInformationDatabase__Server", "value": "${oi_db_address}"},
-        {"name": "Organisation__Authority", "value": "https://authority.${public_hosted_zone_fqdn}"}
+        {"name": "Organisation__Authority", "value": "https://authority.${public_domain}"}
     ],
     "secrets": [
         {"name": "OrganisationInformationDatabase__Password", "valueFrom": "${oi_db_username}"},

--- a/terragrunt/modules/ecs/templates/task-definitions/tenant.json.tftpl
+++ b/terragrunt/modules/ecs/templates/task-definitions/tenant.json.tftpl
@@ -29,7 +29,7 @@
         {"name": "OrganisationInformationDatabase__Database", "value": "${oi_db_name}"},
         {"name": "OrganisationInformationDatabase__Host", "value": "${oi_db_address}"},
         {"name": "OrganisationInformationDatabase__Server", "value": "${oi_db_address}"},
-        {"name": "Organisation__Authority", "value": "https://authority.${public_hosted_zone_fqdn}"}
+        {"name": "Organisation__Authority", "value": "https://authority.${public_domain}"}
     ],
     "secrets": [
         {"name": "OrganisationInformationDatabase__Password", "valueFrom": "${oi_db_username}"},

--- a/terragrunt/modules/ecs/variables.tf
+++ b/terragrunt/modules/ecs/variables.tf
@@ -79,11 +79,6 @@ variable "private_subnet_ids" {
   type        = list(string)
 }
 
-variable "private_subnets_cidr_blocks" {
-  description = "List of private subnet CIDR blocks"
-  type        = list(string)
-}
-
 variable "product" {
   description = "product's common attributes"
   type = object({
@@ -93,8 +88,8 @@ variable "product" {
   })
 }
 
-variable "public_hosted_zone_fqdn" {
-  description = "Fully qualified domain name of the public hosted zone"
+variable "public_domain" {
+  description = "The fully qualified domain name (FQDN) that may differ from the main delegated domain specified by 'public_hosted_zone_fqdn'. This domain represents the public-facing endpoint."
   type        = string
 }
 
@@ -105,11 +100,6 @@ variable "public_hosted_zone_id" {
 
 variable "public_subnet_ids" {
   description = "List of public subnet IDs"
-  type        = list(string)
-}
-
-variable "public_subnets_cidr_blocks" {
-  description = "The list of public subnet CIDR blocks"
   type        = list(string)
 }
 
@@ -130,11 +120,6 @@ variable "queue_organisation_queue_arn" {
 
 variable "queue_organisation_queue_url" {
   description = "URL of the Organisation's outbound SQS queue"
-  type        = string
-}
-
-variable "role_cloudwatch_events_arn" {
-  description = "ARN of the IAM role used by CloudWatch Events"
   type        = string
 }
 
@@ -175,11 +160,6 @@ variable "role_service_deployer_step_function_name" {
 
 variable "role_terraform_arn" {
   description = "Terraform IAM role ARN"
-  type        = string
-}
-
-variable "role_terraform_name" {
-  description = "Terraform IAM role name"
   type        = string
 }
 

--- a/terragrunt/modules/telemetry/locals.tf
+++ b/terragrunt/modules/telemetry/locals.tf
@@ -3,6 +3,8 @@ locals {
 
   orchestrator_account_id = var.account_ids["orchestrator"]
 
+  production_subdomain = "supplier-information"
+
   service_widgets = [
     for idx, service in values(var.service_configs) : [
       {

--- a/terragrunt/modules/telemetry/route53.tf
+++ b/terragrunt/modules/telemetry/route53.tf
@@ -1,8 +1,8 @@
-resource "aws_route53_record" "ecs_alb" {
+resource "aws_route53_record" "service_to_entrypoint_alias" {
   zone_id = var.public_hosted_zone_id
-  name    = var.grafana_config.name
+  name    = var.environment == "production" ? "${var.grafana_config.name}.${local.production_subdomain}": var.grafana_config.name
   type    = "CNAME"
   ttl     = 60
 
-  records = [var.ecs_lb_dns_name]
+  records = [var.public_domain]
 }

--- a/terragrunt/modules/telemetry/route53.tf
+++ b/terragrunt/modules/telemetry/route53.tf
@@ -1,6 +1,6 @@
 resource "aws_route53_record" "service_to_entrypoint_alias" {
   zone_id = var.public_hosted_zone_id
-  name    = var.environment == "production" ? "${var.grafana_config.name}.${local.production_subdomain}": var.grafana_config.name
+  name    = var.environment == "production" ? "${var.grafana_config.name}.${local.production_subdomain}" : var.grafana_config.name
   type    = "CNAME"
   ttl     = 60
 

--- a/terragrunt/modules/telemetry/service-grafana.tf
+++ b/terragrunt/modules/telemetry/service-grafana.tf
@@ -33,6 +33,7 @@ module "ecs_service_grafana" {
   name                   = var.grafana_config.name
   private_subnet_ids     = var.private_subnet_ids
   product                = var.product
+  public_domain          = var.public_domain
   role_ecs_task_arn      = var.role_ecs_task_arn
   role_ecs_task_exec_arn = var.role_ecs_task_exec_arn
   tags                   = var.tags

--- a/terragrunt/modules/telemetry/variables.tf
+++ b/terragrunt/modules/telemetry/variables.tf
@@ -13,11 +13,6 @@ variable "ecs_cluster_id" {
   type        = string
 }
 
-variable "ecs_lb_dns_name" {
-  description = "ECS Application Loadbalancer DNS name"
-  type        = string
-}
-
 variable "ecs_listener_arn" {
   description = "ECS Application Loadbalancer Listener ARN"
   type        = string

--- a/terragrunt/modules/telemetry/variables.tf
+++ b/terragrunt/modules/telemetry/variables.tf
@@ -58,8 +58,8 @@ variable "product" {
   })
 }
 
-variable "public_hosted_zone_fqdn" {
-  description = "Fully qualified domain name of the public hosted zone"
+variable "public_domain" {
+  description = "The fully qualified domain name (FQDN) that may differ from the main delegated domain specified by 'public_hosted_zone_fqdn'. This domain represents the public-facing endpoint."
   type        = string
 }
 

--- a/terragrunt/modules/tools/locals.tf
+++ b/terragrunt/modules/tools/locals.tf
@@ -2,4 +2,6 @@ locals {
   name_prefix = var.product.resource_name
 
   orchestrator_account_id = var.account_ids["orchestrator"]
+
+  production_subdomain = "supplier-information"
 }

--- a/terragrunt/modules/tools/route53.tf
+++ b/terragrunt/modules/tools/route53.tf
@@ -1,6 +1,6 @@
 resource "aws_route53_record" "healthcheck_to_entrypoint_alias" {
   zone_id = var.public_hosted_zone_id
-  name    = var.environment == "production" ? "${var.healthcheck_config.name}.${local.production_subdomain}": var.healthcheck_config.name
+  name    = var.environment == "production" ? "${var.healthcheck_config.name}.${local.production_subdomain}" : var.healthcheck_config.name
   type    = "CNAME"
   ttl     = 60
 
@@ -9,7 +9,7 @@ resource "aws_route53_record" "healthcheck_to_entrypoint_alias" {
 
 resource "aws_route53_record" "pgadmin_to_entrypoint_alias" {
   zone_id = var.public_hosted_zone_id
-  name    = var.environment == "production" ? "${var.pgadmin_config.name}.${local.production_subdomain}": var.pgadmin_config.name
+  name    = var.environment == "production" ? "${var.pgadmin_config.name}.${local.production_subdomain}" : var.pgadmin_config.name
   type    = "CNAME"
   ttl     = 60
 

--- a/terragrunt/modules/tools/route53.tf
+++ b/terragrunt/modules/tools/route53.tf
@@ -1,17 +1,17 @@
-resource "aws_route53_record" "healthcheck" {
+resource "aws_route53_record" "healthcheck_to_entrypoint_alias" {
   zone_id = var.public_hosted_zone_id
-  name    = var.healthcheck_config.name
+  name    = var.environment == "production" ? "${var.healthcheck_config.name}.${local.production_subdomain}": var.healthcheck_config.name
   type    = "CNAME"
   ttl     = 60
 
-  records = [var.ecs_lb_dns_name]
+  records = [var.public_domain]
 }
 
-resource "aws_route53_record" "pgadmin" {
+resource "aws_route53_record" "pgadmin_to_entrypoint_alias" {
   zone_id = var.public_hosted_zone_id
-  name    = var.pgadmin_config.name
+  name    = var.environment == "production" ? "${var.pgadmin_config.name}.${local.production_subdomain}": var.pgadmin_config.name
   type    = "CNAME"
   ttl     = 60
 
-  records = [var.ecs_lb_dns_name]
+  records = [var.public_domain]
 }

--- a/terragrunt/modules/tools/service-healthcheck.tf
+++ b/terragrunt/modules/tools/service-healthcheck.tf
@@ -13,7 +13,7 @@ module "ecs_service_healthcheck" {
       db_sirsi_address                = var.db_sirsi_address
       db_sirsi_name                   = var.db_sirsi_name
       db_sirsi_username               = "${var.db_sirsi_credentials_arn}:username::"
-      environment = title(var.environment)
+      environment                     = title(var.environment)
       host_port                       = var.healthcheck_config.port
       image                           = "${local.orchestrator_account_id}.dkr.ecr.${data.aws_region.current.name}.amazonaws.com/cdp-healthcheck:latest"
       lg_name                         = aws_cloudwatch_log_group.healthcheck.name

--- a/terragrunt/modules/tools/service-healthcheck.tf
+++ b/terragrunt/modules/tools/service-healthcheck.tf
@@ -13,7 +13,7 @@ module "ecs_service_healthcheck" {
       db_sirsi_address                = var.db_sirsi_address
       db_sirsi_name                   = var.db_sirsi_name
       db_sirsi_username               = "${var.db_sirsi_credentials_arn}:username::"
-      environment                     = title(var.environment)
+      environment = title(var.environment)
       host_port                       = var.healthcheck_config.port
       image                           = "${local.orchestrator_account_id}.dkr.ecr.${data.aws_region.current.name}.amazonaws.com/cdp-healthcheck:latest"
       lg_name                         = aws_cloudwatch_log_group.healthcheck.name
@@ -38,6 +38,7 @@ module "ecs_service_healthcheck" {
   name                   = var.healthcheck_config.name
   private_subnet_ids     = var.private_subnet_ids
   product                = var.product
+  public_domain          = var.public_domain
   role_ecs_task_arn      = var.role_ecs_task_arn
   role_ecs_task_exec_arn = var.role_ecs_task_exec_arn
   tags                   = var.tags

--- a/terragrunt/modules/tools/service-pgadmin.tf
+++ b/terragrunt/modules/tools/service-pgadmin.tf
@@ -41,6 +41,7 @@ module "ecs_service_pgadmin" {
   name                          = var.pgadmin_config.name
   private_subnet_ids            = var.private_subnet_ids
   product                       = var.product
+  public_domain                 = var.public_domain
   role_ecs_task_arn             = var.role_ecs_task_arn
   role_ecs_task_exec_arn        = var.role_ecs_task_exec_arn
   tags                          = var.tags

--- a/terragrunt/modules/tools/variables.tf
+++ b/terragrunt/modules/tools/variables.tf
@@ -13,11 +13,6 @@ variable "db_entity_verification_credentials_arn" {
   type        = string
 }
 
-variable "db_entity_verification_kms_arn" {
-  description = "ARN of the KMS used to encrypt Entity Verification database secrets"
-  type        = string
-}
-
 variable "db_entity_verification_name" {
   description = "Entity Verification database name"
   type        = string
@@ -110,18 +105,8 @@ variable "product" {
   })
 }
 
-variable "public_hosted_zone_fqdn" {
-  description = "Fully qualified domain name of the public hosted zone"
-  type        = string
-}
-
 variable "public_hosted_zone_id" {
   description = "ID of the public hosted zone"
-  type        = string
-}
-
-variable "queue_healthcheck_queue_arn" {
-  description = "ARN of the Health Check's SQS queue"
   type        = string
 }
 
@@ -130,7 +115,6 @@ variable "queue_healthcheck_queue_url" {
   type        = string
 }
 
-
 variable "role_ecs_task_arn" {
   description = "Task IAM role ARN"
   type        = string
@@ -138,11 +122,6 @@ variable "role_ecs_task_arn" {
 
 variable "role_ecs_task_exec_arn" {
   description = "Task execution IAM role ARN"
-  type        = string
-}
-
-variable "role_ecs_task_name" {
-  description = "Task IAM role Name"
   type        = string
 }
 
@@ -157,11 +136,6 @@ variable "user_pool_arn" {
 }
 
 variable "user_pool_client_id" {
-  default = null
-  type    = string
-}
-
-variable "user_pool_client_secret" {
   default = null
   type    = string
 }

--- a/terragrunt/modules/tools/variables.tf
+++ b/terragrunt/modules/tools/variables.tf
@@ -105,6 +105,11 @@ variable "product" {
   })
 }
 
+variable "public_domain" {
+  description = "The fully qualified domain name (FQDN) that may differ from the main delegated domain specified by 'public_hosted_zone_fqdn'. This domain represents the public-facing endpoint."
+  type        = string
+}
+
 variable "public_hosted_zone_id" {
   description = "ID of the public hosted zone"
   type        = string


### PR DESCRIPTION
- Pin production to the next release candidate
- Set Cognito's password validity period 
_(in preparation of hardening the non-prod tools, if we must deploy them to production)_
>Modified components will required double run when applying these changes. 
>First run to allow destruction of the existing subdomains and the second run to provision the new flavour.