### PR TITLE
Do not configure the fake policy evaluator by default

### DIFF
--- a/Libraries/CO.CDP.DataSharing.WebApiClient.Tests/DataSharingClientIntegrationTest.cs
+++ b/Libraries/CO.CDP.DataSharing.WebApiClient.Tests/DataSharingClientIntegrationTest.cs
@@ -15,6 +15,7 @@ public class DataSharingClientIntegrationTest
         {
             builder.ConfigureInMemoryDbContext<OrganisationInformationContext>();
             builder.ConfigureLogging(testOutputHelper);
+            builder.ConfigureFakePolicyEvaluator();
         });
 
         _httpClient = _factory.CreateClient();

--- a/Libraries/CO.CDP.Forms.WebApiClient.Tests/FormsClientIntegrationTest.cs
+++ b/Libraries/CO.CDP.Forms.WebApiClient.Tests/FormsClientIntegrationTest.cs
@@ -11,6 +11,7 @@ public class FormsClientIntegrationTest(ITestOutputHelper testOutputHelper)
     {
         builder.ConfigureInMemoryDbContext<OrganisationInformationContext>();
         builder.ConfigureLogging(testOutputHelper);
+        builder.ConfigureFakePolicyEvaluator();
     });
 
     [Fact]

--- a/Libraries/CO.CDP.Organisation.WebApiClient.Tests/OrganisationClientIntegrationTest.cs
+++ b/Libraries/CO.CDP.Organisation.WebApiClient.Tests/OrganisationClientIntegrationTest.cs
@@ -17,6 +17,7 @@ public class OrganisationClientIntegrationTest
         TestWebApplicationFactory<Program> _factory = new(builder =>
         {
             builder.ConfigureInMemoryDbContext<OrganisationInformationContext>();
+            builder.ConfigureFakePolicyEvaluator();
             builder.ConfigureLogging(testOutputHelper);
             builder.ConfigureServices((_, s) =>
             {

--- a/Services/CO.CDP.Forms.WebApi.Tests/Api/DeleteFormAnswerSetEndpointTest.cs
+++ b/Services/CO.CDP.Forms.WebApi.Tests/Api/DeleteFormAnswerSetEndpointTest.cs
@@ -20,8 +20,10 @@ public class DeleteFormAnswerSetEndpointTest
         TestWebApplicationFactory<Program> factory = new(builder =>
         {
             builder.ConfigureServices(services =>
-                services.AddScoped(_ => _deleteAnswerSetUseCase.Object)
-            );
+            {
+                services.AddScoped(_ => _deleteAnswerSetUseCase.Object);
+                services.ConfigureFakePolicyEvaluator();
+            });
         });
         _httpClient = factory.CreateClient();
     }

--- a/Services/CO.CDP.Forms.WebApi.Tests/Api/GetFormSectionQuestionsTest.cs
+++ b/Services/CO.CDP.Forms.WebApi.Tests/Api/GetFormSectionQuestionsTest.cs
@@ -21,8 +21,10 @@ public class GetFormSectionQuestionsTest
         TestWebApplicationFactory<Program> factory = new(builder =>
         {
             builder.ConfigureServices(services =>
-                services.AddScoped(_ => _getFormSectionQuestionsUseCase.Object)
-            );
+            {
+                services.AddScoped(_ => _getFormSectionQuestionsUseCase.Object);
+                services.ConfigureFakePolicyEvaluator();
+            });
         });
         _httpClient = factory.CreateClient();
     }

--- a/Services/CO.CDP.Forms.WebApi.Tests/Api/GetFormSectionstEndpointTest.cs
+++ b/Services/CO.CDP.Forms.WebApi.Tests/Api/GetFormSectionstEndpointTest.cs
@@ -21,7 +21,11 @@ public class GetFormSectionstEndpointTest
     {
         TestWebApplicationFactory<Program> factory = new(builder =>
         {
-            builder.ConfigureServices(services => services.AddScoped(_ => _useCase.Object));
+            builder.ConfigureServices(services =>
+            {
+                services.AddScoped(_ => _useCase.Object);
+                services.ConfigureFakePolicyEvaluator();
+            });
         });
         _httpClient = factory.CreateClient();
     }

--- a/Services/CO.CDP.Organisation.WebApi.Tests/Api/OrganisationEndpointsTests.cs
+++ b/Services/CO.CDP.Organisation.WebApi.Tests/Api/OrganisationEndpointsTests.cs
@@ -31,6 +31,7 @@ public class OrganisationEndpointsTests
                 services.AddScoped(_ => _getOrganisationsUseCase.Object);
                 services.AddScoped(_ => _getOrganisationUseCase.Object);
                 services.AddScoped(_ => _updatesOrganisationUseCase.Object);
+                services.ConfigureFakePolicyEvaluator();
             });
         });
         _httpClient = factory.CreateClient();

--- a/Services/CO.CDP.Organisation.WebApi.Tests/Api/SupplierInformationEndpointsTests.cs
+++ b/Services/CO.CDP.Organisation.WebApi.Tests/Api/SupplierInformationEndpointsTests.cs
@@ -28,6 +28,7 @@ public class SupplierInformationEndpointsTests
             {
                 services.AddScoped(_ => _getSupplierInformationUseCase.Object);
                 services.AddScoped(_ => _updatesSupplierInformationUseCase.Object);
+                services.ConfigureFakePolicyEvaluator();
             });
         });
         _httpClient = factory.CreateClient();

--- a/Services/CO.CDP.Tenant.WebApi.Tests/Api/TenantLookupTest.cs
+++ b/Services/CO.CDP.Tenant.WebApi.Tests/Api/TenantLookupTest.cs
@@ -22,8 +22,10 @@ public class TenantLookupTest
         TestWebApplicationFactory<Program> factory = new(builder =>
         {
             builder.ConfigureServices(services =>
-                services.AddScoped(_ => _getTenantUseCase.Object)
-            );
+            {
+                services.AddScoped(_ => _getTenantUseCase.Object);
+                services.ConfigureFakePolicyEvaluator();
+            });
         });
         _httpClient = factory.CreateClient();
     }

--- a/TestKit/CO.CDP.TestKit.Mvc/FakePolicyEvaluator.cs
+++ b/TestKit/CO.CDP.TestKit.Mvc/FakePolicyEvaluator.cs
@@ -1,0 +1,26 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Authorization.Policy;
+using Microsoft.AspNetCore.Http;
+
+namespace CO.CDP.TestKit.Mvc;
+
+public class FakePolicyEvaluator : IPolicyEvaluator
+{
+    public async Task<AuthenticateResult> AuthenticateAsync(AuthorizationPolicy policy, HttpContext context)
+    {
+        var principal = new ClaimsPrincipal();
+
+        principal.AddIdentity(new ClaimsIdentity([new Claim("sub", "fake_sub")], "FakeScheme"));
+
+        return await Task.FromResult(AuthenticateResult.Success(new AuthenticationTicket(principal,
+            new AuthenticationProperties(), "FakeScheme")));
+    }
+
+    public async Task<PolicyAuthorizationResult> AuthorizeAsync(
+        AuthorizationPolicy policy, AuthenticateResult authenticationResult, HttpContext context, object? resource)
+    {
+        return await Task.FromResult(PolicyAuthorizationResult.Success());
+    }
+}

--- a/TestKit/CO.CDP.TestKit.Mvc/HostBuilderExtensions.cs
+++ b/TestKit/CO.CDP.TestKit.Mvc/HostBuilderExtensions.cs
@@ -11,4 +11,7 @@ public static class HostBuilderExtensions
 
     public static IHostBuilder ConfigureLogging<TO>(this IHostBuilder builder, TO testOutputHelper) where TO : ITestOutputHelper =>
         builder.ConfigureLogging(logging => logging.AddProvider(testOutputHelper));
+
+    public static IHostBuilder ConfigureFakePolicyEvaluator(this IHostBuilder builder) =>
+        builder.ConfigureServices(services => services.ConfigureFakePolicyEvaluator());
 }

--- a/TestKit/CO.CDP.TestKit.Mvc/ServiceCollectionExtensions.cs
+++ b/TestKit/CO.CDP.TestKit.Mvc/ServiceCollectionExtensions.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Authorization.Policy;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -12,5 +13,10 @@ public static class ServiceCollectionExtensions
             .UseInMemoryDatabase(databaseName: $"db-{Guid.NewGuid()}")
             .Options;
         return services.AddScoped<DbContextOptions<TC>>(_ => dbContextOptions);
+    }
+
+    public static IServiceCollection ConfigureFakePolicyEvaluator(this IServiceCollection serviceCollection)
+    {
+        return serviceCollection.AddSingleton<IPolicyEvaluator, FakePolicyEvaluator>();
     }
 }

--- a/TestKit/CO.CDP.TestKit.Mvc/TestWebApplicationFactory.cs
+++ b/TestKit/CO.CDP.TestKit.Mvc/TestWebApplicationFactory.cs
@@ -1,11 +1,5 @@
-using Microsoft.AspNetCore.Authentication;
-using Microsoft.AspNetCore.Authorization.Policy;
-using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Testing;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using System.Security.Claims;
 
 namespace CO.CDP.TestKit.Mvc;
 
@@ -16,30 +10,6 @@ public class TestWebApplicationFactory<TProgram>(Action<IHostBuilder> configurat
     {
         configurator(builder);
 
-        builder.ConfigureServices(services =>
-        {
-            services.AddSingleton<IPolicyEvaluator, FakePolicyEvaluator>();
-        });
-
         return base.CreateHost(builder);
-    }
-}
-
-public class FakePolicyEvaluator : IPolicyEvaluator
-{
-    public async Task<AuthenticateResult> AuthenticateAsync(AuthorizationPolicy policy, HttpContext context)
-    {
-        var principal = new ClaimsPrincipal();
-
-        principal.AddIdentity(new ClaimsIdentity([new Claim("sub", "fake_sub")], "FakeScheme"));
-
-        return await Task.FromResult(AuthenticateResult.Success(new AuthenticationTicket(principal,
-         new AuthenticationProperties(), "FakeScheme")));
-    }
-
-    public async Task<PolicyAuthorizationResult> AuthorizeAsync(
-        AuthorizationPolicy policy, AuthenticateResult authenticationResult, HttpContext context, object? resource)
-    {
-        return await Task.FromResult(PolicyAuthorizationResult.Success());
     }
 }


### PR DESCRIPTION
This way the application factory is more reusable as it does not make any assumptions about the application.