### PR TITLE
Use identifier and lookup for all join request screens.

### DIFF
--- a/Frontend/CO.CDP.OrganisationApp.Tests/Pages/Registration/CompanyHouseNumberQuestionTests.cs
+++ b/Frontend/CO.CDP.OrganisationApp.Tests/Pages/Registration/CompanyHouseNumberQuestionTests.cs
@@ -111,7 +111,7 @@ public class CompanyHouseNumberQuestionTests
         model.HasCompaniesHouseNumber = true;
         model.RedirectToSummary = true;
         model.CompaniesHouseNumber = "123456";
-        model.OrganisationId = new Guid();
+        model.OrganisationIdentifier = "GB-COH:123456789";
         model.OrganisationName = "Test company";
 
         GivenRegistrationIsInProgress(model.HasCompaniesHouseNumber, model.CompaniesHouseNumber);

--- a/Frontend/CO.CDP.OrganisationApp.Tests/Pages/Registration/JoinOrganisationSuccessTests.cs
+++ b/Frontend/CO.CDP.OrganisationApp.Tests/Pages/Registration/JoinOrganisationSuccessTests.cs
@@ -11,8 +11,8 @@ public class JoinOrganisationSuccessModelTests
 {
     private readonly Mock<IOrganisationClient> _organisationClientMock;
     private readonly JoinOrganisationSuccessModel _joinOrganisationSuccessModel;
+    private readonly string _identifier = "GB-COH:123456789";
     private readonly Guid _organisationId = Guid.NewGuid();
-    private readonly Guid _personId = Guid.NewGuid();
     private readonly CO.CDP.Organisation.WebApiClient.Organisation _organisation;
 
     public JoinOrganisationSuccessModelTests()
@@ -25,29 +25,27 @@ public class JoinOrganisationSuccessModelTests
     [Fact]
     public async Task OnGet_ValidOrganisationId_ReturnsPageResult()
     {
-        var organisationId = Guid.NewGuid();
-
-        _organisationClientMock.Setup(client => client.GetOrganisationAsync(organisationId))
+        _organisationClientMock.Setup(client => client.LookupOrganisationAsync(string.Empty, _identifier))
             .ReturnsAsync(_organisation);
 
-        var result = await _joinOrganisationSuccessModel.OnGet(organisationId);
+        var result = await _joinOrganisationSuccessModel.OnGet(_identifier);
 
         result.Should().BeOfType<PageResult>();
         _joinOrganisationSuccessModel.OrganisationDetails.Should().Be(_organisation);
-        _organisationClientMock.Verify(client => client.GetOrganisationAsync(organisationId), Times.Once);
+        _organisationClientMock.Verify(client => client.LookupOrganisationAsync(string.Empty, _identifier), Times.Once);
     }
 
     [Fact]
     public async Task OnGet_OrganisationNotFound_ReturnsRedirectToPageNotFound()
     {
-        _organisationClientMock.Setup(client => client.GetOrganisationAsync(_organisationId))
+        _organisationClientMock.Setup(client => client.LookupOrganisationAsync(string.Empty, _identifier))
             .ThrowsAsync(new ApiException("Not Found", 404, "Not Found", null, null));
 
-        var result = await _joinOrganisationSuccessModel.OnGet(_organisationId);
+        var result = await _joinOrganisationSuccessModel.OnGet(_identifier);
 
         result.Should().BeOfType<RedirectResult>()
             .Which.Url.Should().Be("/page-not-found");
 
-        _organisationClientMock.Verify(client => client.GetOrganisationAsync(_organisationId), Times.Once);
+        _organisationClientMock.Verify(client => client.LookupOrganisationAsync(string.Empty, _identifier), Times.Once);
     }
 }

--- a/Frontend/CO.CDP.OrganisationApp/Pages/Registration/CompanyHouseNumberQuestion.cshtml.cs
+++ b/Frontend/CO.CDP.OrganisationApp/Pages/Registration/CompanyHouseNumberQuestion.cshtml.cs
@@ -32,12 +32,12 @@ public class CompanyHouseNumberQuestionModel(ISession session,
     [BindProperty]
     public string? FailedCompaniesHouseNumber { get; set; }
 
-    public Guid? OrganisationId;
+    public string? OrganisationIdentifier;
 
     public string? OrganisationName;
 
     public string NotificationBannerCompanyNotFound { get { return "We cannot find your company number on Companies House. If it’s correct continue and enter your details manually."; } }
-    public string NotificationBannerCompanyAlreadyRegistered { get { return "An organisation with this company number already exists. Change the company number or <a class='govuk-notification-banner__link' href='/registration/" + OrganisationId + "/join-organisation'>request to join " + OrganisationName + ".</a>"; } }
+    public string NotificationBannerCompanyAlreadyRegistered { get { return "An organisation with this company number already exists. Change the company number or <a class='govuk-notification-banner__link' href='/registration/" + OrganisationIdentifier + "/join-organisation'>request to join " + OrganisationName + ".</a>"; } }
 
     public void OnGet()
     {
@@ -57,11 +57,11 @@ public class CompanyHouseNumberQuestionModel(ISession session,
         {
             RegistrationDetails.OrganisationIdentificationNumber = CompaniesHouseNumber;
             RegistrationDetails.OrganisationScheme = "GB-COH";
+            OrganisationIdentifier = $"GB-COH:{RegistrationDetails.OrganisationIdentificationNumber}";
 
             try
             {
-                var organisation = await organisationClient.LookupOrganisationAsync(string.Empty, $"GB-COH:{RegistrationDetails.OrganisationIdentificationNumber}");
-                OrganisationId = organisation?.Id;
+                var organisation = await organisationClient.LookupOrganisationAsync(string.Empty, OrganisationIdentifier);
                 OrganisationName = organisation?.Name;
                 tempDataService.Put(FlashMessageTypes.Important, NotificationBannerCompanyAlreadyRegistered);
                 return Page();

--- a/Frontend/CO.CDP.OrganisationApp/Pages/Registration/JoinOrganisation.cshtml
+++ b/Frontend/CO.CDP.OrganisationApp/Pages/Registration/JoinOrganisation.cshtml
@@ -1,4 +1,4 @@
-@page "/registration/{organisationId}/join-organisation"
+@page "/registration/{identifier}/join-organisation"
 @model JoinOrganisationModel
 
 @{

--- a/Frontend/CO.CDP.OrganisationApp/Pages/Registration/JoinOrganisation.cshtml.cs
+++ b/Frontend/CO.CDP.OrganisationApp/Pages/Registration/JoinOrganisation.cshtml.cs
@@ -15,11 +15,11 @@ public class JoinOrganisationModel(
     [Required(ErrorMessage = "Select an option")]
     public bool Join { get; set; }
 
-    public async Task<IActionResult> OnGet(Guid organisationId)
+    public async Task<IActionResult> OnGet(string identifier)
     {
         try
         {
-            OrganisationDetails = await organisationClient.GetOrganisationAsync(organisationId);
+            OrganisationDetails = await organisationClient.LookupOrganisationAsync(string.Empty, $"{identifier}");
             return Page();
         }
         catch (ApiException ex) when (ex.StatusCode == 404)
@@ -28,23 +28,24 @@ public class JoinOrganisationModel(
         }
     }
 
-    public async Task<IActionResult> OnPost(Guid organisationId)
+    public async Task<IActionResult> OnPost(string identifier)
     {
+        OrganisationDetails = await organisationClient.LookupOrganisationAsync(string.Empty, $"{identifier}");
+
         if (!ModelState.IsValid)
         {
-            OrganisationDetails = await organisationClient.GetOrganisationAsync(organisationId);
             return Page();
         }
 
-        if (UserDetails.PersonId != null)
+        if (UserDetails.PersonId != null && OrganisationDetails != null)
         {
             if (Join == true)
             {
-                await organisationClient.CreateJoinRequestAsync(organisationId, new CreateOrganisationJoinRequest(
+                await organisationClient.CreateJoinRequestAsync(OrganisationDetails.Id, new CreateOrganisationJoinRequest(
                     personId: UserDetails.PersonId.Value
                 ));
 
-                return Redirect("/registration/" + organisationId + "/join-organisation/success");
+                return Redirect("/registration/" + identifier + "/join-organisation/success");
             }
 
             return Redirect("/registration/has-companies-house-number");

--- a/Frontend/CO.CDP.OrganisationApp/Pages/Registration/JoinOrganisationSuccess.cshtml
+++ b/Frontend/CO.CDP.OrganisationApp/Pages/Registration/JoinOrganisationSuccess.cshtml
@@ -1,4 +1,4 @@
-@page "/registration/{organisationId}/join-organisation/success"
+@page "/registration/{identifier}/join-organisation/success"
 @model JoinOrganisationSuccessModel
 
 @{

--- a/Frontend/CO.CDP.OrganisationApp/Pages/Registration/JoinOrganisationSuccess.cshtml.cs
+++ b/Frontend/CO.CDP.OrganisationApp/Pages/Registration/JoinOrganisationSuccess.cshtml.cs
@@ -10,11 +10,11 @@ public class JoinOrganisationSuccessModel(
 {
     public OrganisationWebApiClient.Organisation? OrganisationDetails { get; set; }
 
-    public async Task<IActionResult> OnGet(Guid organisationId)
+    public async Task<IActionResult> OnGet(string identifier)
     {
         try
         {
-            OrganisationDetails = await organisationClient.GetOrganisationAsync(organisationId);
+            OrganisationDetails = await organisationClient.LookupOrganisationAsync(string.Empty, $"{identifier}");
             return Page();
         }
         catch (ApiException ex) when (ex.StatusCode == 404)


### PR DESCRIPTION
Without at least the Viewer permission for an organisation, the user does not have access to call the `GetOrganisationAsync` endpoint. This code fixes that by switching to use `LookupOrganisationAsync` instead.