### PR TITLE
DP-761: Disable the HTTPS redirection middleware

### DIFF
--- a/Frontend/CO.CDP.OrganisationApp/Program.cs
+++ b/Frontend/CO.CDP.OrganisationApp/Program.cs
@@ -206,7 +206,6 @@ var localizationOptions = new RequestLocalizationOptions()
 app.UseRequestLocalization(localizationOptions);
 
 app.MapHealthChecks("/health").AllowAnonymous();
-app.UseHttpsRedirection();
 app.UseStaticFiles();
 app.UseRouting();
 app.UseAuthentication();

--- a/Prototype/CompanyHouseApi.Integration/Program.cs
+++ b/Prototype/CompanyHouseApi.Integration/Program.cs
@@ -22,7 +22,6 @@ if (!app.Environment.IsDevelopment())
     app.UseHsts();
 }
 
-app.UseHttpsRedirection();
 app.UseStaticFiles();
 
 app.UseRouting();

--- a/Services/CO.CDP.DataSharing.WebApi/Program.cs
+++ b/Services/CO.CDP.DataSharing.WebApi/Program.cs
@@ -101,7 +101,6 @@ if (!app.Environment.IsDevelopment())
 app.UseStatusCodePages();
 
 app.MapHealthChecks("/health").AllowAnonymous();
-app.UseHttpsRedirection();
 app.UseAuthentication();
 app.UseAuthorization();
 app.UseRequestLocalization();

--- a/Services/CO.CDP.EntityVerification/Program.cs
+++ b/Services/CO.CDP.EntityVerification/Program.cs
@@ -86,7 +86,6 @@ if (!app.Environment.IsDevelopment())
 
 app.UseStatusCodePages();
 app.MapHealthChecks("/health").AllowAnonymous();
-app.UseHttpsRedirection();
 app.UseAuthentication();
 app.UseAuthorization();
 app.UsePponEndpoints();

--- a/Services/CO.CDP.Forms.WebApi/Program.cs
+++ b/Services/CO.CDP.Forms.WebApi/Program.cs
@@ -92,7 +92,6 @@ if (!app.Environment.IsDevelopment())
 app.UseStatusCodePages();
 
 app.MapHealthChecks("/health").AllowAnonymous();
-app.UseHttpsRedirection();
 app.UseAuthentication();
 app.UseAuthorization();
 app.UseFormsEndpoints();

--- a/Services/CO.CDP.Organisation.Authority/Program.cs
+++ b/Services/CO.CDP.Organisation.Authority/Program.cs
@@ -39,7 +39,6 @@ if (Assembly.GetEntryAssembly().IsRunAs("CO.CDP.Organisation.Authority"))
 var app = builder.Build();
 app.UseForwardedHeaders();
 app.MapHealthChecks("/health");
-app.UseHttpsRedirection();
 
 if (builder.Configuration.GetValue("Features:SwaggerUI", false))
 {

--- a/Services/CO.CDP.Organisation.WebApi/Program.cs
+++ b/Services/CO.CDP.Organisation.WebApi/Program.cs
@@ -125,7 +125,6 @@ if (!app.Environment.IsDevelopment())
 app.UseStatusCodePages();
 
 app.MapHealthChecks("/health").AllowAnonymous();
-app.UseHttpsRedirection();
 app.UseAuthentication();
 app.UseAuthorization();
 app.UseOrganisationEndpoints();

--- a/Services/CO.CDP.Person.WebApi/Program.cs
+++ b/Services/CO.CDP.Person.WebApi/Program.cs
@@ -65,7 +65,6 @@ if (!app.Environment.IsDevelopment())
 app.UseStatusCodePages();
 
 app.MapHealthChecks("/health").AllowAnonymous();
-app.UseHttpsRedirection();
 app.UseAuthentication();
 app.UseAuthorization();
 app.UsePersonEndpoints();

--- a/Services/CO.CDP.Tenant.WebApi/Program.cs
+++ b/Services/CO.CDP.Tenant.WebApi/Program.cs
@@ -73,7 +73,6 @@ if (!app.Environment.IsDevelopment())
 app.UseStatusCodePages();
 
 app.MapHealthChecks("/health").AllowAnonymous();
-app.UseHttpsRedirection();
 app.UseAuthentication();
 app.UseAuthorization();
 app.UseTenantEndpoints();

--- a/terragrunt/tools/healthcheck-service/healthCheck/Startup.cs
+++ b/terragrunt/tools/healthcheck-service/healthCheck/Startup.cs
@@ -68,7 +68,6 @@ namespace healthCheck
                 app.UseHsts();
             }
 
-            app.UseHttpsRedirection();
             app.UseStaticFiles();
 
             app.Use(async (context, next) =>


### PR DESCRIPTION
All services are running behind a load balancer that is responsible for ssl termination. There is no need to do https redictions as all services are always behind https.