### PR TITLE
Update to RemovePersonFromOrganisationUseCase.Execute

### DIFF
--- a/Services/CO.CDP.Organisation.WebApi.Tests/UseCase/RemovePersonFromOrganisationUseCaseTest.cs
+++ b/Services/CO.CDP.Organisation.WebApi.Tests/UseCase/RemovePersonFromOrganisationUseCaseTest.cs
@@ -12,7 +12,7 @@ public class RemovePersonFromOrganisationUseCaseTest
     private RemovePersonFromOrganisationUseCase UseCase => new(_organisationRepository.Object, _personRepository.Object);
 
     [Fact]
-    public async Task Execute_SuccessfulRemoval_ReturnsTrue()
+    public async Task Execute_OrganisationPersonAndPersonWithTenant_ReturnsTrue()
     {
         var person = new OrganisationInformation.Persistence.Person { Id = 1, Guid = Guid.NewGuid(), FirstName = "Tom", LastName = "Smith", Email = "js@biz.com" };
         var organisation = new OrganisationInformation.Persistence.Organisation
@@ -33,5 +33,75 @@ public class RemovePersonFromOrganisationUseCaseTest
 
         result.Should().BeTrue();
         _organisationRepository.Verify(r => r.Save(organisation), Times.Once);
+    }
+
+    [Fact]
+    public async Task Execute_NoOrganisationPerson_ReturnsTrue()
+    {
+        var person = new OrganisationInformation.Persistence.Person { Id = 1, Guid = Guid.NewGuid(), FirstName = "Tom", LastName = "Smith", Email = "js@biz.com" };
+        var organisation = new OrganisationInformation.Persistence.Organisation
+        {
+            Id = 1,
+            Guid = Guid.NewGuid(),
+            Name = "Acme",
+            OrganisationPersons = [],
+            Tenant = new Tenant { Guid = Guid.NewGuid(), Name = "A Tenant" }
+        };
+
+        var command = (organisation.Guid, new RemovePersonFromOrganisation { PersonId = person.Guid });
+        _organisationRepository.Setup(r => r.Find(command.Item1)).ReturnsAsync(organisation);
+        _personRepository.Setup(r => r.FindByOrganisation(command.Item1)).ReturnsAsync(new List<OrganisationInformation.Persistence.Person> { person });
+        _personRepository.Setup(r => r.FindPersonWithTenant(person.Guid)).ReturnsAsync(person);
+
+        var result = await UseCase.Execute(command);
+
+        result.Should().BeTrue();
+        _organisationRepository.Verify(r => r.Save(organisation), Times.Once);
+    }
+
+    [Fact]
+    public async Task Execute_NoPersonWithTenant_ReturnsTrue()
+    {
+        var person = new OrganisationInformation.Persistence.Person { Id = 1, Guid = Guid.NewGuid(), FirstName = "Tom", LastName = "Smith", Email = "js@biz.com" };
+        var organisation = new OrganisationInformation.Persistence.Organisation
+        {
+            Id = 1,
+            Guid = Guid.NewGuid(),
+            Name = "Acme",
+            OrganisationPersons = [new OrganisationPerson { PersonId = 1, Person = person, Organisation = Mock.Of<OrganisationInformation.Persistence.Organisation>() }],
+            Tenant = new Tenant { Guid = Guid.NewGuid(), Name = "A Tenant" }
+        };
+
+        var command = (organisation.Guid, new RemovePersonFromOrganisation { PersonId = person.Guid });
+        _organisationRepository.Setup(r => r.Find(command.Item1)).ReturnsAsync(organisation);
+        _personRepository.Setup(r => r.FindByOrganisation(command.Item1)).ReturnsAsync(new List<OrganisationInformation.Persistence.Person> { person });
+        
+        var result = await UseCase.Execute(command);
+
+        result.Should().BeTrue();
+        _organisationRepository.Verify(r => r.Save(organisation), Times.Once);
+    }
+
+    [Fact]
+    public async Task Execute_NoOrganisationPersonNoPersonWithTenant_ReturnsFalse()
+    {
+        var person = new OrganisationInformation.Persistence.Person { Id = 1, Guid = Guid.NewGuid(), FirstName = "Tom", LastName = "Smith", Email = "js@biz.com" };
+        var organisation = new OrganisationInformation.Persistence.Organisation
+        {
+            Id = 1,
+            Guid = Guid.NewGuid(),
+            Name = "Acme",
+            OrganisationPersons = [],
+            Tenant = new Tenant { Guid = Guid.NewGuid(), Name = "A Tenant" }
+        };
+
+        var command = (organisation.Guid, new RemovePersonFromOrganisation { PersonId = person.Guid });
+        _organisationRepository.Setup(r => r.Find(command.Item1)).ReturnsAsync(organisation);
+        _personRepository.Setup(r => r.FindByOrganisation(command.Item1)).ReturnsAsync(new List<OrganisationInformation.Persistence.Person> { person });
+
+        var result = await UseCase.Execute(command);
+
+        result.Should().BeFalse();
+        _organisationRepository.Verify(r => r.Save(organisation), Times.Never);
     }
 }

--- a/Services/CO.CDP.Organisation.WebApi/UseCase/RemovePersonFromOrganisationUseCase.cs
+++ b/Services/CO.CDP.Organisation.WebApi/UseCase/RemovePersonFromOrganisationUseCase.cs
@@ -17,15 +17,19 @@ public class RemovePersonFromOrganisationUseCase(IOrganisationRepository organis
         if (person == null) return await Task.FromResult(false);
 
         var organisationPerson = organisation.OrganisationPersons.FindLast(op => op.PersonId == person.Id);
-
-        if (organisationPerson == null) return await Task.FromResult(false);
-
         var personWithTenant = await personRepository.FindPersonWithTenant(person.Guid);
 
-        if (personWithTenant == null) return await Task.FromResult(false);
+        if (organisationPerson == null && personWithTenant == null) return await Task.FromResult(false);
 
-        organisation.Tenant.Persons.Remove(person);
-        organisation.OrganisationPersons.Remove(organisationPerson);
+        if (personWithTenant != null)
+        {
+            organisation.Tenant.Persons.Remove(person);
+        }
+
+        if (organisationPerson != null)
+        {
+            organisation.OrganisationPersons.Remove(organisationPerson);
+        }
 
         organisationRepository.Save(organisation);
 


### PR DESCRIPTION
RemovePersonFromOrganisationUseCase.Execute returns False only if corresponding records not found in Organisation_Person and Tenant_Person tables.