### PR TITLE
DP-838 Allow unauthenticated calls to organisation-app's /one-login/back-channel-sign-out

### DIFF
--- a/terragrunt/modules/auth/organisation-app.tf
+++ b/terragrunt/modules/auth/organisation-app.tf
@@ -13,7 +13,7 @@ resource "aws_cognito_user_pool_client" "organisation_app" {
     "ALLOW_REFRESH_TOKEN_AUTH"
   ]
   generate_secret = true
-  logout_urls     = ["${local.organisation_app_url}/logout"]
+  logout_urls     = ["${local.organisation_app_url}/one-login/back-channel-sign-out"]
 
   supported_identity_providers = ["COGNITO"]
   user_pool_id                 = aws_cognito_user_pool.auth.id

--- a/terragrunt/modules/ecs-service/locals.tf
+++ b/terragrunt/modules/ecs-service/locals.tf
@@ -1,4 +1,5 @@
 locals {
-  tg_host_header            = ["${var.name}.${var.public_domain}"]
-  tg_host_header_with_alias = ["${var.name}.${var.public_domain}", var.public_domain]
+  tg_host_header                 = ["${var.name}.${var.public_domain}"]
+  tg_host_header_with_alias      = ["${var.name}.${var.public_domain}", var.public_domain]
+  service_listener_rule_priority = var.family == "app" ? var.host_port - 8000 : var.host_port
 }

--- a/terragrunt/modules/ecs-service/variables.tf
+++ b/terragrunt/modules/ecs-service/variables.tf
@@ -126,6 +126,12 @@ variable "tags" {
   type        = map(string)
 }
 
+variable "allowed_unauthenticated_paths" {
+  description = "List of paths allowed access to protected services, bypassing Cognito authentication."
+  type        = list(string)
+  default     = []
+}
+
 variable "unhealthy_threshold" {
   description = "Number of consecutive health check failures required before considering a target unhealthy. The range is 2-10. Defaults to 3."
   type        = number

--- a/terragrunt/modules/ecs/service-organisation-app.tf
+++ b/terragrunt/modules/ecs/service-organisation-app.tf
@@ -72,6 +72,7 @@ module "ecs_service_organisation_app" {
   role_ecs_task_arn      = var.role_ecs_task_arn
   role_ecs_task_exec_arn = var.role_ecs_task_exec_arn
   tags                   = var.tags
+  allowed_unauthenticated_paths = ["/one-login/back-channel-sign-out", "/assets/*", "/css/*", "/manifest.json"]
   user_pool_arn          = var.user_pool_arn
   user_pool_client_id    = var.user_pool_client_id
   user_pool_domain       = var.user_pool_domain


### PR DESCRIPTION
  - As well as its assets

This change has been applied to the [development environment](https://dev.supplier.information.findatender.codatt.net/one-login/back-channel-sign-out) and can be cross-checked with [staging](https://staging.supplier.information.findatender.codatt.net/one-login/back-channel-sign-out) or other accounts.

We are currently receiving a 500 HTTP response instead of the expected 405. However, this issue is likely related to the application itself rather than the lifted restriction in this PR.