### PR TITLE
DP-837 Improve deployment notifications

### DIFF
--- a/terragrunt/components/orchestrator/common/terragrunt.hcl
+++ b/terragrunt/components/orchestrator/common/terragrunt.hcl
@@ -1,0 +1,34 @@
+terraform {
+  source = local.global_vars.locals.environment == "orchestrator" ? "../../../modules//orchestrator/common" : null
+}
+
+include {
+  path = find_in_parent_folders()
+}
+
+locals {
+  global_vars = read_terragrunt_config(find_in_parent_folders("terragrunt.hcl"))
+  orchestrator_vars = read_terragrunt_config(find_in_parent_folders("orchestrator.hcl"))
+
+  exclude_list = ["orchestrator"]
+
+  pinned_service_versions = {
+    for key, env in local.global_vars.locals.environments :
+    key => try(env.pinned_service_version, null) if !(contains(local.exclude_list, env.name))
+  }
+
+  tags = merge(
+    local.global_vars.inputs.tags,
+    local.orchestrator_vars.inputs.tags,
+    {
+      component = "common"
+    }
+  )
+
+}
+
+inputs = {
+
+  pinned_service_versions = local.pinned_service_versions
+  tags                    = local.tags
+}

--- a/terragrunt/components/orchestrator/notification/terragrunt.hcl
+++ b/terragrunt/components/orchestrator/notification/terragrunt.hcl
@@ -46,6 +46,13 @@ dependency orchestrator_ci {
   }
 }
 
+dependency orchestrator_common {
+  config_path = "../common"
+  mock_outputs = {
+    ssm_envs_service_version_name = "mock"
+  }
+}
+
 dependency orchestrator_ecr {
   config_path = "../ecr"
   mock_outputs = {
@@ -67,6 +74,7 @@ inputs = {
 
   deployment_pipeline_name                   = dependency.orchestrator_ci.outputs.deployment_pipeline_name
   event_rule_ci_service_version_updated_name = dependency.orchestrator_ci.outputs.event_rule_ci_service_version_updated_name
-  ssm_service_version_arn                    = dependency.orchestrator_ci.outputs.ssm_service_version_arn
-  ssm_service_version_name                   = dependency.orchestrator_ci.outputs.ssm_service_version_name
+
+  ssm_envs_service_version_arn  = dependency.orchestrator_common.outputs.ssm_envs_service_version_arn
+  ssm_envs_service_version_name = dependency.orchestrator_common.outputs.ssm_envs_service_version_name
 }

--- a/terragrunt/modules/ecs-service/listeners.tf
+++ b/terragrunt/modules/ecs-service/listeners.tf
@@ -76,7 +76,7 @@ resource "aws_lb_listener_rule" "this_allowed_unauthenticated_paths" {
 
   listener_arn = var.ecs_listener_arn
   // To ensure overriding the authenticated rule. @TODO (ABN) (GO Live) Remove when removing Cognito
-  priority     = local.service_listener_rule_priority - 55
+  priority = local.service_listener_rule_priority - 55
 
   action {
     type             = "forward"

--- a/terragrunt/modules/ecs/service-organisation-app.tf
+++ b/terragrunt/modules/ecs/service-organisation-app.tf
@@ -54,27 +54,27 @@ module "ecs_service_organisation_app" {
     }
   )
 
-  cluster_id             = aws_ecs_cluster.this.id
-  container_port         = var.service_configs.organisation_app.port
-  cpu                    = var.service_configs.organisation_app.cpu
-  desired_count          = var.service_configs.organisation_app.desired_count
-  ecs_alb_sg_id          = var.alb_sg_id
-  ecs_listener_arn       = aws_lb_listener.ecs.arn
-  ecs_service_base_sg_id = var.ecs_sg_id
-  family                 = "app"
-  host_port              = var.service_configs.organisation_app.port
-  is_frontend_app        = true
-  memory                 = var.service_configs.organisation_app.memory
-  name                   = var.service_configs.organisation_app.name
-  private_subnet_ids     = var.private_subnet_ids
-  product                = var.product
-  public_domain          = var.public_domain
-  role_ecs_task_arn      = var.role_ecs_task_arn
-  role_ecs_task_exec_arn = var.role_ecs_task_exec_arn
-  tags                   = var.tags
+  cluster_id                    = aws_ecs_cluster.this.id
+  container_port                = var.service_configs.organisation_app.port
+  cpu                           = var.service_configs.organisation_app.cpu
+  desired_count                 = var.service_configs.organisation_app.desired_count
+  ecs_alb_sg_id                 = var.alb_sg_id
+  ecs_listener_arn              = aws_lb_listener.ecs.arn
+  ecs_service_base_sg_id        = var.ecs_sg_id
+  family                        = "app"
+  host_port                     = var.service_configs.organisation_app.port
+  is_frontend_app               = true
+  memory                        = var.service_configs.organisation_app.memory
+  name                          = var.service_configs.organisation_app.name
+  private_subnet_ids            = var.private_subnet_ids
+  product                       = var.product
+  public_domain                 = var.public_domain
+  role_ecs_task_arn             = var.role_ecs_task_arn
+  role_ecs_task_exec_arn        = var.role_ecs_task_exec_arn
+  tags                          = var.tags
   allowed_unauthenticated_paths = ["/one-login/back-channel-sign-out", "/assets/*", "/css/*", "/manifest.json"]
-  user_pool_arn          = var.user_pool_arn
-  user_pool_client_id    = var.user_pool_client_id
-  user_pool_domain       = var.user_pool_domain
-  vpc_id                 = var.vpc_id
+  user_pool_arn                 = var.user_pool_arn
+  user_pool_client_id           = var.user_pool_client_id
+  user_pool_domain              = var.user_pool_domain
+  vpc_id                        = var.vpc_id
 }

--- a/terragrunt/modules/orchestrator/canary/variables.tf
+++ b/terragrunt/modules/orchestrator/canary/variables.tf
@@ -88,11 +88,6 @@ variable "role_terraform_arn" {
   type        = string
 }
 
-variable "role_terraform_name" {
-  description = "Terraform IAM role name"
-  type        = string
-}
-
 variable "tags" {
   description = "Tags to apply to all resources in this module"
   type        = map(string)

--- a/terragrunt/modules/orchestrator/common/datasource.tf
+++ b/terragrunt/modules/orchestrator/common/datasource.tf
@@ -1,0 +1,7 @@
+data "aws_caller_identity" "current" {}
+
+data "aws_region" "current" {}
+
+data "aws_ssm_parameter" "cdp_sirsi_service_version" {
+  name = "cdp-sirsi-service-version"
+}

--- a/terragrunt/modules/orchestrator/common/locals.tf
+++ b/terragrunt/modules/orchestrator/common/locals.tf
@@ -1,0 +1,6 @@
+locals {
+  envs_service_version = jsonencode({
+    for env, version in var.pinned_service_versions : env => coalesce(version, data.aws_ssm_parameter.cdp_sirsi_service_version.value)
+  })
+  name_prefix = var.product.resource_name
+}

--- a/terragrunt/modules/orchestrator/common/outputs.tf
+++ b/terragrunt/modules/orchestrator/common/outputs.tf
@@ -1,0 +1,7 @@
+output "ssm_envs_service_version_arn" {
+  value = aws_ssm_parameter.service_versions.arn
+}
+
+output "ssm_envs_service_version_name" {
+  value = aws_ssm_parameter.service_versions.name
+}

--- a/terragrunt/modules/orchestrator/common/ssm.tf
+++ b/terragrunt/modules/orchestrator/common/ssm.tf
@@ -1,0 +1,7 @@
+resource "aws_ssm_parameter" "service_versions" {
+  description = "This parameter stores the service version pinned for all accounts"
+  value       = local.envs_service_version
+  name        = "${local.name_prefix}-envs-service-version"
+  tags        = var.tags
+  type        = "String"
+}

--- a/terragrunt/modules/orchestrator/common/variables.tf
+++ b/terragrunt/modules/orchestrator/common/variables.tf
@@ -1,0 +1,18 @@
+variable "pinned_service_versions" {
+  description = "Specifies the pinned service versions for each environment, if defined."
+  type        = map(string)
+}
+
+variable "product" {
+  description = "product's common attributes"
+  type = object({
+    name               = string
+    resource_name      = string
+    public_hosted_zone = string
+  })
+}
+
+variable "tags" {
+  description = "Tags to apply to all resources in this module"
+  type        = map(string)
+}

--- a/terragrunt/modules/orchestrator/notification/cloudwatch.tf
+++ b/terragrunt/modules/orchestrator/notification/cloudwatch.tf
@@ -26,12 +26,6 @@ resource "aws_cloudwatch_event_connection" "slack_unified_notification" {
   }
 }
 
-resource "aws_cloudwatch_event_target" "service_version_slack_notification" {
-  arn      = aws_sfn_state_machine.slack_notification.arn
-  role_arn = var.role_cloudwatch_events_arn
-  rule     = var.event_rule_ci_service_version_updated_name
-}
-
 resource "aws_cloudwatch_event_rule" "deployment_codebuild" {
 
   name        = "${local.name_prefix}-ci-deployment-codebuild"

--- a/terragrunt/modules/orchestrator/notification/datasource.tf
+++ b/terragrunt/modules/orchestrator/notification/datasource.tf
@@ -70,7 +70,7 @@ data "aws_iam_policy_document" "notification_step_function" {
       "ssm:GetParameter"
     ]
     resources = [
-      var.ssm_service_version_arn
+      var.ssm_envs_service_version_arn
     ]
   }
 

--- a/terragrunt/modules/orchestrator/notification/step-function.tf
+++ b/terragrunt/modules/orchestrator/notification/step-function.tf
@@ -15,11 +15,12 @@ resource "aws_sfn_state_machine" "slack_notification" {
   tags     = var.tags
 
   definition = templatefile("${path.module}/templates/state-machine/send-slack-notification.json.tftpl", {
-    auth_connection_arn   = aws_cloudwatch_event_connection.slack_unified_notification.arn
-    dynamodb_table_name   = aws_dynamodb_table.pipeline_execution_timestamps.name
-    slack_channel_id      = var.slack_channel_id
-    slack_post_endpoint   = "${local.slack_api_endpoint}/chat.postMessage"
-    slack_update_endpoint = "${local.slack_api_endpoint}/chat.update"
+    auth_connection_arn           = aws_cloudwatch_event_connection.slack_unified_notification.arn
+    dynamodb_table_name           = aws_dynamodb_table.pipeline_execution_timestamps.name
+    ssm_envs_service_version_name = var.ssm_envs_service_version_name
+    slack_channel_id              = var.slack_channel_id
+    slack_post_endpoint           = "${local.slack_api_endpoint}/chat.postMessage"
+    slack_update_endpoint         = "${local.slack_api_endpoint}/chat.update"
   })
 }
 

--- a/terragrunt/modules/orchestrator/notification/templates/state-machine/send-slack-notification.json.tftpl
+++ b/terragrunt/modules/orchestrator/notification/templates/state-machine/send-slack-notification.json.tftpl
@@ -16,7 +16,7 @@
               "StringMatches": "STARTED"
             }
           ],
-          "Next": "Create Message"
+          "Next": "Get Envs Service Versions"
         },
         {
           "And": [
@@ -33,6 +33,24 @@
         }
       ],
       "Default": "Update Message"
+    },
+    "Get Envs Service Versions": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::aws-sdk:ssm:getParameter",
+      "Parameters": {
+        "Name": "${ssm_envs_service_version_name}",
+        "WithDecryption": true
+      },
+      "ResultPath": "$.serviceVersions",
+      "Next": "Parse Service Versions"
+    },
+    "Parse Service Versions": {
+    "Type": "Pass",
+      "Parameters": {
+        "parsedServiceVersions.$": "States.StringToJson($.serviceVersions.Parameter.Value)"
+      },
+      "ResultPath": "$.parsedServiceVersions",
+      "Next": "Create Message"
     },
     "Create Message": {
       "Type": "Task",
@@ -71,6 +89,22 @@
               },
               "cdp-sirsi-deployment-to-production": {
                 "S.$": "States.Format(':white_circle: ` PENDING ` @ `{}....`', $.time)"
+              }
+            }
+          },
+          "Versions": {
+            "M": {
+              "development": {
+                "S.$": "$.parsedServiceVersions.parsedServiceVersions['development']"
+              },
+              "staging": {
+                "S.$": "$.parsedServiceVersions.parsedServiceVersions['staging']"
+              },
+              "integration": {
+                "S.$": "$.parsedServiceVersions.parsedServiceVersions['integration']"
+              },
+              "production": {
+                "S.$": "$.parsedServiceVersions.parsedServiceVersions['production']"
               }
             }
           }
@@ -190,7 +224,7 @@
       "InputPath": "$.dynamoResult.Attributes",
       "Parameters": {
         "formattedMessage": {
-          "text.$": "States.Format(':github: Git commit: {}\n```{}```\n:aws-codepipeline: AWS Execution ID: <https://eu-west-2.console.aws.amazon.com/codesuite/codepipeline/pipelines/cdp-sirsi-deployment/executions/{}/visualization?region=eu-west-2|{}>\n*Started Deployment Pipeline:* \n{} Pull *Source Code*\n{} Update *Orchestrator*\n{} Update *Development*\n{} Update *Staging*\n{} Update *Integration*\n{} Update *Production*', $.commit_link.S, $.commit_message.S, $.pipeline_execution_id.S,$.pipeline_execution_id.S,$.stages.M.Source.S,$.stages.M['cdp-sirsi-deployment-to-orchestrator'].S, $.stages.M['cdp-sirsi-deployment-to-development'].S, $.stages.M['cdp-sirsi-deployment-to-staging'].S, $.stages.M['cdp-sirsi-deployment-to-integration'].S, $.stages.M['cdp-sirsi-deployment-to-production'].S)"
+          "text.$": "States.Format(':github: Git commit: {}\n```{}```\n:aws-codepipeline: AWS Execution ID: <https://eu-west-2.console.aws.amazon.com/codesuite/codepipeline/pipelines/cdp-sirsi-deployment/executions/{}/visualization?region=eu-west-2|{}>\n*Started Deployment Pipeline:* \n{} Pull *Source Code*\n{} Update *Orchestrator*\n{} Deploy `v{}` to *Development*\n{} Deploy `v{}` to *Staging*\n{} Deploy `v{}` to *Integration*\n{} Deploy `v{}` to *Production*', $.commit_link.S, $.commit_message.S, $.pipeline_execution_id.S,$.pipeline_execution_id.S,$.stages.M.Source.S,$.stages.M['cdp-sirsi-deployment-to-orchestrator'].S, $.stages.M['cdp-sirsi-deployment-to-development'].S, $.Versions.M['development'].S, $.stages.M['cdp-sirsi-deployment-to-staging'].S, $.Versions.M['staging'].S, $.stages.M['cdp-sirsi-deployment-to-integration'].S, $.Versions.M['integration'].S, $.stages.M['cdp-sirsi-deployment-to-production'].S, $.Versions.M['production'].S)"
         }
       },
       "ResultPath": "$.formattedMessage",

--- a/terragrunt/modules/orchestrator/notification/variables.tf
+++ b/terragrunt/modules/orchestrator/notification/variables.tf
@@ -43,13 +43,13 @@ variable "slack_channel_id" {
   default     = "C07FUD6GL7R"
 }
 
-variable "ssm_service_version_arn" {
-  description = "ARN of the parameter holding the service version"
+variable "ssm_envs_service_version_arn" {
+  description = "ARN of the parameter holding the service versions for all environments"
   type        = string
 }
 
-variable "ssm_service_version_name" {
-  description = "Name of the parameter holding the service version"
+variable "ssm_envs_service_version_name" {
+  description = "Name of the parameter holding the service versions for all environments"
   type        = string
 }
 

--- a/terragrunt/modules/tools/secrets.tf
+++ b/terragrunt/modules/tools/secrets.tf
@@ -18,5 +18,5 @@ resource "aws_secretsmanager_secret_version" "pgadmin_credentials_version" {
 }
 
 data "aws_secretsmanager_secret" "pgadmin_production_support_users" {
-  name        = "${local.name_prefix}-${var.pgadmin_config.name}-production-support-users"
+  name = "${local.name_prefix}-${var.pgadmin_config.name}-production-support-users"
 }


### PR DESCRIPTION
  - Include application version deploying to each account
  - Add orchestrator/common component, holding SSM for all envs versions
  - Remove target triggered by service-version parameter update

**Before:**
![image](https://github.com/user-attachments/assets/b138a9f8-65f1-454b-8e0b-35eb993265ac)

**After:**
![image](https://github.com/user-attachments/assets/81335685-c55b-45cd-8a89-375c7e1d5d9f)

**Step-function changes:**
![image](https://github.com/user-attachments/assets/1906df24-2b97-4437-a1ba-6a222d970b3c)
