### PR TITLE
DP-885 Configure FTS DB instance's parameter groups

### DIFF
--- a/terragrunt/modules/externals/database/locals.tf
+++ b/terragrunt/modules/externals/database/locals.tf
@@ -5,8 +5,12 @@ locals {
     character_set_database = "latin1"
     character_set_server = "latin1"
     collation_server = "latin1_swedish_ci"
-    explicit_defaults_for_timestamp = false
-    sql_mode = "NO_ENGINE_SUBSTITUTION"
+    explicit_defaults_for_timestamp = 0
+    sql_mode = "NO_ENGINE_SUBSTITUTION,STRICT_TRANS_TABLES"
+  }
+
+  db_parameters_instance = {
+    sql_mode = "NO_ENGINE_SUBSTITUTION,STRICT_TRANS_TABLES"
   }
 
 }

--- a/terragrunt/modules/externals/database/rds-fts.tf
+++ b/terragrunt/modules/externals/database/rds-fts.tf
@@ -5,6 +5,7 @@ module "rds_fts" {
   copy_tags_to_snapshot        = true
   db_name                      = local.name_prefix
   db_parameters_cluster        = local.db_parameters_cluster
+  db_parameters_instance       = local.db_parameters_instance
   db_sg_id                     = var.db_mysql_sg_id
   deletion_protection          = var.is_production
   engine_version               = "8.0.mysql_aurora.3.07.1"

--- a/terragrunt/modules/rds-cluster/parameter-groups.tf
+++ b/terragrunt/modules/rds-cluster/parameter-groups.tf
@@ -1,0 +1,33 @@
+
+resource "aws_db_parameter_group" "this" {
+  family = var.family
+  name   = "${var.db_name}-instance"
+
+  dynamic "parameter" {
+    for_each = var.db_parameters_instance
+    content {
+      apply_method = "pending-reboot"
+      name         = parameter.key
+      value        = parameter.value
+    }
+  }
+
+  tags = var.tags
+}
+
+
+resource "aws_rds_cluster_parameter_group" "this" {
+  family      = var.family
+  name        = "${var.db_name}-cluster"
+
+  dynamic "parameter" {
+    for_each = var.db_parameters_cluster
+    content {
+      apply_method = "pending-reboot"
+      name         = parameter.key
+      value        = parameter.value
+    }
+  }
+
+  tags = var.tags
+}

--- a/terragrunt/modules/rds-cluster/rds-cluster.tf
+++ b/terragrunt/modules/rds-cluster/rds-cluster.tf
@@ -38,6 +38,7 @@ resource "aws_rds_cluster_instance" "this" {
   count = var.instance_count
 
   cluster_identifier           = aws_rds_cluster.this.id
+  db_parameter_group_name      = aws_db_parameter_group.this.name
   engine                       = var.engine
   identifier                   = "${var.db_name}-${count.index}"
   instance_class               = var.instance_type
@@ -52,45 +53,4 @@ resource "aws_rds_cluster_instance" "this" {
       Name = "${replace(var.db_name, "-", "_")}-${count.index}"
     }
   )
-}
-
-resource "aws_db_parameter_group" "this" {
-  family = var.family
-  name   = "${var.db_name}-instance"
-
-  dynamic "parameter" {
-    for_each = var.db_parameters_instance
-    content {
-      apply_method = "pending-reboot"
-      name         = parameter.key
-      value        = parameter.value
-    }
-  }
-
-  lifecycle {
-    create_before_destroy = true
-  }
-
-  tags = var.tags
-}
-
-
-resource "aws_rds_cluster_parameter_group" "this" {
-  family      = var.family
-  name        = "${var.db_name}-cluster"
-
-  dynamic "parameter" {
-    for_each = var.db_parameters_cluster
-    content {
-      apply_method = "pending-reboot"
-      name         = parameter.key
-      value        = parameter.value
-    }
-  }
-
-  lifecycle {
-    create_before_destroy = true
-  }
-
-  tags = var.tags
 }


### PR DESCRIPTION
  - Keep default `STRICT_TRANS_TABLES` in `sql_mod`
  - Noticed it will remain in `@@sql_mode` even after re-provisioning cluster, but removed from global vars
  - Attach instance Parameter Group
  - Move Parameter Groups to a separate file 
  
![image](https://github.com/user-attachments/assets/27484ecb-9e15-4caa-a1c2-5afd0f977192)
