### PR TITLE
DP-912 - Clicking the Back link on the Connected Persons remove page leads to a Page Not Found error.

### DIFF
--- a/Frontend/CO.CDP.OrganisationApp/Pages/Supplier/ConnectedEntity/ConnectedEntityRemoveConfirmation.cshtml
+++ b/Frontend/CO.CDP.OrganisationApp/Pages/Supplier/ConnectedEntity/ConnectedEntityRemoveConfirmation.cshtml
@@ -12,7 +12,7 @@
 }
 
 @section BeforeContent {
-    <a href="/organisation/@Model.Id/supplier-information/connected-person-summary" class="govuk-back-link">@StaticTextResource.Global_Back</a>
+    <a href="/organisation/@Model.Id/supplier-information/connected-person/connected-person-summary" class="govuk-back-link">@StaticTextResource.Global_Back</a>
 }
 
 <div class="govuk-grid-row">


### PR DESCRIPTION
DP-912 - Clicking the Back link on the Connected Persons remove page leads to a Page Not Found error.