### PR TITLE
DP-925 Provision ElastiCache replication group, within private subnets using new module

### DIFF
--- a/terragrunt/components/service/cache/terragrunt.hcl
+++ b/terragrunt/components/service/cache/terragrunt.hcl
@@ -1,0 +1,45 @@
+terraform {
+  source = local.global_vars.locals.environment != "orchestrator" ? "../../../modules//elasticache" : null
+}
+
+include {
+  path = find_in_parent_folders()
+}
+
+locals {
+  global_vars = read_terragrunt_config(find_in_parent_folders("terragrunt.hcl"))
+  service_vars = read_terragrunt_config(find_in_parent_folders("service.hcl"))
+
+  tags = merge(
+    local.global_vars.inputs.tags,
+    local.service_vars.inputs.tags,
+    {
+      component = "cache"
+    }
+  )
+
+}
+
+dependency core_networking {
+  config_path = "../../core/networking"
+  mock_outputs = {
+    private_subnets             = "mock"
+    private_subnets_cidr_blocks = "mock"
+  }
+}
+
+dependency core_security_groups {
+  config_path = "../../core/security-groups"
+  mock_outputs = {
+    elasticache_redis_sg_id = "mock"
+  }
+}
+
+inputs = {
+  tags = local.tags
+
+  private_subnet_ids          = dependency.core_networking.outputs.private_subnet_ids
+  private_subnets_cidr_blocks = dependency.core_networking.outputs.private_subnets_cidr_blocks
+
+  elasticache_redis_sg_id = dependency.core_security_groups.outputs.elasticache_redis_sg_id
+}

--- a/terragrunt/modules/core-iam/terraform-global-datasource.tf
+++ b/terragrunt/modules/core-iam/terraform-global-datasource.tf
@@ -92,6 +92,7 @@ data "aws_iam_policy_document" "terraform_global" {
       "ec2:DescribeAccountAttributes",
       "ec2:DescribeAddresses",
       "ec2:DescribeAddressesAttribute",
+      "ec2:DescribeAvailabilityZones",
       "ec2:DescribeInternetGateways",
       "ec2:DescribeNatGateways",
       "ec2:DescribeNetworkInterfaces",
@@ -192,7 +193,15 @@ data "aws_iam_policy_document" "terraform_global" {
 
   statement {
     actions = [
+      "logs:CreateLogDelivery",
+      "logs:DeleteLogDelivery",
+      "logs:DeleteResourcePolicy",
       "logs:DescribeLogGroups",
+      "logs:DescribeResourcePolicies",
+      "logs:GetLogDelivery",
+      "logs:ListLogDeliveries",
+      "logs:PutResourcePolicy",
+      "logs:UpdateLogDelivery",
     ]
     effect = "Allow"
     resources = [

--- a/terragrunt/modules/core-iam/terraform-product-data-datasource.tf
+++ b/terragrunt/modules/core-iam/terraform-product-data-datasource.tf
@@ -1,0 +1,80 @@
+data "aws_iam_policy_document" "terraform_product_data" {
+
+  statement {
+    actions = [
+      "elasticache:AddTagsToResource",
+      "elasticache:CreateCacheParameterGroup",
+      "elasticache:CreateCacheSubnetGroup",
+      "elasticache:CreateReplicationGroup",
+      "elasticache:DeleteCacheParameterGroup",
+      "elasticache:DeleteCacheSubnetGroup",
+      "elasticache:DeleteReplicationGroup",
+      "elasticache:DescribeCacheClusters",
+      "elasticache:DescribeCacheParameterGroups",
+      "elasticache:DescribeCacheParameters",
+      "elasticache:DescribeCacheSubnetGroups",
+      "elasticache:DescribeReplicationGroups",
+      "elasticache:ListTagsForResource",
+      "elasticache:ModifyReplicationGroup",
+    ]
+    effect = "Allow"
+    resources = [
+      "arn:aws:elasticache:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:cluster:${local.name_prefix}-*",
+      "arn:aws:elasticache:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parametergroup:${local.name_prefix}-*",
+      "arn:aws:elasticache:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:replicationgroup:${local.name_prefix}-*",
+      "arn:aws:elasticache:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:subnetgroup:${local.name_prefix}-*",
+    ]
+    sid = "ManageProductCache"
+  }
+
+  statement {
+    actions = [
+      "rds:AddTagsToResource",
+      "rds:Create*",
+      "rds:Delete*",
+      "rds:Describe*",
+      "rds:List*",
+      "rds:Modify*",
+      "rds:ModifyDBCluster",
+      "rds:ResetDBClusterParameterGroup",
+      "rds:ResetDBParameterGroup",
+    ]
+    effect = "Allow"
+    resources = [
+      "arn:aws:rds:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:cluster:cdp-*",
+      "arn:aws:rds:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:cluster-pg:cdp-*",
+      "arn:aws:rds:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:db:cdp-*",
+      "arn:aws:rds:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:pg:cdp-*",
+      "arn:aws:rds:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:subgrp:cdp-*",
+    ]
+    sid = "ManageProductRDS"
+  }
+
+  statement {
+    actions = [
+      "s3:Create*",
+      "s3:Delete*",
+      "s3:Get*",
+      "s3:List*",
+      "s3:Put*",
+    ]
+    effect = "Allow"
+    resources = [
+      "arn:aws:s3:::${local.name_prefix}-*",
+      "arn:aws:s3:::${local.name_prefix}-*/*"
+    ]
+    sid = "ManageProductS3Buckets"
+  }
+
+  statement {
+    actions = [
+      "sqs:*",
+    ]
+    effect = "Allow"
+    resources = [
+      "arn:aws:sqs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:${local.name_prefix}-*"
+    ]
+    sid = "ManageProductSQS"
+  }
+
+}

--- a/terragrunt/modules/core-iam/terraform-product-datasource.tf
+++ b/terragrunt/modules/core-iam/terraform-product-datasource.tf
@@ -89,7 +89,7 @@ data "aws_iam_policy_document" "terraform_product" {
 
   statement {
     actions = ["ec2:*"]
-    effect  = "Allow"
+    effect = "Allow"
     resources = [
       "arn:aws:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*/${local.name_prefix}-*"
     ]
@@ -126,7 +126,8 @@ data "aws_iam_policy_document" "terraform_product" {
     effect = "Allow"
     resources = [
       "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/ecs*",
-      "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/cdp-*",
+      "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/${local.name_prefix}*",
+      "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/aws/vendedlogs/${local.name_prefix}*",
     ]
     sid = "ManageProductLogs"
   }
@@ -154,29 +155,6 @@ data "aws_iam_policy_document" "terraform_product" {
       "arn:aws:events:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:rule/StepFunctionsGetEventsForStepFunctionsExecutionRule",
     ]
     sid = "ManageProductEvents"
-  }
-
-  statement {
-    actions = [
-      "rds:AddTagsToResource",
-      "rds:Create*",
-      "rds:Delete*",
-      "rds:Describe*",
-      "rds:List*",
-      "rds:Modify*",
-      "rds:ModifyDBCluster",
-      "rds:ResetDBClusterParameterGroup",
-      "rds:ResetDBParameterGroup",
-    ]
-    effect = "Allow"
-    resources = [
-      "arn:aws:rds:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:cluster:cdp-*",
-      "arn:aws:rds:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:cluster-pg:cdp-*",
-      "arn:aws:rds:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:db:cdp-*",
-      "arn:aws:rds:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:pg:cdp-*",
-      "arn:aws:rds:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:subgrp:cdp-*",
-    ]
-    sid = "ManageProductRDS"
   }
 
   statement {
@@ -247,34 +225,5 @@ data "aws_iam_policy_document" "terraform_product" {
     ]
     sid = "ManageProductCodebuild"
   }
-
-  statement {
-    actions = [
-      "s3:Create*",
-      "s3:Delete*",
-      "s3:Get*",
-      "s3:List*",
-      "s3:Put*",
-    ]
-    effect = "Allow"
-    resources = [
-      "arn:aws:s3:::${local.name_prefix}-*",
-      "arn:aws:s3:::${local.name_prefix}-*/*"
-    ]
-    sid = "ManageProductS3Buckets"
-  }
-
-  statement {
-    actions = [
-      "sqs:*",
-    ]
-    effect = "Allow"
-    resources = [
-      "arn:aws:sqs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:${local.name_prefix}-*"
-    ]
-    sid = "ManageProductSQS"
-  }
-
-
 
 }

--- a/terragrunt/modules/core-iam/terraform.tf
+++ b/terragrunt/modules/core-iam/terraform.tf
@@ -48,6 +48,13 @@ resource "aws_iam_policy" "terraform_product" {
   tags        = var.tags
 }
 
+resource "aws_iam_policy" "terraform_product_data" {
+  name        = "${local.name_prefix}-terraform-product-data"
+  description = "Product's Data specific policy"
+  policy      = data.aws_iam_policy_document.terraform_product_data.json
+  tags        = var.tags
+}
+
 import {
   to = aws_iam_policy.terraform_assume_orchestrator_role
   id = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/${local.name_prefix}-terraform-assume-orchestrator-role"
@@ -71,6 +78,11 @@ resource "aws_iam_role_policy_attachment" "terraform_global" {
 
 resource "aws_iam_role_policy_attachment" "terraform_production" {
   policy_arn = aws_iam_policy.terraform_product.arn
+  role       = aws_iam_role.terraform.name
+}
+
+resource "aws_iam_role_policy_attachment" "terraform_production_data" {
+  policy_arn = aws_iam_policy.terraform_product_data.arn
   role       = aws_iam_role.terraform.name
 }
 

--- a/terragrunt/modules/core-networking/outputs.tf
+++ b/terragrunt/modules/core-networking/outputs.tf
@@ -8,7 +8,7 @@ output "private_route_table_ids" {
 
 output "private_subnet_arns" {
   description = "VPC private subnet ARNs"
-  value       = aws_subnet.private.*.id
+  value       = aws_subnet.private.*.arn
 }
 
 output "private_subnet_ids" {

--- a/terragrunt/modules/core-security-groups/cache.tf
+++ b/terragrunt/modules/core-security-groups/cache.tf
@@ -1,0 +1,12 @@
+resource "aws_security_group" "elasticache_redis" {
+  description = "Security group to be attached to the Elasticache Redis"
+  name        = "${local.name_prefix}-elasticache"
+  vpc_id      = var.vpc_id
+
+  tags = merge(
+    var.tags,
+    {
+      Name = "${local.name_prefix}-elasticache"
+    }
+  )
+}

--- a/terragrunt/modules/core-security-groups/outputs.tf
+++ b/terragrunt/modules/core-security-groups/outputs.tf
@@ -14,6 +14,10 @@ output "ecs_sg_id" {
   value = aws_security_group.ecs.id
 }
 
+output "elasticache_redis_sg_id" {
+  value = aws_security_group.elasticache_redis.id
+}
+
 output "vpce_ecr_api_sg_id" {
   value = aws_security_group.vpce_ecr_api.id
 }

--- a/terragrunt/modules/elasticache/cloudwatch.tf
+++ b/terragrunt/modules/elasticache/cloudwatch.tf
@@ -1,0 +1,16 @@
+resource "aws_cloudwatch_log_group" "engine_log" {
+  name              = "/aws/vendedlogs/${local.name_prefix}/elasticache/engine-log"
+  retention_in_days = var.environment == "production" ? 0 : 90
+  tags              = var.tags
+}
+
+resource "aws_cloudwatch_log_group" "slow_log" {
+  name              = "/aws/vendedlogs/${local.name_prefix}/elasticache/slow-log"
+  retention_in_days = var.environment == "production" ? 0 : 90
+  tags              = var.tags
+}
+
+resource "aws_cloudwatch_log_resource_policy" "elasticache_logs" {
+  policy_name = "ElastiCacheLogAccess"
+  policy_document = data.aws_iam_policy_document.elasticache_log_policy.json
+}

--- a/terragrunt/modules/elasticache/datasource.tf
+++ b/terragrunt/modules/elasticache/datasource.tf
@@ -1,0 +1,29 @@
+data "aws_caller_identity" "current" {}
+
+data "aws_region" "current" {}
+
+data "aws_availability_zones" "current" {
+  filter {
+    name = "region-name"
+    values = [data.aws_region.current.name]
+  }
+}
+
+data "aws_iam_policy_document" "elasticache_log_policy" {
+  statement {
+    sid       = "AllowElastiCacheSlowLogAccess"
+    effect    = "Allow"
+    actions   = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents"
+    ]
+    resources = [
+      aws_cloudwatch_log_group.engine_log.arn,
+      aws_cloudwatch_log_group.slow_log.arn
+    ]
+    principals {
+      type        = "Service"
+      identifiers = ["elasticache.amazonaws.com"]
+    }
+  }
+}

--- a/terragrunt/modules/elasticache/locals.tf
+++ b/terragrunt/modules/elasticache/locals.tf
@@ -1,0 +1,3 @@
+locals {
+  name_prefix = var.product.resource_name
+}

--- a/terragrunt/modules/elasticache/outputs.tf
+++ b/terragrunt/modules/elasticache/outputs.tf
@@ -1,0 +1,18 @@
+output "redis_auth_token_arn" {
+  value = aws_secretsmanager_secret.redis_auth_token.arn
+}
+
+output "redis_auth_token_id" {
+  value = aws_secretsmanager_secret.redis_auth_token.id
+}
+
+output "primary_endpoint_address" {
+  value = aws_elasticache_replication_group.this.primary_endpoint_address
+}
+
+output "reader_endpoint_address" {
+  value = aws_elasticache_replication_group.this.reader_endpoint_address
+}
+output "port" {
+  value = aws_elasticache_replication_group.this.port
+}

--- a/terragrunt/modules/elasticache/redis.tf
+++ b/terragrunt/modules/elasticache/redis.tf
@@ -1,0 +1,53 @@
+resource "aws_elasticache_replication_group" "this" {
+  at_rest_encryption_enabled  = true
+  apply_immediately           = true
+  auth_token                  = aws_secretsmanager_secret_version.redis_auth_token.secret_string
+  auth_token_update_strategy  = "ROTATE"
+  automatic_failover_enabled  = true
+  description                 = "Redis cluster for organisation-app's authentication sessions"
+  engine                      = var.engine
+  engine_version              = var.engine_version
+  multi_az_enabled            = true
+  node_type                   = "cache.t3.medium"
+  num_cache_clusters          = 3
+  parameter_group_name        = aws_elasticache_parameter_group.this.name
+  port                        = var.port
+  preferred_cache_cluster_azs = data.aws_availability_zones.current.names
+  replication_group_id        = "${local.name_prefix}-org-app-sessions"
+  security_group_ids = [var.elasticache_redis_sg_id]
+  subnet_group_name           = aws_elasticache_subnet_group.this.name
+  tags                        = var.tags
+  transit_encryption_enabled  = true
+
+  log_delivery_configuration {
+    destination      = aws_cloudwatch_log_group.slow_log.name
+    destination_type = "cloudwatch-logs"
+    log_format       = "json"
+    log_type         = "slow-log"
+  }
+
+  log_delivery_configuration {
+    destination      = aws_cloudwatch_log_group.engine_log.name
+    destination_type = "cloudwatch-logs"
+    log_format       = "json"
+    log_type         = "engine-log"
+  }
+
+  depends_on = [
+    aws_cloudwatch_log_resource_policy.elasticache_logs,
+  ]
+}
+
+resource "aws_elasticache_parameter_group" "this" {
+  description = "Used by ${local.name_prefix}, based on default ${var.family}"
+  family      = var.family
+  name        = "${local.name_prefix}-org-app-sessions"
+  tags        = var.tags
+}
+
+resource "aws_elasticache_subnet_group" "this" {
+  name       = "${local.name_prefix}-private-subnet-group"
+  subnet_ids = var.private_subnet_ids
+
+  tags = var.tags
+}

--- a/terragrunt/modules/elasticache/secrets.tf
+++ b/terragrunt/modules/elasticache/secrets.tf
@@ -1,0 +1,16 @@
+resource "random_password" "redis_auth_token" {
+  length           = 20
+  special          = true
+  override_special = "!@#%^&*()_+=-"
+}
+
+resource "aws_secretsmanager_secret" "redis_auth_token" {
+  name        = "${local.name_prefix}-redis-auth-token"
+  description = "Redis authentication token"
+  tags        = var.tags
+}
+
+resource "aws_secretsmanager_secret_version" "redis_auth_token" {
+  secret_id     = aws_secretsmanager_secret.redis_auth_token.id
+  secret_string = random_password.redis_auth_token.result
+}

--- a/terragrunt/modules/elasticache/variables.tf
+++ b/terragrunt/modules/elasticache/variables.tf
@@ -1,0 +1,84 @@
+variable "elasticache_redis_sg_id" {
+  description = "ElastiCache security group ID"
+  type        = string
+}
+
+variable "environment" {
+  description = "The environment we are provisioning, i.e. test, do not mistake this with the AWS account"
+  type        = string
+}
+
+variable "is_production" {
+  description = "Indicates whether the target account is configured with production-level settings"
+  type        = bool
+}
+
+variable "engine" {
+  description = "Name of the cache engine to be used for the clusters in this replication group"
+  type        = string
+  default     = "redis"
+
+  validation {
+    condition = contains(["redis", "valkey"], var.engine)
+    error_message = "Invalid value for engine. Valid values are 'redis' or 'valkey'."
+  }
+}
+
+variable "engine_version" {
+  description = "Version number of the cache engine to be used for the cache clusters in this replication group"
+  type        = string
+  default     = "6.x"
+}
+
+variable "family" {
+  description = "The family of the ElastiCache parameter group."
+  type        = string
+  default     = "redis6.x"
+}
+variable "node_type" {
+  description = "Instance class to be used"
+  type        = string
+  default     = "cache.t3.medium"
+}
+
+# variable "parameter_group_name" {
+#   description = "Name of the parameter group to associate with this replication group."
+#   type        = string
+#   default     = "default.redis6.x.cluster.on"
+# }
+
+variable "private_subnet_ids" {
+  description = "List of private subnet IDs"
+  type = list(string)
+}
+
+variable "port" {
+  description = "Port number on which each of the cache nodes will accept."
+  type        = number
+  default     = 6379
+}
+
+variable "product" {
+  description = "product's common attributes"
+  type = object({
+    name               = string
+    resource_name      = string
+    public_hosted_zone = string
+  })
+}
+
+# variable "role_rds_cloudwatch_arn" {
+#   description = "The ARN for the IAM role that permits RDS to send data to CloudWatch. Required in production accounts where enhanced monitoring is enabled"
+#   type        = string
+#   default     = ""
+# }
+#
+# variable "role_terraform_arn" {
+#   description = "Terraform IAM role ARN"
+#   type        = string
+# }
+
+variable "tags" {
+  description = "Tags to apply to all resources in this module"
+  type = map(string)
+}

--- a/terragrunt/modules/externals/networking/outputs.tf
+++ b/terragrunt/modules/externals/networking/outputs.tf
@@ -1,7 +1,7 @@
 
 output "private_subnet_arns" {
   description = "VPC private subnet ARNs"
-  value       = aws_subnet.private.*.id
+  value       = aws_subnet.private.*.arn
 }
 
 output "private_subnet_ids" {

--- a/terragrunt/providers.tf
+++ b/terragrunt/providers.tf
@@ -2,8 +2,8 @@ terraform {
   required_version = "= 1.9.5"
   required_providers {
     aws = {
-      version = "~> 5.64.0"
       source  = "hashicorp/aws"
+      version = "~> 5.77.0"
     }
     awscc = {
       source  = "hashicorp/awscc"


### PR DESCRIPTION
- Provisioned a secret holding the Redis authentication token.
- Split the product's IAM policy and included the ElastiCache-specific policy.
- Added a Security Group for the ElastiCache cluster.
- Created CloudWatch log groups for cache’s engine and slow logs.
- Configured log delivery for both engine and slow logs.
- Upgraded the AWS provider version.