### PR TITLE
DP-925 Switch to random string as some password chracters are not valid for AuthToken

### DIFF
--- a/terragrunt/components/service/cache/terragrunt.hcl
+++ b/terragrunt/components/service/cache/terragrunt.hcl
@@ -20,6 +20,14 @@ locals {
 
 }
 
+dependency core_iam {
+  config_path = "../../core/iam"
+  mock_outputs = {
+    terraform_arn  = "mock"
+    terraform_name = "mock"
+  }
+}
+
 dependency core_networking {
   config_path = "../../core/networking"
   mock_outputs = {

--- a/terragrunt/modules/core-iam/ci.tf
+++ b/terragrunt/modules/core-iam/ci.tf
@@ -67,11 +67,6 @@ resource "aws_iam_role_policy_attachment" "generic_pipeline_policy" {
   role       = aws_iam_role.ci_pipeline.name
 }
 
-# resource "aws_iam_role_policy_attachment" "terraform_pipeline_policy" {
-#   policy_arn = aws_iam_policy.terraform.arn
-#   role       = aws_iam_role.ci_pipeline.name
-# }
-
 resource "aws_iam_role_policy_attachment" "terraform_global_pipeline_policy" {
   policy_arn = aws_iam_policy.terraform_global.arn
   role       = aws_iam_role.ci_pipeline.name

--- a/terragrunt/modules/core-iam/terraform-global-datasource.tf
+++ b/terragrunt/modules/core-iam/terraform-global-datasource.tf
@@ -236,6 +236,7 @@ data "aws_iam_policy_document" "terraform_global" {
 
   statement {
     actions = [
+      "elasticloadbalancing:DescribeListenerAttributes",
       "elasticloadbalancing:DescribeListeners",
       "elasticloadbalancing:DescribeLoadBalancerAttributes",
       "elasticloadbalancing:DescribeLoadBalancers",

--- a/terragrunt/modules/elasticache/secrets.tf
+++ b/terragrunt/modules/elasticache/secrets.tf
@@ -1,7 +1,6 @@
-resource "random_password" "redis_auth_token" {
+resource "random_string" "redis_auth_token" {
   length           = 20
   special          = true
-  override_special = "!@#%^&*()_+=-"
 }
 
 resource "aws_secretsmanager_secret" "redis_auth_token" {
@@ -12,5 +11,5 @@ resource "aws_secretsmanager_secret" "redis_auth_token" {
 
 resource "aws_secretsmanager_secret_version" "redis_auth_token" {
   secret_id     = aws_secretsmanager_secret.redis_auth_token.id
-  secret_string = random_password.redis_auth_token.result
+  secret_string = random_string.redis_auth_token.result
 }


### PR DESCRIPTION
  - Add core-iam as ElastiCache dependency 
    (even thou it does not need it and can be removed later on. But for the first run, terrafom roles need to be updated)

- BAU, grant terraform permission to describe listeners attributes