### PR TITLE
BAU: Increase build timeout by 15 minutes

### DIFF
--- a/terragrunt/modules/ci/codebuild-update-account.tf
+++ b/terragrunt/modules/ci/codebuild-update-account.tf
@@ -2,7 +2,7 @@ resource "aws_codebuild_project" "update_account" {
   name          = "${local.name_prefix}-${local.update_account_cb_name}"
   description   = "Run terraform in components updating entire account"
   service_role  = var.ci_build_role_arn
-  build_timeout = 5
+  build_timeout = 20
 
   artifacts {
     type = "CODEPIPELINE"

--- a/terragrunt/modules/ci/codebuild-update-ecs-services.tf
+++ b/terragrunt/modules/ci/codebuild-update-ecs-services.tf
@@ -2,7 +2,7 @@ resource "aws_codebuild_project" "update_ecs_services" {
   name          = "${local.name_prefix}-${local.update_ecs_service_cb_name}"
   description   = "Run terraform in service/ecs component to only update ECS services"
   service_role  = var.ci_build_role_arn
-  build_timeout = 5
+  build_timeout = 20
 
   artifacts {
     type = "CODEPIPELINE"

--- a/terragrunt/modules/orchestrator/ci/codebuild.tf
+++ b/terragrunt/modules/orchestrator/ci/codebuild.tf
@@ -1,7 +1,7 @@
 resource "aws_codebuild_project" "this" {
   for_each = local.deployment_environments
 
-  build_timeout = 5
+  build_timeout = 20
   description   = "Deploy infra and application changes into ${each.key}"
   name          = "${local.name_prefix}-deployment-to-${each.key}"
   service_role  = var.ci_build_role_arn


### PR DESCRIPTION
- While deployment jobs for existing components typically take about 2 minutes per account, provisioning new heavy components (such as Elasticache in this case) can take significantly longer.
- The increased timeout is intended to accommodate these rare situations and does not imply that we expect such durations during normal day-to-day operations.