### PR TITLE
DP-889 Add OneLoginLogoutNotificationUrls env_var with account-specific values

### DIFF
--- a/terragrunt/components/service/ecs/terragrunt.hcl
+++ b/terragrunt/components/service/ecs/terragrunt.hcl
@@ -105,10 +105,11 @@ dependency service_queue {
 
 inputs = {
 
-  account_ids            = local.global_vars.locals.account_ids
-  pinned_service_version = local.global_vars.locals.pinned_service_version
-  service_configs        = local.global_vars.locals.service_configs
-  tags                   = local.tags
+  account_ids                        = local.global_vars.locals.account_ids
+  onelogin_logout_notification_urls  = local.global_vars.locals.onelogin_logout_notification_urls
+  pinned_service_version             = local.global_vars.locals.pinned_service_version
+  service_configs                    = local.global_vars.locals.service_configs
+  tags                               = local.tags
 
   role_cloudwatch_events_arn               = dependency.core_iam.outputs.cloudwatch_events_arn
   role_cloudwatch_events_name              = dependency.core_iam.outputs.cloudwatch_events_name

--- a/terragrunt/components/terragrunt.hcl
+++ b/terragrunt/components/terragrunt.hcl
@@ -4,13 +4,12 @@ locals {
     for name, env in local.environments : name => env.account_id
   }
 
-  cidr_b_production   = 1
-  cidr_b_staging      = 2
-  cidr_b_development  = 3
-  cidr_b_integration  = 4
-  cidr_b_orchestrator = 5
+  cidr_b_production           = 1
+  cidr_b_staging              = 2
+  cidr_b_development          = 3
+  cidr_b_integration          = 4
+  cidr_b_orchestrator         = 5
   cidr_b_external_integration = 6
-
 
   environment = get_env("TG_ENVIRONMENT", "development")
 
@@ -38,13 +37,14 @@ locals {
       externals_private_subnets = "integration account feature" # To be deprecated after FTS Migration
     }
     development = {
-      cidr_block             = "10.${local.cidr_b_development}.0.0/16"
-      account_id             = 471112892058
-      canary_schedule_expression = "rate(30 minutes)" # "cron(15 7,11,15 ? * MON-FRI)" # UTC+0
-      fts_azure_frontdoor    = null
-      name                   = "dev"
-      pinned_service_version = null
-      postgres_instance_type = "db.t4g.micro"
+      cidr_block                        = "10.${local.cidr_b_development}.0.0/16"
+      account_id                        = 471112892058
+      canary_schedule_expression        = "rate(30 minutes)" # "cron(15 7,11,15 ? * MON-FRI)" # UTC+0
+      fts_azure_frontdoor               = null
+      name                              = "dev"
+      onelogin_logout_notification_urls = "[ \\\"https://test-findtender.nqc.com/auth/backchannellogout\\\" ]"
+      pinned_service_version            = null
+      postgres_instance_type            = "db.t4g.micro"
       private_subnets = [
         "10.${local.cidr_b_development}.101.0/24",
         "10.${local.cidr_b_development}.102.0/24",
@@ -61,13 +61,14 @@ locals {
       externals_private_subnets = "integration account feature" # To be deprecated after FTS Migration
     }
     staging = {
-      cidr_block                 = "10.${local.cidr_b_staging}.0.0/16"
-      account_id                 = 905418042182
-      canary_schedule_expression = "rate(30 minutes)"
-      fts_azure_frontdoor        = null
-      name                       = "staging"
-      pinned_service_version     = "1.0.10"
-      postgres_instance_type     = "db.t4g.micro"
+      cidr_block                        = "10.${local.cidr_b_staging}.0.0/16"
+      account_id                        = 905418042182
+      canary_schedule_expression        = "rate(30 minutes)"
+      fts_azure_frontdoor               = null
+      name                              = "staging"
+      onelogin_logout_notification_urls = "[ \\\"https://sirsi-integration-findtender.nqc.com/auth/backchannellogout\\\" ]"
+      pinned_service_version            = "1.0.10"
+      postgres_instance_type            = "db.t4g.micro"
       private_subnets = [
         "10.${local.cidr_b_staging}.101.0/24",
         "10.${local.cidr_b_staging}.102.0/24",
@@ -84,13 +85,14 @@ locals {
       externals_private_subnets = "integration account feature" # To be deprecated after FTS Migration
     }
     integration = {
-      cidr_block                 = "10.${local.cidr_b_integration}.0.0/16"
-      account_id                 = 767397666448
-      canary_schedule_expression = "rate(30 minutes)"
-      fts_azure_frontdoor        = null
-      name                       = "integration"
-      pinned_service_version     = "1.0.9"
-      postgres_instance_type     = "db.t4g.micro"
+      cidr_block                        = "10.${local.cidr_b_integration}.0.0/16"
+      account_id                        = 767397666448
+      canary_schedule_expression        = "rate(30 minutes)"
+      fts_azure_frontdoor               = null
+      name                              = "integration"
+      onelogin_logout_notification_urls = "[ \\\"https://test-findtender.nqc.com/auth/backchannellogout\\\" ]"
+      pinned_service_version            = "1.0.9"
+      postgres_instance_type            = "db.t4g.micro"
       private_subnets = [
         "10.${local.cidr_b_integration}.101.0/24",
         "10.${local.cidr_b_integration}.102.0/24",
@@ -111,13 +113,14 @@ locals {
       ]
     }
     production = {
-      cidr_block                 = "10.${local.cidr_b_production}.0.0/16"
-      account_id                 = 471112843276
-      canary_schedule_expression = "rate(15 minutes)"
-      fts_azure_frontdoor        = "nqc-front-door-uksouth.azurefd.net"
-      name                       = "production"
-      pinned_service_version     = "1.0.9"
-      postgres_instance_type     = "db.t4g.micro"
+      cidr_block                        = "10.${local.cidr_b_production}.0.0/16"
+      account_id                        = 471112843276
+      canary_schedule_expression        = "rate(15 minutes)"
+      fts_azure_frontdoor               = "nqc-front-door-uksouth.azurefd.net"
+      name                              = "production"
+      onelogin_logout_notification_urls = "[ \\\"https://www.private-beta.find-tender.service.gov.uk/auth/backchannellogout\\\" ]"
+      pinned_service_version            = "1.0.9"
+      postgres_instance_type            = "db.t4g.micro"
       private_subnets = [
         "10.${local.cidr_b_production}.101.0/24",
         "10.${local.cidr_b_production}.102.0/24",
@@ -135,9 +138,9 @@ locals {
     }
   }
 
-  fts_azure_frontdoor = try(local.environments[local.environment].fts_azure_frontdoor, null)
-
-  pinned_service_version = try(local.environments[local.environment].pinned_service_version, null)
+  fts_azure_frontdoor               = try(local.environments[local.environment].fts_azure_frontdoor, null)
+  onelogin_logout_notification_urls = try(local.environments[local.environment].onelogin_logout_notification_urls, null)
+  pinned_service_version            = try(local.environments[local.environment].pinned_service_version, null)
 
   product = {
     name               = "CDP SIRSI"

--- a/terragrunt/modules/ecs/service-organisation-app.tf
+++ b/terragrunt/modules/ecs/service-organisation-app.tf
@@ -46,6 +46,7 @@ module "ecs_service_organisation_app" {
       onelogin_account_url                = local.one_loging.credential_locations.account_url
       onelogin_authority                  = local.one_loging.credential_locations.authority
       onelogin_client_id                  = local.one_loging.credential_locations.client_id
+      onelogin_logout_notification_urls   = var.onelogin_logout_notification_urls
       onelogin_private_key                = local.one_loging.credential_locations.private_key
       public_domain                       = var.public_domain
       s3_permanent_bucket                 = module.s3_bucket_permanent.bucket

--- a/terragrunt/modules/ecs/templates/task-definitions/organisation-app.json.tftpl
+++ b/terragrunt/modules/ecs/templates/task-definitions/organisation-app.json.tftpl
@@ -31,6 +31,7 @@
         {"name": "Features__DiagnosticPage__Enabled", "value": "${diagnostic_page_enabled}"},
         {"name": "FormsService", "value": "https://forms.${public_domain}"},
         {"name": "ForwardedHeaders__KnownNetwork", "value": "${vpc_cidr}"},
+        {"name": "OneLoginLogoutNotificationUrls", "value": "${onelogin_logout_notification_urls}"},
         {"name": "OrganisationService", "value": "https://organisation.${public_domain}"},
         {"name": "Organisation__Authority", "value": "https://authority.${public_domain}"},
         {"name": "PersonService", "value": "https://person.${public_domain}"},

--- a/terragrunt/modules/ecs/variables.tf
+++ b/terragrunt/modules/ecs/variables.tf
@@ -68,6 +68,18 @@ variable "is_production" {
   type        = bool
 }
 
+variable "onelogin_logout_notification_urls" {
+  description = <<EOT
+    JSON-like string representing a list of notification URLs.
+    This will be passed to the organisation-app as an environment variable.
+
+    Note:
+    - The value must be formatted as a JSON-like string (e.g., "[ \\\"url1\\\", \\\"url2\\\" ]").
+    - This format will result in [ "url1", "url2" ] as instructed, ensuring that the application can properly parse and utilise this value as a JSON array.
+    EOT
+  type        = string
+}
+
 variable "pinned_service_version" {
   description = "The service version for the this environment. If null, latest version from Orchestration will be used"
   type        = string


### PR DESCRIPTION
- Added the `OneLoginLogoutNotificationUrls` environment variable to support logout notification forwarding.
- Configured different values for different accounts as per requirements.

The outcome has been tested in development and can confirm is as per the request:

![image](https://github.com/user-attachments/assets/fcd831a2-4c38-4af2-8cdf-7f34daf790c4)

