### PR TITLE
DP-925 Provide ECS access to Redis

### DIFF
--- a/terragrunt/components/service/ecs/terragrunt.hcl
+++ b/terragrunt/components/service/ecs/terragrunt.hcl
@@ -55,6 +55,7 @@ dependency core_security_groups {
     alb_sg_id                 = "mock"
     db_postgres_sg_id         = "mock"
     ecs_sg_id                 = "mock"
+    elasticache_redis_sg_id   = "mock"
     vpce_ecr_api_sg_id        = "mock"
     vpce_ecr_dkr_sg_id        = "mock"
     vpce_s3_sg_id             = "mock"
@@ -93,6 +94,15 @@ dependency service_database {
   }
 }
 
+dependency service_cache {
+  config_path = "../../service/cache"
+  mock_outputs = {
+    port                     = "mock"
+    primary_endpoint_address = "mock"
+    redis_auth_token_arn     = "mock"
+  }
+}
+
 dependency service_queue {
   config_path = "../../service/queue"
   mock_outputs = {
@@ -105,11 +115,11 @@ dependency service_queue {
 
 inputs = {
 
-  account_ids                        = local.global_vars.locals.account_ids
-  onelogin_logout_notification_urls  = local.global_vars.locals.onelogin_logout_notification_urls
-  pinned_service_version             = local.global_vars.locals.pinned_service_version
-  service_configs                    = local.global_vars.locals.service_configs
-  tags                               = local.tags
+  account_ids                       = local.global_vars.locals.account_ids
+  onelogin_logout_notification_urls = local.global_vars.locals.onelogin_logout_notification_urls
+  pinned_service_version            = local.global_vars.locals.pinned_service_version
+  service_configs                   = local.global_vars.locals.service_configs
+  tags                              = local.tags
 
   role_cloudwatch_events_arn               = dependency.core_iam.outputs.cloudwatch_events_arn
   role_cloudwatch_events_name              = dependency.core_iam.outputs.cloudwatch_events_name
@@ -137,6 +147,7 @@ inputs = {
   alb_sg_id                 = dependency.core_security_groups.outputs.alb_sg_id
   db_postgres_sg_id         = dependency.core_security_groups.outputs.db_postgres_sg_id
   ecs_sg_id                 = dependency.core_security_groups.outputs.ecs_sg_id
+  redis_sg_id               = dependency.core_security_groups.outputs.elasticache_redis_sg_id
   vpce_ecr_api_sg_id        = dependency.core_security_groups.outputs.vpce_ecr_api_sg_id
   vpce_ecr_dkr_sg_id        = dependency.core_security_groups.outputs.vpce_ecr_dkr_sg_id
   vpce_logs_sg_id           = dependency.core_security_groups.outputs.vpce_logs_sg_id
@@ -156,6 +167,9 @@ inputs = {
   db_sirsi_kms_arn                       = dependency.service_database.outputs.sirsi_kms_arn
   db_sirsi_name                          = dependency.service_database.outputs.sirsi_name
 
+  redis_primary_endpoint = dependency.service_cache.outputs.primary_endpoint_address
+  redis_auth_token_arn   = dependency.service_cache.outputs.redis_auth_token_arn
+  redis_port             = dependency.service_cache.outputs.port
 
   queue_entity_verification_queue_arn = dependency.service_queue.outputs.entity_verification_queue_arn
   queue_entity_verification_queue_url = dependency.service_queue.outputs.entity_verification_queue_url

--- a/terragrunt/modules/ecs-service/variables.tf
+++ b/terragrunt/modules/ecs-service/variables.tf
@@ -4,6 +4,12 @@ variable "add_security_group_roles" {
   type        = bool
 }
 
+variable "allowed_unauthenticated_paths" {
+  description = "List of paths allowed access to protected services, bypassing Cognito authentication."
+  type        = list(string)
+  default     = []
+}
+
 variable "cluster_id" {
   description = "Cluster ID of which the service will be part of"
   type        = string
@@ -124,12 +130,6 @@ variable "role_ecs_task_exec_arn" {
 variable "tags" {
   description = "Tags to apply to all resources in this module"
   type        = map(string)
-}
-
-variable "allowed_unauthenticated_paths" {
-  description = "List of paths allowed access to protected services, bypassing Cognito authentication."
-  type        = list(string)
-  default     = []
 }
 
 variable "unhealthy_threshold" {

--- a/terragrunt/modules/ecs/datasource.tf
+++ b/terragrunt/modules/ecs/datasource.tf
@@ -32,6 +32,10 @@ data "aws_secretsmanager_secret" "companies_house" {
   name = "${local.name_prefix}-companies-house-credentials"
 }
 
+data "aws_secretsmanager_secret" "redis_auth_token" {
+  arn = var.redis_auth_token_arn
+}
+
 data "aws_secretsmanager_secret_version" "fts_service_url" {
   secret_id = "${local.name_prefix}-fts-service-url"
 }

--- a/terragrunt/modules/ecs/security-groups.tf
+++ b/terragrunt/modules/ecs/security-groups.tf
@@ -78,6 +78,26 @@ resource "aws_security_group_rule" "ecs_service_to_postregs" {
   type                     = "egress"
 }
 
+resource "aws_security_group_rule" "redis_from_ecs_service" {
+  description              = "From ECS Service"
+  from_port                = var.redis_port
+  protocol                 = "TCP"
+  security_group_id        = var.redis_sg_id
+  source_security_group_id = var.ecs_sg_id
+  to_port                  = var.redis_port
+  type                     = "ingress"
+}
+
+resource "aws_security_group_rule" "ecs_service_to_redis" {
+  description              = "To RDS"
+  from_port                = var.redis_port
+  protocol                 = "TCP"
+  security_group_id        = var.ecs_sg_id
+  source_security_group_id = var.redis_sg_id
+  to_port                  = var.redis_port
+  type                     = "egress"
+}
+
 resource "aws_security_group_rule" "ecs_service_to_vpce_ecr_api" {
   description              = "To ECR API VPCE"
   from_port                = 443

--- a/terragrunt/modules/ecs/service-organisation-app.tf
+++ b/terragrunt/modules/ecs/service-organisation-app.tf
@@ -46,9 +46,12 @@ module "ecs_service_organisation_app" {
       onelogin_account_url                = local.one_loging.credential_locations.account_url
       onelogin_authority                  = local.one_loging.credential_locations.authority
       onelogin_client_id                  = local.one_loging.credential_locations.client_id
-      onelogin_logout_notification_urls   = join(",", var.onelogin_logout_notification_urls)
+      onelogin_logout_notification_urls = join(",", var.onelogin_logout_notification_urls)
       onelogin_private_key                = local.one_loging.credential_locations.private_key
       public_domain                       = var.public_domain
+      redis_auth_token_arn                = var.redis_auth_token_arn
+      redis_port                          = var.redis_port
+      redis_primary_endpoint_address      = var.redis_primary_endpoint
       s3_permanent_bucket                 = module.s3_bucket_permanent.bucket
       s3_staging_bucket                   = module.s3_bucket_staging.bucket
       service_version                     = local.service_version

--- a/terragrunt/modules/ecs/templates/task-definitions/organisation-app.json.tftpl
+++ b/terragrunt/modules/ecs/templates/task-definitions/organisation-app.json.tftpl
@@ -26,6 +26,8 @@
         {"name": "Aws__Buckets__StagingBucket", "value": "${s3_staging_bucket}"},
         {"name": "Aws__CloudWatch__LogGroup", "value": "${lg_name}"},
         {"name": "Aws__CloudWatch__LogStream", "value": "${lg_prefix}-serilog"},
+        {"name": "Aws__ElastiCache__Hostname", "value": "${redis_primary_endpoint_address}"},
+        {"name": "Aws__ElastiCache__Port", "value": "${redis_port}"},
         {"name": "DataSharingService", "value": "https://data-sharing.${public_domain}"},
         {"name": "EntityVerificationService", "value": "https://entity-verification.${public_domain}"},
         {"name": "Features__DiagnosticPage__Enabled", "value": "${diagnostic_page_enabled}"},
@@ -38,6 +40,7 @@
         {"name": "TenantService", "value": "https://tenant.${public_domain}"}
     ],
     "secrets": [
+        {"name": "Aws__ElastiCache__Token", "valueFrom": "${redis_auth_token_arn}"},
         {"name": "CharityCommission__SubscriptionKey", "valueFrom": "${charity_commission_subscription_key}"},
         {"name": "CharityCommission__Url", "valueFrom": "${charity_commission_url}"},
         {"name": "CompaniesHouse__Url", "valueFrom": "${companies_house_url}"},

--- a/terragrunt/modules/ecs/variables.tf
+++ b/terragrunt/modules/ecs/variables.tf
@@ -128,6 +128,27 @@ variable "queue_organisation_queue_url" {
   type        = string
 }
 
+variable "redis_auth_token_arn" {
+  description = "The ARN of the Secrets Manager secret storing the Redis authentication token."
+  type        = string
+}
+
+variable "redis_port" {
+  description = "The port number used to connect to the ElastiCache Redis cluster."
+  type        = number
+}
+
+variable "redis_primary_endpoint" {
+  description = "The primary endpoint address of the ElastiCache Redis replication group."
+  type        = string
+}
+
+variable "redis_sg_id" {
+  description = "ElastiCache Redis security group ID"
+  type        = string
+}
+
+
 variable "role_cloudwatch_events_name" {
   description = "Name of the IAM role used by CloudWatch Events"
   type        = string

--- a/terragrunt/modules/elasticache/outputs.tf
+++ b/terragrunt/modules/elasticache/outputs.tf
@@ -1,9 +1,5 @@
-output "redis_auth_token_arn" {
-  value = aws_secretsmanager_secret.redis_auth_token.arn
-}
-
-output "redis_auth_token_id" {
-  value = aws_secretsmanager_secret.redis_auth_token.id
+output "port" {
+  value = aws_elasticache_replication_group.this.port
 }
 
 output "primary_endpoint_address" {
@@ -13,6 +9,11 @@ output "primary_endpoint_address" {
 output "reader_endpoint_address" {
   value = aws_elasticache_replication_group.this.reader_endpoint_address
 }
-output "port" {
-  value = aws_elasticache_replication_group.this.port
+
+output "redis_auth_token_arn" {
+  value = aws_secretsmanager_secret.redis_auth_token.arn
+}
+
+output "redis_auth_token_id" {
+  value = aws_secretsmanager_secret.redis_auth_token.id
 }

--- a/terragrunt/modules/elasticache/variables.tf
+++ b/terragrunt/modules/elasticache/variables.tf
@@ -3,16 +3,6 @@ variable "elasticache_redis_sg_id" {
   type        = string
 }
 
-variable "environment" {
-  description = "The environment we are provisioning, i.e. test, do not mistake this with the AWS account"
-  type        = string
-}
-
-variable "is_production" {
-  description = "Indicates whether the target account is configured with production-level settings"
-  type        = bool
-}
-
 variable "engine" {
   description = "Name of the cache engine to be used for the clusters in this replication group"
   type        = string
@@ -30,32 +20,37 @@ variable "engine_version" {
   default     = "6.x"
 }
 
+variable "environment" {
+  description = "The environment we are provisioning, i.e. test, do not mistake this with the AWS account"
+  type        = string
+}
+
 variable "family" {
   description = "The family of the ElastiCache parameter group."
   type        = string
   default     = "redis6.x"
 }
+
+variable "is_production" {
+  description = "Indicates whether the target account is configured with production-level settings"
+  type        = bool
+}
+
 variable "node_type" {
   description = "Instance class to be used"
   type        = string
   default     = "cache.t3.medium"
 }
 
-# variable "parameter_group_name" {
-#   description = "Name of the parameter group to associate with this replication group."
-#   type        = string
-#   default     = "default.redis6.x.cluster.on"
-# }
-
-variable "private_subnet_ids" {
-  description = "List of private subnet IDs"
-  type = list(string)
-}
-
 variable "port" {
   description = "Port number on which each of the cache nodes will accept."
   type        = number
   default     = 6379
+}
+
+variable "private_subnet_ids" {
+  description = "List of private subnet IDs"
+  type = list(string)
 }
 
 variable "product" {
@@ -66,17 +61,6 @@ variable "product" {
     public_hosted_zone = string
   })
 }
-
-# variable "role_rds_cloudwatch_arn" {
-#   description = "The ARN for the IAM role that permits RDS to send data to CloudWatch. Required in production accounts where enhanced monitoring is enabled"
-#   type        = string
-#   default     = ""
-# }
-#
-# variable "role_terraform_arn" {
-#   description = "Terraform IAM role ARN"
-#   type        = string
-# }
 
 variable "tags" {
   description = "Tags to apply to all resources in this module"


### PR DESCRIPTION
And a bit of tidy up.

### Note:
Merging this will not interrupt the current version of the application running in any of our accounts. However, it does not fully establish connectivity yet.

![image](https://github.com/user-attachments/assets/39898e46-64f7-4754-8561-d13ef04660be)

At the moment, it’s unclear whether the provided secret (Redis Auth Token) will be used by the application for authentication. Additionally, we might need another parameter for the application to store the token and verify its stored sessions.
