### PR TITLE
DP-972: Configure vulnerability scans for docker images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,6 +116,8 @@ jobs:
           path: cdp-images.tar
 
   vulnerability-scan:
+    # since we do not fail the build for now, but the report is to get feedback, only run it on the main branch and tags
+    if: (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')) && github.repository_owner == 'cabinetoffice'
     runs-on: ubuntu-latest
     name: Scan for vulnerabilities
     needs: [test, package]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -137,6 +137,7 @@ jobs:
       - name: Determine the category
         id: category
         run: |
+          image=${{ matrix.image }}
           category=${image%%:*}
           echo "category=$category" >> $GITHUB_OUTPUT
       - name: Scan ${{ matrix.image }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,18 +93,6 @@ jobs:
         run: make down
         env:
           IMAGE_VERSION: ${{ steps.version.outputs.version }}
-      - name: Scan Images for Vulnerabilities
-        uses: anchore/scan-action@v5
-        id: scan
-        with:
-          path: "."
-          fail-build: true
-          severity-cutoff: critical
-          output-format: sarif
-      - name: Upload Image Vulnerability Report
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: ${{ steps.scan.outputs.sarif }}
       - name: Save Docker Images
         id: save
         run: |
@@ -119,6 +107,37 @@ jobs:
         with:
           name: docker-images
           path: cdp-images.tar
+
+  vulnerability-scan:
+    runs-on: ubuntu-latest
+    name: Scan for vulnerabilities
+    needs: [test, package]
+    env:
+      IMAGES: ${{ needs.package.outputs.images }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download Docker Images
+        uses: actions/download-artifact@v4
+        with:
+          name: docker-images
+      - name: Load Docker Images
+        run: docker load -i cdp-images.tar
+
+      - uses: anchore/scan-action/download-grype@v5
+        id: grype
+      - name: Scan Docker Images
+        id: scan
+        run: |
+          mkdir -p build/reports
+          echo "$IMAGES" | tr ' ' '\n' | xargs -I'{}' $GRYPE_CMD -o sarif '{}' --file 'build/reports/{}.sarif'
+          echo "sarif=build/reports" >> $GITHUB_OUTPUT
+        env:
+          GRYPE_CMD: ${{ steps.grype.outputs.cmd }}
+      - name: Upload Image Vulnerability Reports
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: ${{ steps.scan.outputs.sarif }}
 
   publish:
     if: (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')) && github.repository_owner == 'cabinetoffice'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,24 +132,24 @@ jobs:
       - name: Load Docker Images
         run: docker load -i cdp-images.tar
 
-      - uses: anchore/scan-action/download-grype@v5
-        id: grype
-      - name: Scan ${{ matrix.image }}
-        id: scan
+      - name: Determine the category
+        id: category
         run: |
-          mkdir -p build/reports
-          image=${{ matrix.image }}
           category=${image%%:*}
-          $GRYPE_CMD -o sarif "$image" --file "build/reports/$category.sarif"
-          echo "sarif=build/reports" >> $GITHUB_OUTPUT
           echo "category=$category" >> $GITHUB_OUTPUT
-        env:
-          GRYPE_CMD: ${{ steps.grype.outputs.cmd }}
+      - name: Scan ${{ matrix.image }}
+        uses: anchore/scan-action@v5
+        id: scan
+        with:
+          image: "${{ matrix.image }}"
+          fail-build: false
+          severity-cutoff: critical
+          output-format: sarif
       - name: Upload Image Vulnerability Reports
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-          category: ${{ steps.scan.outputs.category }}
+          category: ${{ steps.category.outputs.category }}
 
   publish:
     if: (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')) && github.repository_owner == 'cabinetoffice'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,3 +1,6 @@
+# Run github actions locally with act https://github.com/nektos/act
+# act --container-architecture linux/amd64 --artifact-server-path ./build/artifacts -W ./.github/workflows/build.yml
+
 name: Build
 
 on:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,6 +59,7 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
       images: ${{ steps.save.outputs.images }}
+      images_json: ${{ steps.save.outputs.images_json }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -97,9 +98,12 @@ jobs:
         id: save
         run: |
           IMAGES=$(docker images | awk '$1 ~ /cabinetoffice\/cdp-/ && $2 ~ /^'$IMAGE_VERSION'$/ { print $1":"$2}' | tr '\n' ' ')
+          IMAGES_JSON=$(echo $IMAGES | tr " " "\n" | jq -R . | jq -c -s .)
           echo "Images to be saved: $IMAGES"
+          echo "Images to be saved (json): $IMAGES_JSON"
           docker save -o cdp-images.tar $IMAGES
           echo "images=${IMAGES}" >> $GITHUB_OUTPUT
+          echo "images_json=${IMAGES_JSON}" >> $GITHUB_OUTPUT
         env:
           IMAGE_VERSION: ${{ steps.version.outputs.version }}
       - name: Upload Docker Images as Artifacts
@@ -112,8 +116,9 @@ jobs:
     runs-on: ubuntu-latest
     name: Scan for vulnerabilities
     needs: [test, package]
-    env:
-      IMAGES: ${{ needs.package.outputs.images }}
+    strategy:
+      matrix:
+        image: ${{ fromJSON(needs.package.outputs.images_json) }}
     steps:
       - uses: actions/checkout@v4
 
@@ -126,18 +131,22 @@ jobs:
 
       - uses: anchore/scan-action/download-grype@v5
         id: grype
-      - name: Scan Docker Images
+      - name: Scan ${{ matrix.image }}
         id: scan
         run: |
           mkdir -p build/reports
-          echo "$IMAGES" | tr ' ' '\n' | xargs -I'{}' $GRYPE_CMD -o sarif '{}' --file 'build/reports/{}.sarif'
+          image=${{ matrix.image }}
+          category=${image%%:*}
+          $GRYPE_CMD -o sarif "$image" --file "build/reports/$category.sarif"
           echo "sarif=build/reports" >> $GITHUB_OUTPUT
+          echo "category=$category" >> $GITHUB_OUTPUT
         env:
           GRYPE_CMD: ${{ steps.grype.outputs.cmd }}
       - name: Upload Image Vulnerability Reports
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
+          category: ${{ steps.scan.outputs.category }}
 
   publish:
     if: (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')) && github.repository_owner == 'cabinetoffice'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,6 +93,18 @@ jobs:
         run: make down
         env:
           IMAGE_VERSION: ${{ steps.version.outputs.version }}
+      - name: Scan Images for Vulnerabilities
+        uses: anchore/scan-action@v5
+        id: scan
+        with:
+          path: "."
+          fail-build: true
+          severity-cutoff: critical
+          output-format: sarif
+      - name: Upload Image Vulnerability Report
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: ${{ steps.scan.outputs.sarif }}
       - name: Save Docker Images
         id: save
         run: |


### PR DESCRIPTION
Each container we built will now be scanned for vulnerabilities with Grype.

<img width="657" alt="image" src="https://github.com/user-attachments/assets/5ef24fb8-407d-476c-b820-86b54d767d77">

Since there are existing vulnerabilities on base docker containers, I did not opt to fail the build if vulnerabilities are found, since it would hinder development. I also opted to only run these scans on the main branch and for tags.

Vulnerabilities are reported on GitHub and are hidden from the public: https://github.com/cabinetoffice/GCGS-Central-Digital-Platform/security/code-scanning?query=pr%3A1008+is%3Aopen

<img width="944" alt="image" src="https://github.com/user-attachments/assets/7d51f30b-af26-49f3-a5d6-30a280279fc9">

