### PR TITLE
DP-925 Allow application to manage its own EC token for Data Protection

### DIFF
--- a/terragrunt/modules/ecs/datasource.tf
+++ b/terragrunt/modules/ecs/datasource.tf
@@ -97,6 +97,20 @@ data "aws_iam_policy_document" "ecs_task_access_queue" {
   }
 }
 
+data "aws_iam_policy_document" "ecs_task_access_elasticache" {
+  statement {
+    sid    = "AllowAppToManageItsOwnDataProtectionToken"
+    effect = "Allow"
+    actions = [
+      "ssm:GetParametersByPath",
+      "ssm:PutParameter"
+    ]
+    resources = [
+      "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter/${local.name_prefix}-ec-*"
+    ]
+  }
+}
+
 data "aws_iam_policy_document" "ecs_task_serilog" {
   statement {
     sid    = "AllowSerilogCreateStreamAndLog"

--- a/terragrunt/modules/ecs/iam.tf
+++ b/terragrunt/modules/ecs/iam.tf
@@ -20,6 +20,17 @@ resource "aws_iam_role_policy_attachment" "ecs_task_access_queue" {
   role       = var.role_ecs_task_name
 }
 
+resource "aws_iam_policy" "ecs_task_access_elasticache" {
+  name   = "${local.name_prefix}-ecs-task-access-elasticache"
+  policy = data.aws_iam_policy_document.ecs_task_access_elasticache.json
+  tags   = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_task_access_elasticache" {
+  policy_arn = aws_iam_policy.ecs_task_access_elasticache.arn
+  role       = var.role_ecs_task_name
+}
+
 resource "aws_iam_policy" "ecs_task_serilog" {
   name   = "${local.name_prefix}-ecs-task-serilog"
   policy = data.aws_iam_policy_document.ecs_task_serilog.json


### PR DESCRIPTION
We would like to merge small, unblocker PRs even thought the full functionality is not in place yet. (More details in [this thread ](https://goacoglobal.slack.com/archives/C06M34UGL59/p1733243497005579))

This one has been proven in development, for new parameter has been created once new instances came up and their value were populated successfully. 


