### PR TITLE
DP-925 Remove ElastiCache transit & at-rest encryption

### DIFF
--- a/terragrunt/modules/elasticache/redis.tf
+++ b/terragrunt/modules/elasticache/redis.tf
@@ -1,8 +1,6 @@
 resource "aws_elasticache_replication_group" "this" {
   at_rest_encryption_enabled  = true
   apply_immediately           = true
-  auth_token                  = aws_secretsmanager_secret_version.redis_auth_token.secret_string
-  auth_token_update_strategy  = "ROTATE"
   automatic_failover_enabled  = true
   description                 = "Redis cluster for organisation-app's authentication sessions"
   engine                      = var.engine
@@ -17,7 +15,7 @@ resource "aws_elasticache_replication_group" "this" {
   security_group_ids          = [var.elasticache_redis_sg_id]
   subnet_group_name           = aws_elasticache_subnet_group.this.name
   tags                        = var.tags
-  transit_encryption_enabled  = true
+  transit_encryption_enabled  = false
 
   log_delivery_configuration {
     destination      = aws_cloudwatch_log_group.slow_log.name


### PR DESCRIPTION
  - Temporarily disabled encryption as the application cannot connect using a secure connection