### PR TITLE
Bugfix/dp 945 Add buyer information to Organisation Overview screen

### DIFF
--- a/Frontend/CO.CDP.OrganisationApp/Constants/DevolvedRegulation.cs
+++ b/Frontend/CO.CDP.OrganisationApp/Constants/DevolvedRegulation.cs
@@ -32,6 +32,17 @@ public static class DevolvedRegulationsExtensions
         }
     }
 
+    public static DevolvedRegulation AsDevolvedRegulation(this WebApiClient.DevolvedRegulation devolvedRegulation)
+    {
+        switch (devolvedRegulation)
+        {
+            case WebApiClient.DevolvedRegulation.NorthernIreland: return DevolvedRegulation.NorthernIreland;
+            case WebApiClient.DevolvedRegulation.Scotland: return DevolvedRegulation.Scotland;
+            case WebApiClient.DevolvedRegulation.Wales: return DevolvedRegulation.Wales;
+            default: return DevolvedRegulation.NorthernIreland;
+        }
+    }
+
     public static ICollection<WebApiClient.DevolvedRegulation> AsApiClientDevolvedRegulationList(this List<DevolvedRegulation> devolvedRegulation)
     {
         var list = new List<WebApiClient.DevolvedRegulation>();
@@ -39,6 +50,18 @@ public static class DevolvedRegulationsExtensions
         foreach (var item in devolvedRegulation)
         {
             list.Add(item.AsApiClientDevolvedRegulation());
+        }
+
+        return list;
+    }
+
+    public static List<DevolvedRegulation> AsDevolvedRegulationList(this ICollection<WebApiClient.DevolvedRegulation> devolvedRegulation)
+    {
+        var list = new List<DevolvedRegulation>();
+
+        foreach (var item in devolvedRegulation)
+        {
+            list.Add(item.AsDevolvedRegulation());
         }
 
         return list;

--- a/Frontend/CO.CDP.OrganisationApp/Pages/Organisation/OrganisationOverview.cshtml
+++ b/Frontend/CO.CDP.OrganisationApp/Pages/Organisation/OrganisationOverview.cshtml
@@ -3,7 +3,11 @@
 @using CO.CDP.OrganisationApp.Pages
 @using CO.CDP.OrganisationApp.WebApiClients
 @using CO.CDP.Localization
+@using CO.CDP.Organisation.WebApiClient
+@using CO.CDP.OrganisationApp.Pages.Registration
+@using CO.CDP.OrganisationApp.TagHelpers
 @using Microsoft.AspNetCore.Mvc.Localization
+@using Microsoft.AspNetCore.Mvc.TagHelpers
 @inject IUserInfoService userInfoService
 @model OrganisationOverviewModel
 
@@ -145,6 +149,50 @@
                                     <a class="govuk-link govuk-link--no-visited-state" href="/organisation/@Model.Id/address/@(registeredAddress.Country == Country.UKCountryCode ? "uk" : "non-uk")?frm-overview">@Html.Raw(StaticTextResource.Organisation_ChangeAddress)</a>
                                 </dd>
                             </authorize>
+                        </div>
+                    }
+
+                    @if (Model.BuyerInformation != null)
+                    {
+                        <div class="govuk-summary-list__row">
+                            <dt class="govuk-summary-list__key">
+                                Organisation type
+                            </dt>
+                            <dd class="govuk-summary-list__value">
+                                <p class="govuk-body">
+                                    @(BuyerOrganisationTypeModel.BuyerTypes[Model.BuyerInformation.BuyerType!])
+                                </p>
+                            </dd>
+                        </div>
+
+                        <div class="govuk-summary-list__row">
+                            <dt class="govuk-summary-list__key">
+                                @* @StaticTextResource.Organisation_DevolvedRegulations *@
+                                Devolved regulations
+                            </dt>
+                            <dd class="govuk-summary-list__value">
+                                <p class="govuk-body">
+                                    @(Model.BuyerInformation.DevolvedRegulations.Count > 0 ? "Yes" : "No")
+                                </p>
+                            </dd>
+                        </div>
+
+                        <div class="govuk-summary-list__row">
+                            <dt class="govuk-summary-list__key">
+                                @* @StaticTextResource.Organisation_DevolvedRegulations *@
+                                Devolved regions
+                            </dt>
+                            <dd class="govuk-summary-list__value">
+                                <p class="govuk-body">
+                                    @if (Model.Regulations != null)
+                                    {
+                                        foreach (var regulation in Model.Regulations)
+                                        {
+                                            @regulation.Description()<br/>
+                                        }
+                                    }
+                                </p>
+                            </dd>
                         </div>
                     }
                 </dl>

--- a/Frontend/CO.CDP.OrganisationApp/Pages/Organisation/OrganisationOverview.cshtml
+++ b/Frontend/CO.CDP.OrganisationApp/Pages/Organisation/OrganisationOverview.cshtml
@@ -156,7 +156,7 @@
                     {
                         <div class="govuk-summary-list__row">
                             <dt class="govuk-summary-list__key">
-                                Organisation type
+                                @StaticTextResource.Organisation_BuyerType
                             </dt>
                             <dd class="govuk-summary-list__value">
                                 <p class="govuk-body">
@@ -167,8 +167,7 @@
 
                         <div class="govuk-summary-list__row">
                             <dt class="govuk-summary-list__key">
-                                @* @StaticTextResource.Organisation_DevolvedRegulations *@
-                                Devolved regulations
+                                @StaticTextResource.Organisation_DevolvedRegulations
                             </dt>
                             <dd class="govuk-summary-list__value">
                                 <p class="govuk-body">
@@ -179,8 +178,7 @@
 
                         <div class="govuk-summary-list__row">
                             <dt class="govuk-summary-list__key">
-                                @* @StaticTextResource.Organisation_DevolvedRegulations *@
-                                Devolved regions
+                                @StaticTextResource.Organisation_DevolvedRegions
                             </dt>
                             <dd class="govuk-summary-list__value">
                                 <p class="govuk-body">

--- a/Frontend/CO.CDP.OrganisationApp/Pages/Organisation/OrganisationOverview.cshtml.cs
+++ b/Frontend/CO.CDP.OrganisationApp/Pages/Organisation/OrganisationOverview.cshtml.cs
@@ -1,8 +1,10 @@
 using CO.CDP.Organisation.WebApiClient;
 using CO.CDP.OrganisationApp.Constants;
+using CO.CDP.OrganisationApp.WebApiClients;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using DevolvedRegulation = CO.CDP.OrganisationApp.Constants.DevolvedRegulation;
 using OrganisationWebApiClient = CO.CDP.Organisation.WebApiClient;
 
 namespace CO.CDP.OrganisationApp.Pages.Organisation;
@@ -11,6 +13,10 @@ namespace CO.CDP.OrganisationApp.Pages.Organisation;
 public class OrganisationOverviewModel(IOrganisationClient organisationClient) : PageModel
 {
     public OrganisationWebApiClient.Organisation? OrganisationDetails { get; set; }
+
+    public BuyerInformation? BuyerInformation { get; set; }
+
+    public List<DevolvedRegulation>? Regulations { get; set; }
     public Review? Review { get; set; }
 
     [BindProperty(SupportsGet = true)]
@@ -21,6 +27,16 @@ public class OrganisationOverviewModel(IOrganisationClient organisationClient) :
         try
         {
             OrganisationDetails = await organisationClient.GetOrganisationAsync(Id);
+
+            if (OrganisationDetails.IsBuyer() || OrganisationDetails.IsPendingBuyer())
+            {
+                BuyerInformation = await organisationClient.GetOrganisationBuyerInformationAsync(OrganisationDetails.Id);
+
+                var devolvedRegulations = BuyerInformation.DevolvedRegulations;
+
+                Regulations = devolvedRegulations.AsDevolvedRegulationList();
+            }
+
             if (OrganisationDetails.Details.PendingRoles.Count > 0)
             {
                 Review = (await organisationClient.GetOrganisationReviewsAsync(Id)).FirstOrDefault();

--- a/Services/CO.CDP.Localization/StaticTextResource.resx
+++ b/Services/CO.CDP.Localization/StaticTextResource.resx
@@ -1452,6 +1452,15 @@
   <data name="Organisation_OrganisationIdentification_ODS_Code_ErrorMessage" xml:space="preserve">
     <value>Enter the code</value>
   </data>
+  <data name="Organisation_BuyerType" xml:space="preserve">
+    <value>Organisation type</value>
+  </data>
+  <data name="Organisation_DevolvedRegulations" xml:space="preserve">
+    <value>Devolved regulations</value>
+  </data>
+  <data name="Organisation_DevolvedRegions" xml:space="preserve">
+    <value>Devolved regions</value>
+  </data>
   <data name="ShareYourInformation_Title" xml:space="preserve">
     <value>Share your supplier information</value>
   </data>

--- a/Services/CO.CDP.Organisation.WebApi.Tests/UseCase/GetBuyerInformationUseCaseTest.cs
+++ b/Services/CO.CDP.Organisation.WebApi.Tests/UseCase/GetBuyerInformationUseCaseTest.cs
@@ -1,0 +1,89 @@
+using CO.CDP.Organisation.WebApi.Model;
+using CO.CDP.Organisation.WebApi.Tests.AutoMapper;
+using CO.CDP.Organisation.WebApi.UseCase;
+using CO.CDP.OrganisationInformation;
+using CO.CDP.OrganisationInformation.Persistence;
+using FluentAssertions;
+using Moq;
+using Persistence = CO.CDP.OrganisationInformation.Persistence;
+
+namespace CO.CDP.Organisation.WebApi.Tests.UseCase;
+
+public class GetBuyerInformationUseCaseTest(AutoMapperFixture mapperFixture)
+    : IClassFixture<AutoMapperFixture>
+{
+    private readonly Mock<IOrganisationRepository> _repository = new();
+    private GetBuyerInformationUseCase UseCase => new(_repository.Object, mapperFixture.Mapper);
+
+    [Fact]
+    public async Task Execute_ValidOrganisationWithBuyerInfo_ReturnsBuyerInformation()
+    {
+        var organisationId = Guid.NewGuid();
+        var organisation = FakeOrganisation();
+
+        _repository.Setup(repo => repo.Find(organisationId))
+            .ReturnsAsync(organisation);
+
+        var result = await UseCase.Execute(organisationId);
+
+        result.Should().NotBeNull();
+        result.As<BuyerInformation>().BuyerType.Should().Be("FakeBuyerType");
+        result.As<BuyerInformation>().DevolvedRegulations.Should().NotBeNullOrEmpty();
+        result.As<BuyerInformation>().DevolvedRegulations.Should().Contain(DevolvedRegulation.NorthernIreland);
+    }
+
+    [Fact]
+    public async Task Execute_OrganisationNotFound_ReturnsNull()
+    {
+        var organisationId = Guid.NewGuid();
+
+        _repository.Setup(repo => repo.Find(organisationId))
+            .ReturnsAsync((Persistence.Organisation?)null);
+
+        var result = await UseCase.Execute(organisationId);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Execute_OrganisationWithoutBuyerInfo_ReturnsNull()
+    {
+        var organisationId = Guid.NewGuid();
+
+        _repository.Setup(repo => repo.Find(organisationId))
+            .ReturnsAsync(FakeOrganisation(false));
+
+        var result = await UseCase.Execute(organisationId);
+
+        result.Should().BeNull();
+    }
+
+    private static Persistence.Organisation FakeOrganisation(bool? withBuyerInfo = true)
+    {
+        Persistence.Organisation org = new()
+        {
+            Guid = Guid.NewGuid(),
+            Name = "FakeOrg",
+            Tenant = new Tenant
+            {
+                Guid = Guid.NewGuid(),
+                Name = "Tenant 101"
+            },
+            ContactPoints = [new Persistence.Organisation.ContactPoint { Email = "contact@test.org" }]
+        };
+
+        if (withBuyerInfo == true)
+        {
+            var devolvedRegulations = new List<DevolvedRegulation>();
+            devolvedRegulations.Add(DevolvedRegulation.NorthernIreland);
+
+            org.BuyerInfo = new Persistence.Organisation.BuyerInformation
+            {
+                BuyerType = "FakeBuyerType",
+                DevolvedRegulations = devolvedRegulations,
+            };
+        }
+
+        return org;
+    }
+}

--- a/Services/CO.CDP.Organisation.WebApi/Api/Organisation.cs
+++ b/Services/CO.CDP.Organisation.WebApi/Api/Organisation.cs
@@ -389,6 +389,34 @@ public static class EndpointExtensions
                 operation.Responses["500"].Description = "Internal server error.";
                 return operation;
             });
+
+        app.MapGet("/{organisationId}/buyer-information",
+                [OrganisationAuthorize(
+                    [AuthenticationChannel.OneLogin],
+                    [Constants.OrganisationPersonScope.Admin, Constants.OrganisationPersonScope.Editor, Constants.OrganisationPersonScope.Viewer],
+                    OrganisationIdLocation.Path,
+                    [Constants.PersonScope.SupportAdmin])]
+                async (Guid organisationId, IUseCase<Guid, BuyerInformation?> useCase) =>
+                    await useCase.Execute(organisationId)
+                        .AndThen(buyer => buyer != null ? Results.Ok(buyer) : Results.NotFound()))
+            .Produces<BuyerInformation>(StatusCodes.Status200OK, "application/json")
+            .Produces<ProblemDetails>(StatusCodes.Status401Unauthorized)
+            .Produces<ProblemDetails>(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status422UnprocessableEntity)
+            .Produces<ProblemDetails>(StatusCodes.Status500InternalServerError)
+            .WithOpenApi(operation =>
+            {
+                operation.OperationId = "GetOrganisationBuyerInformation";
+                operation.Description = "Get organisation buyer information by ID.";
+                operation.Summary = "Get organisation buyer information by ID.";
+                operation.Responses["200"].Description = "Organisation buyer information details.";
+                operation.Responses["401"].Description = "Valid authentication credentials are missing in the request.";
+                operation.Responses["404"].Description = "Organisation buyer information not found.";
+                operation.Responses["422"].Description = "Unprocessable entity.";
+                operation.Responses["500"].Description = "Internal server error.";
+                return operation;
+            });
+
         return app;
     }
 
@@ -804,7 +832,7 @@ public static class EndpointExtensions
                 operation.Responses["500"].Description = "Internal server error.";
                 return operation;
             });
-        
+
         return app;
     }
 

--- a/Services/CO.CDP.Organisation.WebApi/AutoMapper/WebApiToPersistenceProfile.cs
+++ b/Services/CO.CDP.Organisation.WebApi/AutoMapper/WebApiToPersistenceProfile.cs
@@ -127,6 +127,8 @@ public class WebApiToPersistenceProfile : Profile
         CreateMap<Persistence.Organisation.SupplierInformation, SupplierInformation>()
             .ForMember(m => m.OrganisationName, o => o.Ignore());
 
+        CreateMap<Persistence.Organisation.BuyerInformation, BuyerInformation>();
+
         CreateMap<LegalForm, Persistence.Organisation.LegalForm>()
             .ForMember(m => m.CreatedOn, o => o.Ignore())
             .ForMember(m => m.UpdatedOn, o => o.Ignore())

--- a/Services/CO.CDP.Organisation.WebApi/Program.cs
+++ b/Services/CO.CDP.Organisation.WebApi/Program.cs
@@ -96,6 +96,7 @@ builder.Services.AddScoped<IUseCase<(Guid, OrganisationJoinRequestStatus?), IEnu
 builder.Services.AddScoped<IUseCase<(Guid, Guid, UpdateJoinRequest), bool>, UpdateJoinRequestUseCase>();
 builder.Services.AddScoped<IUseCase<ProvideFeedbackAndContact, bool>, ProvideFeedbackAndContactUseCase>();
 builder.Services.AddScoped<IUseCase<ContactUs, bool>, ContactUsUseCase>();
+builder.Services.AddScoped<IUseCase<Guid, BuyerInformation?>, GetBuyerInformationUseCase>();
 
 builder.Services.AddProblemDetails();
 

--- a/Services/CO.CDP.Organisation.WebApi/UseCase/GetBuyerInformationUseCase.cs
+++ b/Services/CO.CDP.Organisation.WebApi/UseCase/GetBuyerInformationUseCase.cs
@@ -1,0 +1,19 @@
+using AutoMapper;
+using CO.CDP.Organisation.WebApi.Model;
+using CO.CDP.OrganisationInformation.Persistence;
+
+namespace CO.CDP.Organisation.WebApi.UseCase;
+public class GetBuyerInformationUseCase(IOrganisationRepository organisationRepository, IMapper mapper)
+    : IUseCase<Guid, BuyerInformation?>
+{
+    public async Task<BuyerInformation?> Execute(Guid command)
+    {
+        var organisation = await organisationRepository.Find(command);
+        if (organisation == null || organisation.BuyerInfo == null)
+        {
+            return null;
+        }
+
+        return mapper.Map<BuyerInformation>(organisation.BuyerInfo);
+    }
+}


### PR DESCRIPTION
The buyer information fields were missing from the organisation overview screen. This PR adds the GET buyer info endpoint and uses it to grab the info to display on the organisation overview screen.