### PR TITLE
Update POST /organisations to use the logged in user rather than the one passed in the payload

### DIFF
--- a/Frontend/CO.CDP.OrganisationApp/Pages/Registration/OrganisationDetailsSummary.cshtml.cs
+++ b/Frontend/CO.CDP.OrganisationApp/Pages/Registration/OrganisationDetailsSummary.cshtml.cs
@@ -95,8 +95,7 @@ public class OrganisationDetailsSummaryModel(
                 scheme: details.OrganisationScheme),
             name: details.OrganisationName,
             type: OrganisationWebApiClient.OrganisationType.Organisation,
-            roles: [details.OrganisationType!.Value.AsPartyRole()],
-            personId: user.PersonId.Value
+            roles: [details.OrganisationType!.Value.AsPartyRole()]
         );
     }
 }

--- a/Libraries/CO.CDP.Organisation.WebApiClient.Tests/CO.CDP.Organisation.WebApiClient.Tests.csproj
+++ b/Libraries/CO.CDP.Organisation.WebApiClient.Tests/CO.CDP.Organisation.WebApiClient.Tests.csproj
@@ -16,6 +16,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
     <PackageReference Include="xunit" Version="2.9.0" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Libraries/CO.CDP.Organisation.WebApiClient.Tests/OrganisationClientIntegrationTest.cs
+++ b/Libraries/CO.CDP.Organisation.WebApiClient.Tests/OrganisationClientIntegrationTest.cs
@@ -1,6 +1,7 @@
 using CO.CDP.GovUKNotify;
 using CO.CDP.OrganisationInformation.Persistence;
 using CO.CDP.TestKit.Mvc;
+using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using Xunit.Abstractions;
@@ -33,7 +34,6 @@ public class OrganisationClientIntegrationTest
     {
         IOrganisationClient client = new OrganisationClient("https://localhost", _httpClient);
 
-        var unknownPersonId = Guid.NewGuid();
         var identifier = new OrganisationIdentifier(
             scheme: "ISO9001",
             id: "1234567",
@@ -68,7 +68,6 @@ public class OrganisationClientIntegrationTest
             devolvedRegulations: [DevolvedRegulation.NorthernIreland, DevolvedRegulation.Wales]);
 
         var newOrganisation = new NewOrganisation(
-            personId: unknownPersonId,
             additionalIdentifiers: additionalIdentifiers,
             addresses: [address],
             contactPoint: contactPoint,
@@ -78,8 +77,10 @@ public class OrganisationClientIntegrationTest
             roles: roles
         );
 
-        var exception = await Assert.ThrowsAsync<ApiException<ProblemDetails>>(() => client.CreateOrganisationAsync(newOrganisation));
-        Assert.Equal(404, exception.StatusCode);
-        Assert.Contains("Unknown person", exception.Result.Detail);
+        Func<Task> act = async () => await client.CreateOrganisationAsync(newOrganisation);
+
+        var exception = await act.Should().ThrowAsync<ApiException<ProblemDetails>>();
+        exception.Which.StatusCode.Should().Be(404);
+        exception.Which.Result.Detail.Should().Contain("Unknown person");
     }
 }

--- a/Services/CO.CDP.Organisation.WebApi.Tests/Api/OrganisationEndpointsTests.cs
+++ b/Services/CO.CDP.Organisation.WebApi.Tests/Api/OrganisationEndpointsTests.cs
@@ -9,7 +9,6 @@ using Microsoft.Extensions.Hosting;
 using Moq;
 using System.Net;
 using System.Net.Http.Json;
-using System.Text.Json;
 using static CO.CDP.Authentication.Constants;
 using static System.Net.HttpStatusCode;
 
@@ -324,7 +323,6 @@ public class OrganisationEndpointsTests
         return new RegisterOrganisation
         {
             Name = "TheOrganisation",
-            PersonId = Guid.NewGuid(),
             Type = OrganisationType.Organisation,
             Identifier = new OrganisationIdentifier
             {

--- a/Services/CO.CDP.Organisation.WebApi/Model/Command.cs
+++ b/Services/CO.CDP.Organisation.WebApi/Model/Command.cs
@@ -12,9 +12,6 @@ public record RegisterOrganisation
 
     public required OrganisationType Type { get; set; } = OrganisationType.Organisation;
 
-    /// <example>"d230dbc1-b273-4e0e-8f58-d94f2ab3c096"</example>
-    [Required] public required Guid PersonId { get; init; }
-
     public required OrganisationIdentifier Identifier { get; init; }
 
     public List<OrganisationIdentifier>? AdditionalIdentifiers { get; init; }


### PR DESCRIPTION
dp-937 Update POST /organisations to use the logged in user rather than the one passed in the payload