### PR TITLE
DP-1002 Provision WAF & include its required IAM permissions

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,5 +1,5 @@
 [tools]
 dotnet = "8.0.401"
-terraform = "1.9.5"
-terragrunt = "0.66.9"
+terraform = "1.10.2"
+terragrunt = "0.69.10"
 poetry = "1.8.3"

--- a/terragrunt/modules/core-iam/terraform-global-datasource.tf
+++ b/terragrunt/modules/core-iam/terraform-global-datasource.tf
@@ -335,4 +335,16 @@ data "aws_iam_policy_document" "terraform_global" {
     sid = "ManageStateMachines"
   }
 
+  statement {
+    actions = [
+      "wafv2:CreateWebACL",
+      "wafv2:UpdateWebACL"
+    ]
+    effect = "Allow"
+    resources = [
+      "arn:aws:wafv2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:regional/managedruleset/*/*",
+    ]
+    sid = "ManageWAF"
+  }
+
 }

--- a/terragrunt/modules/core-iam/terraform-product-datasource.tf
+++ b/terragrunt/modules/core-iam/terraform-product-datasource.tf
@@ -226,4 +226,19 @@ data "aws_iam_policy_document" "terraform_product" {
     sid = "ManageProductCodebuild"
   }
 
+  statement {
+    actions = [
+      "wafv2:CreateWebACL",
+      "wafv2:TagResource",
+      "wafv2:GetWebACL",
+      "wafv2:ListTagsForResource",
+      "wafv2:UpdateWebACL",
+    ]
+    effect = "Allow"
+    resources = [
+      "arn:aws:wafv2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:regional/webacl/${local.name_prefix}-*"
+    ]
+    sid = "ManageProductWAF"
+  }
+
 }

--- a/terragrunt/modules/core-networking/locals.tf
+++ b/terragrunt/modules/core-networking/locals.tf
@@ -1,4 +1,15 @@
 locals {
+  name_prefix = var.product.resource_name
+
   production_subdomain = "supplier-information"
-  tags                 = merge(var.tags, { Name = var.product.resource_name })
+
+  tags = merge(var.tags, { Name = var.product.resource_name })
+
+  waf_rule_sets_priority = {
+    AWSManagedRulesAmazonIpReputationList : 2
+    AWSManagedRulesAnonymousIpList : 3
+    AWSManagedRulesBotControlRuleSet : 5
+    AWSManagedRulesCommonRuleSet : 1
+    AWSManagedRulesSQLiRuleSet : 4
+  }
 }

--- a/terragrunt/modules/core-networking/waf.tf
+++ b/terragrunt/modules/core-networking/waf.tf
@@ -1,0 +1,53 @@
+resource "aws_wafv2_web_acl" "this" {
+  name        = "${local.name_prefix}-acl"
+  description = "${local.name_prefix} Web ACL"
+  scope       = "REGIONAL" # "CLOUDFRONT" N.Virginia
+
+  default_action {
+    allow {}
+  }
+
+  custom_response_body {
+    key          = "${local.name_prefix}_blocked_request"
+    content      = "Access denied"
+    content_type = "TEXT_PLAIN"
+  }
+
+  dynamic "rule" {
+    for_each = local.waf_rule_sets_priority
+    content {
+      name     = "${local.name_prefix}-${rule.key}"
+      priority = rule.value
+
+      override_action {
+        none {}
+      }
+
+      statement {
+        managed_rule_group_statement {
+          name        = rule.key
+          vendor_name = "AWS"
+        }
+      }
+
+      visibility_config {
+        cloudwatch_metrics_enabled = true
+        metric_name                = "${local.name_prefix}-${rule.key}"
+        sampled_requests_enabled   = true
+      }
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "${local.name_prefix}-waf-acl"
+    sampled_requests_enabled   = true
+  }
+
+  tags = merge(
+    { Name = "${local.name_prefix}-acl" },
+    var.tags
+  )
+
+}
+

--- a/terragrunt/providers.tf
+++ b/terragrunt/providers.tf
@@ -1,9 +1,9 @@
 terraform {
-  required_version = "= 1.9.5"
+  required_version = "= 1.10.2"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.77.0"
+      version = "~> 5.80.0"
     }
     awscc = {
       source  = "hashicorp/awscc"


### PR DESCRIPTION
Also upgrade Tools and Providers

We are including more managed rules than defined in the ticket, while keeping the capacity bellow 1500 which impact the cost.

  - [Common](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs)
  - [Amazon IP Reputation (& Anonymous IP)](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-ip-rep.html#aws-managed-rule-groups-ip-rep-amazon)
  - [Bot Control](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-bot.html#aws-managed-rule-groups-bot-rules)
  - [SQL Injection](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-use-case.html#aws-managed-rule-groups-use-case-sql-db)

Once integrated with the load balance and tested, we might decide to lift some of the restriction.