### PR TITLE
Feature/dp 970 incorrect text heading postal address

### DIFF
--- a/Frontend/CO.CDP.OrganisationApp/Pages/Supplier/SupplierAddress.cshtml.cs
+++ b/Frontend/CO.CDP.OrganisationApp/Pages/Supplier/SupplierAddress.cshtml.cs
@@ -57,7 +57,8 @@ public class SupplierAddressModel(IOrganisationClient organisationClient) : Page
     public async Task<IActionResult> OnPost()
     {
         SetupAddress();
-        if (!ModelState.IsValid) return Page();
+        if (!ModelState.IsValid)
+            return Page();
 
         try
         {
@@ -85,10 +86,11 @@ public class SupplierAddressModel(IOrganisationClient organisationClient) : Page
 
     private void SetupAddress(bool reset = false)
     {
-        if (reset) Address = new AddressPartialModel { UkOrNonUk = UkOrNonUk };
+        if (reset)
+            Address = new AddressPartialModel { UkOrNonUk = UkOrNonUk };
 
         Address.Heading = AddressType == Constants.AddressType.Registered ?
-            StaticTextResource.Supplier_Address_EnterRegisteredAddress : StaticTextResource.Supplier_Address_EnterUkRegisteredAddress;
+            StaticTextResource.Supplier_Address_EnterRegisteredAddress : StaticTextResource.Supplier_Address_EnterOrganisationPostalAddress;
 
         Address.NonUkAddressLink = $"/organisation/{Id}/supplier-information/{AddressType.ToString().ToLower()}-address/non-uk";
     }

--- a/Services/CO.CDP.Localization/StaticTextResource.resx
+++ b/Services/CO.CDP.Localization/StaticTextResource.resx
@@ -2417,8 +2417,8 @@
   <data name="Supplier_Address_EnterRegisteredAddress" xml:space="preserve">
     <value>Enter your organisation's registered address</value>
   </data>
-  <data name="Supplier_Address_EnterUkRegisteredAddress" xml:space="preserve">
-    <value>Enter your organisation's UK postal address</value>
+  <data name="Supplier_Address_EnterOrganisationPostalAddress" xml:space="preserve">
+    <value>Enter your organisation's postal address</value>
   </data>
   <data name="Supplier_OperationQuestion_Title" xml:space="preserve">
     <value>How does your organisation operate?</value>


### PR DESCRIPTION
I have removed the word "UK" to keep it as in the prototype and title says  postal address for both UK and non UK


![image](https://github.com/user-attachments/assets/f54e38e9-de96-446d-bb20-753ea5b4d127)

