### PR TITLE
Disable shared sessions in frontend tests

### DIFF
--- a/Frontend/CO.CDP.OrganisationApp.Tests/AuthorizationTests.cs
+++ b/Frontend/CO.CDP.OrganisationApp.Tests/AuthorizationTests.cs
@@ -12,6 +12,7 @@ using System.Net;
 using Amazon.SimpleSystemsManagement;
 using CO.CDP.TestKit.Mvc;
 using Microsoft.AspNetCore.DataProtection.KeyManagement;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
@@ -118,6 +119,11 @@ public class AuthorizationTests
                 services.RemoveAll<IConfigureOptions<KeyManagementOptions>>();
                 services.AddDataProtection().DisableAutomaticKeyGeneration();
             });
+            builder.ConfigureHostConfiguration(c => c.AddInMemoryCollection(
+                [
+                    new KeyValuePair<string, string?>("Features:SharedSessions", "false")
+                ]
+            ));
         });
 
         return factory.CreateClient();

--- a/Frontend/CO.CDP.OrganisationApp.Tests/ContentSecurityPolicyTests.cs
+++ b/Frontend/CO.CDP.OrganisationApp.Tests/ContentSecurityPolicyTests.cs
@@ -13,6 +13,7 @@ using Amazon.SimpleSystemsManagement;
 using Microsoft.AspNetCore.DataProtection.KeyManagement;
 using Microsoft.Extensions.Options;
 using Microsoft.AspNetCore.DataProtection;
+using Microsoft.Extensions.Configuration;
 
 namespace CO.CDP.OrganisationApp.Tests;
 
@@ -74,6 +75,11 @@ public class ContentSecurityPolicyTests
                 services.RemoveAll<IConfigureOptions<KeyManagementOptions>>();
                 services.AddDataProtection().DisableAutomaticKeyGeneration();
             });
+            builder.ConfigureHostConfiguration(c => c.AddInMemoryCollection(
+                [
+                    new KeyValuePair<string, string?>("Features:SharedSessions", "false")
+                ]
+            ));
         });
 
         return factory.CreateClient();

--- a/Frontend/CO.CDP.OrganisationApp.Tests/LocalizationTests.cs
+++ b/Frontend/CO.CDP.OrganisationApp.Tests/LocalizationTests.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.DataProtection.KeyManagement;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Localization;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
@@ -70,6 +71,11 @@ public class LocalizationTests
                 services.RemoveAll<IConfigureOptions<KeyManagementOptions>>();
                 services.AddDataProtection().DisableAutomaticKeyGeneration();
             });
+            builder.ConfigureHostConfiguration(c => c.AddInMemoryCollection(
+                [
+                    new KeyValuePair<string, string?>("Features:SharedSessions", "false")
+                ]
+            ));
         });
 
         return factory.CreateClient();


### PR DESCRIPTION
Otherwise, tests try to connect to redis that is unavailable.

Based on Authorization tests, before:

2min 42sec (locally)

<img width="1429" alt="image" src="https://github.com/user-attachments/assets/f0f3e007-77c1-4d79-9601-31cb11f7a9f4" />

After:

17sec (locally)

<img width="1430" alt="image" src="https://github.com/user-attachments/assets/7cfbdf08-ff1a-41bf-b221-b0e3adbdeb9c" />

Github actions build, before:

<img width="312" alt="image" src="https://github.com/user-attachments/assets/d1dab03f-0323-4dba-9c4f-6c50705a65b5" />

After:

<img width="317" alt="image" src="https://github.com/user-attachments/assets/a45f1a71-7ff8-4324-acaf-dc325c1f4d2f" />

