### PR TITLE
DP-989: Reduce the default number of database connections in the pool to 10

### DIFF
--- a/Services/CO.CDP.DataSharing.WebApi/appsettings.Development.json
+++ b/Services/CO.CDP.DataSharing.WebApi/appsettings.Development.json
@@ -15,7 +15,8 @@
     "Server": "localhost",
     "Database": "cdp",
     "Username": "cdp_user",
-    "Password": "cdp123"
+    "Password": "cdp123",
+    "MaxPoolSize": 10
   },
   "Features": {
     "SwaggerUI": true

--- a/Services/CO.CDP.DataSharing.WebApi/appsettings.json
+++ b/Services/CO.CDP.DataSharing.WebApi/appsettings.json
@@ -19,7 +19,8 @@
     "Server": "localhost",
     "Database": "cdp",
     "Username": "cdp_user",
-    "Password": "cdp123"
+    "Password": "cdp123",
+    "MaxPoolSize": 10
   },
   "Features": {
     "SwaggerUI": false

--- a/Services/CO.CDP.EntityVerification/appsettings.Development.json
+++ b/Services/CO.CDP.EntityVerification/appsettings.Development.json
@@ -35,7 +35,8 @@
     "Server": "localhost",
     "Database": "cdp",
     "Username": "cdp_user",
-    "Password": "cdp123"
+    "Password": "cdp123",
+    "MaxPoolSize": 10
   },
   "Organisation:Authority": "http://localhost:8092",
   "Features": {

--- a/Services/CO.CDP.EntityVerification/appsettings.json
+++ b/Services/CO.CDP.EntityVerification/appsettings.json
@@ -34,7 +34,8 @@
     "Server": "",
     "Database": "",
     "Username": "",
-    "Password": ""
+    "Password": "",
+    "MaxPoolSize": 10
   },
   "Features": {
     "SwaggerUI": false

--- a/Services/CO.CDP.Forms.WebApi/appsettings.Development.json
+++ b/Services/CO.CDP.Forms.WebApi/appsettings.Development.json
@@ -15,7 +15,8 @@
     "Server": "localhost",
     "Database": "cdp",
     "Username": "cdp_user",
-    "Password": "cdp123"
+    "Password": "cdp123",
+    "MaxPoolSize": 10
   },
   "Features": {
     "SwaggerUI": true

--- a/Services/CO.CDP.Forms.WebApi/appsettings.json
+++ b/Services/CO.CDP.Forms.WebApi/appsettings.json
@@ -18,7 +18,8 @@
     "Server": "localhost",
     "Database": "cdp",
     "Username": "cdp_user",
-    "Password": "cdp123"
+    "Password": "cdp123",
+    "MaxPoolSize": 10
   },
   "Features": {
     "SwaggerUI": false

--- a/Services/CO.CDP.Organisation.Authority/appsettings.Development.json
+++ b/Services/CO.CDP.Organisation.Authority/appsettings.Development.json
@@ -16,7 +16,8 @@
     "Server": "localhost",
     "Database": "cdp",
     "Username": "cdp_user",
-    "Password": "cdp123"
+    "Password": "cdp123",
+    "MaxPoolSize": 10
   },
   "Features": {
     "SwaggerUI": true

--- a/Services/CO.CDP.Organisation.Authority/appsettings.json
+++ b/Services/CO.CDP.Organisation.Authority/appsettings.json
@@ -20,7 +20,8 @@
     "Server": "localhost",
     "Database": "cdp",
     "Username": "cdp_user",
-    "Password": "cdp123"
+    "Password": "cdp123",
+    "MaxPoolSize": 10
   },
   "Features": {
     "SwaggerUI": false

--- a/Services/CO.CDP.Organisation.WebApi/appsettings.Development.json
+++ b/Services/CO.CDP.Organisation.WebApi/appsettings.Development.json
@@ -17,7 +17,8 @@
     "Server": "localhost",
     "Database": "cdp",
     "Username": "cdp_user",
-    "Password": "cdp123"
+    "Password": "cdp123",
+    "MaxPoolSize": 10
   },
   "Aws": {
     "Credentials": {

--- a/Services/CO.CDP.Organisation.WebApi/appsettings.json
+++ b/Services/CO.CDP.Organisation.WebApi/appsettings.json
@@ -33,7 +33,8 @@
     "Server": "localhost",
     "Database": "cdp",
     "Username": "cdp_user",
-    "Password": "cdp123"
+    "Password": "cdp123",
+    "MaxPoolSize": 10
   },
   "Aws": {
     "SqsDispatcher": {

--- a/Services/CO.CDP.Person.WebApi/appsettings.Development.json
+++ b/Services/CO.CDP.Person.WebApi/appsettings.Development.json
@@ -15,7 +15,8 @@
     "Server": "localhost",
     "Database": "cdp",
     "Username": "cdp_user",
-    "Password": "cdp123"
+    "Password": "cdp123",
+    "MaxPoolSize": 10
   },
   "Features": {
     "SwaggerUI": true

--- a/Services/CO.CDP.Person.WebApi/appsettings.json
+++ b/Services/CO.CDP.Person.WebApi/appsettings.json
@@ -15,7 +15,8 @@
     "Server": "localhost",
     "Database": "cdp",
     "Username": "cdp_user",
-    "Password": "cdp123"
+    "Password": "cdp123",
+    "MaxPoolSize": 10
   },
   "ForwardedHeaders": {
     "KnownNetwork": ""

--- a/Services/CO.CDP.Tenant.WebApi/appsettings.Development.json
+++ b/Services/CO.CDP.Tenant.WebApi/appsettings.Development.json
@@ -15,7 +15,8 @@
     "Server": "localhost",
     "Database": "cdp",
     "Username": "cdp_user",
-    "Password": "cdp123"
+    "Password": "cdp123",
+    "MaxPoolSize": 10
   },
   "Features": {
     "SwaggerUI": true

--- a/Services/CO.CDP.Tenant.WebApi/appsettings.json
+++ b/Services/CO.CDP.Tenant.WebApi/appsettings.json
@@ -15,7 +15,8 @@
     "Server": "localhost",
     "Database": "cdp",
     "Username": "cdp_user",
-    "Password": "cdp123"
+    "Password": "cdp123",
+    "MaxPoolSize": 10
   },
   "ForwardedHeaders": {
     "KnownNetwork": ""


### PR DESCRIPTION
This brings the number of connections down so that we do not exceed the number in the pool.

Performance tests will reveal if this is sufficient or requires further tweaks.

Builds on top of #1032 and #1037