### PR TITLE
DP-979 Add Aurora PostgreSQL Clusters for SIRSI & EV, Update PGAdmin

### DIFF
--- a/terragrunt/components/service/ecs/terragrunt.hcl
+++ b/terragrunt/components/service/ecs/terragrunt.hcl
@@ -92,6 +92,15 @@ dependency service_database {
     sirsi_kms_arn                       = "mock"
     sirsi_name                          = "mock"
 
+    entity_verification_cluster_address                = "mock"
+    entity_verification_cluster_credentials_arn        = "mock"
+    entity_verification_cluster_credentials_kms_key_id = "mock"
+    entity_verification_cluster_name                   = "mock"
+    sirsi_cluster_address                              = "mock"
+    sirsi_cluster_credentials_arn                      = "mock"
+    sirsi_cluster_credentials_kms_key_id               = "mock"
+    sirsi_cluster_name                                 = "mock"
+
   }
 }
 
@@ -164,7 +173,15 @@ inputs = {
   db_entity_verification_credentials_arn = dependency.service_database.outputs.entity_verification_credentials_arn
   db_entity_verification_kms_arn         = dependency.service_database.outputs.entity_verification_kms_arn
   db_entity_verification_name            = dependency.service_database.outputs.entity_verification_name
+  db_ev_cluster_address                   = dependency.service_database.outputs.entity_verification_cluster_address
+  db_ev_cluster_credentials_arn           = dependency.service_database.outputs.entity_verification_cluster_credentials_arn
+  db_ev_cluster_credentials_kms_key_id    = dependency.service_database.outputs.entity_verification_cluster_credentials_kms_key_id
+  db_ev_cluster_name                      = dependency.service_database.outputs.entity_verification_cluster_name
   db_sirsi_address                       = dependency.service_database.outputs.sirsi_address
+  db_sirsi_cluster_address                = dependency.service_database.outputs.sirsi_cluster_address
+  db_sirsi_cluster_credentials_arn        = dependency.service_database.outputs.sirsi_cluster_credentials_arn
+  db_sirsi_cluster_credentials_kms_key_id = dependency.service_database.outputs.sirsi_cluster_credentials_kms_key_id
+  db_sirsi_cluster_name                   = dependency.service_database.outputs.sirsi_cluster_name
   db_sirsi_credentials_arn               = dependency.service_database.outputs.sirsi_credentials_arn
   db_sirsi_kms_arn                       = dependency.service_database.outputs.sirsi_kms_arn
   db_sirsi_name                          = dependency.service_database.outputs.sirsi_name

--- a/terragrunt/components/service/tools/terragrunt.hcl
+++ b/terragrunt/components/service/tools/terragrunt.hcl
@@ -83,16 +83,18 @@ dependency service_ecs {
 dependency service_database {
   config_path = "../../service/database"
   mock_outputs = {
-    entity_verification_address               = "mock"
-    entity_verification_connection_secret_arn = "mock"
-    entity_verification_credentials_arn       = "mock"
-    entity_verification_kms_arn               = "mock"
-    entity_verification_name                  = "mock"
-    sirsi_address                             = "mock"
-    sirsi_connection_secret_arn               = "mock"
-    sirsi_credentials_arn                     = "mock"
-    sirsi_kms_arn                             = "mock"
-    sirsi_name                                = "mock"
+    entity_verification_address                 = "mock"
+    entity_verification_cluster_address         = "mock"
+    entity_verification_cluster_credentials_arn = "mock"
+    entity_verification_cluster_name            = "mock"
+    entity_verification_credentials_arn         = "mock"
+    entity_verification_name                    = "mock"
+    sirsi_address                               = "mock"
+    sirsi_cluster_address                       = "mock"
+    sirsi_cluster_credentials_arn               = "mock"
+    sirsi_cluster_name                          = "mock"
+    sirsi_credentials_arn                       = "mock"
+    sirsi_name                                  = "mock"
   }
 }
 
@@ -141,11 +143,15 @@ inputs = {
 
   db_entity_verification_address         = dependency.service_database.outputs.entity_verification_address
   db_entity_verification_credentials_arn = dependency.service_database.outputs.entity_verification_credentials_arn
-  db_entity_verification_kms_arn         = dependency.service_database.outputs.entity_verification_kms_arn
   db_entity_verification_name            = dependency.service_database.outputs.entity_verification_name
+  db_ev_cluster_address                  = dependency.service_database.outputs.entity_verification_cluster_address
+  db_ev_cluster_credentials_arn          = dependency.service_database.outputs.entity_verification_cluster_credentials_arn
+  db_ev_cluster_name                     = dependency.service_database.outputs.entity_verification_cluster_name
   db_sirsi_address                       = dependency.service_database.outputs.sirsi_address
+  db_sirsi_cluster_address               = dependency.service_database.outputs.sirsi_cluster_address
+  db_sirsi_cluster_credentials_arn       = dependency.service_database.outputs.sirsi_cluster_credentials_arn
+  db_sirsi_cluster_name                  = dependency.service_database.outputs.sirsi_cluster_name
   db_sirsi_credentials_arn               = dependency.service_database.outputs.sirsi_credentials_arn
-  db_sirsi_kms_arn                       = dependency.service_database.outputs.sirsi_kms_arn
   db_sirsi_name                          = dependency.service_database.outputs.sirsi_name
 
   redis_primary_endpoint = dependency.service_cache.outputs.primary_endpoint_address

--- a/terragrunt/modules/core-iam/terraform-product-datasource.tf
+++ b/terragrunt/modules/core-iam/terraform-product-datasource.tf
@@ -170,10 +170,11 @@ data "aws_iam_policy_document" "terraform_product" {
     effect = "Allow"
     resources = [
       "arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:key*",
+      "arn:aws:secretsmanager:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:secret:${local.name_prefix}*",
       "arn:aws:secretsmanager:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:secret:events!connection/${local.name_prefix}-*",
+      "arn:aws:secretsmanager:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:secret:rds!cluster*",
       "arn:aws:secretsmanager:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:secret:rds!db*",
       "arn:aws:secretsmanager:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:secret:rds-db*",
-      "arn:aws:secretsmanager:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:secret:${local.name_prefix}*",
     ]
     sid = "ManageProductSecrets"
   }

--- a/terragrunt/modules/database/locals.tf
+++ b/terragrunt/modules/database/locals.tf
@@ -1,3 +1,5 @@
 locals {
   name_prefix = var.product.resource_name
+  sirsi_cluster_name = "${local.name_prefix}-cluster"
+  ev_cluster_name = "${local.name_prefix}-ev-cluster"
 }

--- a/terragrunt/modules/database/outputs.tf
+++ b/terragrunt/modules/database/outputs.tf
@@ -2,6 +2,22 @@ output "entity_verification_address" {
   value = module.rds_entity_verification.db_address
 }
 
+output "entity_verification_cluster_address" {
+  value = module.cluster_entity_verification.db_address
+}
+
+output "entity_verification_cluster_credentials_arn" {
+  value = module.cluster_entity_verification.db_master_user_secret_arn
+}
+
+output "entity_verification_cluster_credentials_kms_key_id" {
+  value = module.cluster_entity_verification.db_master_user_secret_kms_key_id
+}
+
+output "entity_verification_cluster_name" {
+  value = module.cluster_entity_verification.db_name
+}
+
 output "entity_verification_credentials_arn" {
   value = module.rds_entity_verification.db_credentials_arn
 }
@@ -16,6 +32,22 @@ output "entity_verification_name" {
 
 output "sirsi_address" {
   value = module.rds_sirsi.db_address
+}
+
+output "sirsi_cluster_address" {
+  value = module.cluster_sirsi.db_address
+}
+
+output "sirsi_cluster_credentials_arn" {
+  value = module.cluster_sirsi.db_master_user_secret_arn
+}
+
+output "sirsi_cluster_credentials_kms_key_id" {
+  value = module.cluster_sirsi.db_master_user_secret_arn
+}
+
+output "sirsi_cluster_name" {
+  value = module.cluster_sirsi.db_name
 }
 
 output "sirsi_credentials_arn" {

--- a/terragrunt/modules/database/rds-entity-verification.tf
+++ b/terragrunt/modules/database/rds-entity-verification.tf
@@ -19,3 +19,21 @@ module "rds_entity_verification" {
   role_terraform_arn           = var.role_terraform_arn
   tags                         = var.tags
 }
+
+module "cluster_entity_verification" {
+  source = "../db-postgres-cluster"
+
+  backup_retention_period      = var.is_production ? 35 : 1
+  db_name                      = local.ev_cluster_name
+  db_sg_id                     = var.db_postgres_sg_id
+  deletion_protection          = var.is_production
+  engine_version               = var.aurora_postgres_engine_version
+  family                       = "aurora-postgresql${floor(var.aurora_postgres_engine_version)}"
+  monitoring_interval          = var.is_production ? 30 : 0
+  monitoring_role_arn          = var.is_production ? var.role_rds_cloudwatch_arn : ""
+  performance_insights_enabled = var.is_production
+  instance_type                = var.aurora_postgres_instance_type
+  private_subnet_ids           = var.private_subnet_ids
+  role_terraform_arn           = var.role_terraform_arn
+  tags                         = var.tags
+}

--- a/terragrunt/modules/database/rds-sirsi.tf
+++ b/terragrunt/modules/database/rds-sirsi.tf
@@ -19,3 +19,21 @@ module "rds_sirsi" {
   role_terraform_arn           = var.role_terraform_arn
   tags                         = var.tags
 }
+
+module "cluster_sirsi" {
+  source = "../db-postgres-cluster"
+
+  backup_retention_period      = var.is_production ? 35 : 1
+  db_name                      = local.sirsi_cluster_name
+  db_sg_id                     = var.db_postgres_sg_id
+  deletion_protection          = var.is_production
+  engine_version               = var.aurora_postgres_engine_version
+  family                       = "aurora-postgresql${floor(var.aurora_postgres_engine_version)}"
+  monitoring_interval          = var.is_production ? 30 : 0
+  monitoring_role_arn          = var.is_production ? var.role_rds_cloudwatch_arn : ""
+  performance_insights_enabled = var.is_production
+  instance_type                = var.aurora_postgres_instance_type
+  private_subnet_ids           = var.private_subnet_ids
+  role_terraform_arn           = var.role_terraform_arn
+  tags                         = var.tags
+}

--- a/terragrunt/modules/database/variables.tf
+++ b/terragrunt/modules/database/variables.tf
@@ -1,3 +1,15 @@
+variable "aurora_postgres_engine_version" {
+  description = "DB engine version"
+  type        = string
+  default     = "16.6"
+}
+
+variable "aurora_postgres_instance_type" {
+  description = "RDS instance type for individual environments"
+  type        = string
+  default     = "db.r5.large"
+}
+
 variable "db_postgres_sg_id" {
   description = "Postgres DB security group ID"
   type        = string

--- a/terragrunt/modules/db-postgres-cluster/kms.tf
+++ b/terragrunt/modules/db-postgres-cluster/kms.tf
@@ -1,0 +1,14 @@
+module "storage_encryption_key" {
+  source = "../kms"
+
+  custom_policies          = []
+  customer_master_key_spec = "SYMMETRIC_DEFAULT"
+  deletion_window_in_days  = 7
+  description              = "RDS at rest encryption key for ${var.db_name}"
+  key_admin_role           = var.role_terraform_arn
+  key_alias                = "rds-${var.db_name}"
+  key_usage                = "ENCRYPT_DECRYPT"
+  key_user_arns            = []
+  other_aws_accounts       = {}
+  tags                     = var.tags
+}

--- a/terragrunt/modules/db-postgres-cluster/outputs.tf
+++ b/terragrunt/modules/db-postgres-cluster/outputs.tf
@@ -1,0 +1,15 @@
+output "db_address" {
+  value = aws_rds_cluster.this.endpoint
+}
+
+output "db_master_user_secret_arn" {
+  value = aws_rds_cluster.this.master_user_secret[0].secret_arn
+}
+
+output "db_master_user_secret_kms_key_id" {
+  value = aws_rds_cluster.this.master_user_secret[0].kms_key_id
+}
+
+output "db_name" {
+  value = aws_rds_cluster.this.database_name
+}

--- a/terragrunt/modules/db-postgres-cluster/parameter-groups.tf
+++ b/terragrunt/modules/db-postgres-cluster/parameter-groups.tf
@@ -1,0 +1,33 @@
+
+resource "aws_db_parameter_group" "this" {
+  family = var.family
+  name   = "${var.db_name}-instance"
+
+  dynamic "parameter" {
+    for_each = var.db_parameters_instance
+    content {
+      apply_method = "pending-reboot"
+      name         = parameter.key
+      value        = parameter.value
+    }
+  }
+
+  tags = var.tags
+}
+
+
+resource "aws_rds_cluster_parameter_group" "this" {
+  family = var.family
+  name   = "${var.db_name}-cluster"
+
+  dynamic "parameter" {
+    for_each = var.db_parameters_cluster
+    content {
+      apply_method = "pending-reboot"
+      name         = parameter.key
+      value        = parameter.value
+    }
+  }
+
+  tags = var.tags
+}

--- a/terragrunt/modules/db-postgres-cluster/rds-cluster.tf
+++ b/terragrunt/modules/db-postgres-cluster/rds-cluster.tf
@@ -1,0 +1,58 @@
+resource "aws_rds_cluster" "this" {
+  backup_retention_period          = var.backup_retention_period
+  cluster_identifier               = var.db_name
+  copy_tags_to_snapshot            = var.copy_tags_to_snapshot
+  database_name                    = replace(var.db_name, "-", "_")
+  db_cluster_parameter_group_name  = aws_rds_cluster_parameter_group.this.name
+  db_instance_parameter_group_name = aws_db_parameter_group.this.name
+  db_subnet_group_name             = aws_db_subnet_group.this.name
+  deletion_protection              = var.deletion_protection
+  engine                           = var.engine
+  engine_version                   = var.engine_version
+  kms_key_id                       = module.storage_encryption_key.key_arn
+  manage_master_user_password      = true
+  master_username                  = "${replace(var.db_name, "-", "_")}_user"
+  storage_encrypted                = true
+
+  vpc_security_group_ids = [var.db_sg_id]
+
+  tags = merge(
+    var.tags,
+    {
+      Name = replace(var.db_name, "-", "_")
+    }
+  )
+}
+
+resource "aws_db_subnet_group" "this" {
+  name       = "${var.db_name}-private-subnet-group"
+  subnet_ids = var.private_subnet_ids
+
+  tags = merge(
+    var.tags,
+    {
+      Name = "${var.db_name}-private-subnet-group"
+    }
+  )
+}
+
+resource "aws_rds_cluster_instance" "this" {
+  count = var.instance_count
+
+  cluster_identifier           = aws_rds_cluster.this.id
+  db_parameter_group_name      = aws_db_parameter_group.this.name
+  engine                       = var.engine
+  identifier                   = "${var.db_name}-${count.index}"
+  instance_class               = var.instance_type
+  monitoring_interval          = var.monitoring_interval
+  monitoring_role_arn          = var.monitoring_role_arn
+  performance_insights_enabled = var.performance_insights_enabled
+  publicly_accessible          = var.publicly_accessible
+
+  tags = merge(
+    var.tags,
+    {
+      Name = "${replace(var.db_name, "-", "_")}-${count.index}"
+    }
+  )
+}

--- a/terragrunt/modules/db-postgres-cluster/variables.tf
+++ b/terragrunt/modules/db-postgres-cluster/variables.tf
@@ -1,0 +1,111 @@
+variable "backup_retention_period" {
+  description = "The number of days to retain backups for"
+  type        = number
+  default     = 7
+}
+
+variable "copy_tags_to_snapshot" {
+  description = "Whether copy all Instance tags to snapshots"
+  type        = bool
+  default     = false
+}
+
+variable "db_name" {
+  description = "Data base name"
+  type        = string
+}
+
+variable "db_parameters_cluster" {
+  description = "A map of database parameters to apply to the RDS DB Cluster parameter group. Keys are parameter names, and values are the desired settings."
+  type        = map(string)
+  default     = {}
+}
+
+variable "db_parameters_instance" {
+  description = "A map of database parameters to apply to the RDS DB parameter group. Keys are parameter names, and values are the desired settings."
+  type        = map(string)
+  default     = {}
+}
+
+variable "db_sg_id" {
+  description = "DB security group ID"
+  type        = string
+}
+
+variable "deletion_protection" {
+  description = "If the DB instance should have deletion protection enabled"
+  type        = bool
+  default     = true
+}
+
+variable "engine" {
+  description = "RDS engine"
+  type        = string
+  default     = "aurora-postgresql"
+}
+
+variable "engine_version" {
+  description = "DB engine version"
+  type        = string
+  default     = "16.6"
+}
+
+variable "family" {
+  description = "The family of the DB parameter group"
+  type        = string
+}
+
+variable "instance_count" {
+  description = ""
+  type        = number
+  default     = 2
+}
+
+variable "instance_type" {
+  description = "RDS instance type for individual environments"
+  type        = string
+}
+
+variable "monitoring_interval" {
+  description = "The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance. To disable collecting Enhanced Monitoring metrics, specify 0."
+  type        = number
+  default     = 0
+
+  validation {
+    condition     = contains([0, 1, 5, 10, 15, 30, 60], var.monitoring_interval)
+    error_message = "Invalid value for monitoring_interval. Valid values are: 0, 1, 5, 10, 15, 30, 60 seconds."
+  }
+}
+
+variable "monitoring_role_arn" {
+  description = "The ARN for the IAM role that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. Required if monitoring_interval is greater than 0."
+  type        = string
+  default     = ""
+}
+
+variable "performance_insights_enabled" {
+  description = "Enable Performance Insights"
+  type        = bool
+  default     = true
+}
+
+variable "private_subnet_ids" {
+  description = "List of private subnet IDs"
+  type        = list(string)
+}
+
+variable "publicly_accessible" {
+  description = "Control if instance is publicly accessible"
+  type        = bool
+  default     = false
+}
+
+variable "role_terraform_arn" {
+  description = "Terraform IAM role ARN"
+  type        = string
+}
+
+variable "tags" {
+  description = "Tags to apply to all resources in this module"
+  type        = map(string)
+}

--- a/terragrunt/modules/ecs/datasource.tf
+++ b/terragrunt/modules/ecs/datasource.tf
@@ -65,8 +65,9 @@ data "aws_iam_policy_document" "ecs_task_access_secrets" {
       "secretsmanager:GetSecretValue"
     ]
     resources = [
+      "arn:aws:secretsmanager:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:secret:${local.name_prefix}-*",
       "arn:aws:secretsmanager:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:secret:rds!*",
-      "arn:aws:secretsmanager:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:secret:${local.name_prefix}-*"
+      "arn:aws:secretsmanager:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:secret:rds-*"
     ]
   }
   statement {
@@ -77,8 +78,10 @@ data "aws_iam_policy_document" "ecs_task_access_secrets" {
       "kms:Decrypt"
     ]
     resources = [
+      var.db_entity_verification_kms_arn,
+      var.db_ev_cluster_credentials_kms_key_id,
+      var.db_sirsi_cluster_credentials_kms_key_id,
       var.db_sirsi_kms_arn,
-      var.db_entity_verification_kms_arn
     ]
   }
 }

--- a/terragrunt/modules/ecs/variables.tf
+++ b/terragrunt/modules/ecs/variables.tf
@@ -28,6 +28,11 @@ variable "db_entity_verification_name" {
   type        = string
 }
 
+variable "db_ev_cluster_credentials_kms_key_id" {
+  description = "Key ID of the KMS used to encrypt Entity Verification secrets"
+  type        = string
+}
+
 variable "db_postgres_sg_id" {
   description = "Postgres DB security group ID"
   type        = string
@@ -35,6 +40,11 @@ variable "db_postgres_sg_id" {
 
 variable "db_sirsi_address" {
   description = "Sirsi DB address"
+  type        = string
+}
+
+variable "db_sirsi_cluster_credentials_kms_key_id" {
+  description = "Key ID of the KMS used to encrypt Sirsi secrets"
   type        = string
 }
 
@@ -147,7 +157,6 @@ variable "redis_sg_id" {
   description = "ElastiCache Redis security group ID"
   type        = string
 }
-
 
 variable "role_cloudwatch_events_name" {
   description = "Name of the IAM role used by CloudWatch Events"

--- a/terragrunt/modules/tools/service-pgadmin.tf
+++ b/terragrunt/modules/tools/service-pgadmin.tf
@@ -4,31 +4,37 @@ module "ecs_service_pgadmin" {
   container_definitions = templatefile(
     "${path.module}/templates/task-definitions/pgadmin.json.tftpl",
     {
-      account_id                      = data.aws_caller_identity.current.account_id
-      allow_save_password             = var.is_production ? "False" : "True"
-      container_port                  = var.pgadmin_config.port
-      cpu                             = var.pgadmin_config.cpu
-      db_entity_verification_address  = var.db_entity_verification_address
-      db_entity_verification_name     = var.db_entity_verification_name
-      db_entity_verification_username = "${var.db_entity_verification_credentials_arn}:username::"
-      db_sirsi_address                = var.db_sirsi_address
-      db_sirsi_name                   = var.db_sirsi_name
-      db_sirsi_username               = "${var.db_sirsi_credentials_arn}:username::"
-      support_usernames               = data.aws_secretsmanager_secret.pgadmin_production_support_users.arn
-      pgadmin_admin_password          = "${aws_secretsmanager_secret.pgadmin_credentials.arn}:ADMIN_PASSWORD::"
-      pgadmin_admin_user              = "${aws_secretsmanager_secret.pgadmin_credentials.arn}:ADMIN_USERNAME::"
-      pgadmin_database_host           = module.rds_pgadmin.db_address
-      pgadmin_database_name           = module.rds_pgadmin.db_name
-      pgadmin_database_password       = "${module.rds_pgadmin.db_credentials_arn}:password::"
-      pgadmin_database_username       = "${module.rds_pgadmin.db_credentials_arn}:username::"
-      host_port                       = var.pgadmin_config.port
-      image                           = "${local.orchestrator_account_id}.dkr.ecr.${data.aws_region.current.name}.amazonaws.com/cdp-pgadmin:8.12.0"
-      lg_name                         = aws_cloudwatch_log_group.pgadmin.name
-      lg_prefix                       = "tools"
-      lg_region                       = data.aws_region.current.name
-      login_banner                    = "${upper(local.name_prefix)} ${title(var.environment)}"
-      memory                          = var.pgadmin_config.memory
-      name                            = var.pgadmin_config.name
+      account_id                              = data.aws_caller_identity.current.account_id
+      allow_save_password                     = var.is_production ? "False" : "True"
+      container_port                          = var.pgadmin_config.port
+      cpu                                     = var.pgadmin_config.cpu
+      db_entity_verification_address          = var.db_entity_verification_address
+      db_entity_verification_cluster_address  = var.db_ev_cluster_address
+      db_entity_verification_cluster_name     = var.db_ev_cluster_name
+      db_entity_verification_cluster_username = "${var.db_ev_cluster_credentials_arn}:username::"
+      db_entity_verification_name             = var.db_entity_verification_name
+      db_entity_verification_username         = "${var.db_entity_verification_credentials_arn}:username::"
+      db_sirsi_address                        = var.db_sirsi_address
+      db_sirsi_cluster_address                = var.db_sirsi_cluster_address
+      db_sirsi_cluster_name                   = var.db_sirsi_cluster_name
+      db_sirsi_cluster_username               = "${var.db_sirsi_cluster_credentials_arn}:username::"
+      db_sirsi_name                           = var.db_sirsi_name
+      db_sirsi_username                       = "${var.db_sirsi_credentials_arn}:username::"
+      host_port                               = var.pgadmin_config.port
+      image                                   = "${local.orchestrator_account_id}.dkr.ecr.${data.aws_region.current.name}.amazonaws.com/cdp-pgadmin:8.14.0"
+      lg_name                                 = aws_cloudwatch_log_group.pgadmin.name
+      lg_prefix                               = "tools"
+      lg_region                               = data.aws_region.current.name
+      login_banner                            = "${upper(local.name_prefix)} ${title(var.environment)}"
+      memory                                  = var.pgadmin_config.memory
+      name                                    = var.pgadmin_config.name
+      pgadmin_admin_password                  = "${aws_secretsmanager_secret.pgadmin_credentials.arn}:ADMIN_PASSWORD::"
+      pgadmin_admin_user                      = "${aws_secretsmanager_secret.pgadmin_credentials.arn}:ADMIN_USERNAME::"
+      pgadmin_database_host                   = module.rds_pgadmin.db_address
+      pgadmin_database_name                   = module.rds_pgadmin.db_name
+      pgadmin_database_password               = "${module.rds_pgadmin.db_credentials_arn}:password::"
+      pgadmin_database_username               = "${module.rds_pgadmin.db_credentials_arn}:username::"
+      support_usernames                       = data.aws_secretsmanager_secret.pgadmin_production_support_users.arn
     }
   )
 

--- a/terragrunt/modules/tools/templates/task-definitions/pgadmin.json.tftpl
+++ b/terragrunt/modules/tools/templates/task-definitions/pgadmin.json.tftpl
@@ -22,18 +22,24 @@
     "environment": [
         {"name": "ALLOW_SAVE_PASSWORD", "value": "${allow_save_password}"},
         {"name": "DB_ENTITY_VERIFICATION_ADDRESS", "value": "${db_entity_verification_address}"},
+        {"name": "DB_ENTITY_VERIFICATION_CLUSTER_ADDRESS", "value": "${db_entity_verification_cluster_address}"},
+        {"name": "DB_ENTITY_VERIFICATION_CLUSTER_NAME", "value": "${db_entity_verification_cluster_name}"},
         {"name": "DB_ENTITY_VERIFICATION_NAME", "value": "${db_entity_verification_name}"},
         {"name": "DB_SIRSI_ADDRESS", "value": "${db_sirsi_address}"},
+        {"name": "DB_SIRSI_CLUSTER_ADDRESS", "value": "${db_sirsi_cluster_address}"},
+        {"name": "DB_SIRSI_CLUSTER_NAME", "value": "${db_sirsi_cluster_name}"},
         {"name": "DB_SIRSI_NAME", "value": "${db_sirsi_name}"},
+        {"name": "LOGIN_BANNER", "value": "${login_banner}"},
+        {"name": "LOG_LEVEL", "value": "ERROR"},
+        {"name": "PGADMIN_CONFIG_SERVER_MODE" , "value": "True"},
         {"name": "PGADMIN_DATABASE_HOST" , "value": "${pgadmin_database_host}"},
         {"name": "PGADMIN_DATABASE_NAME" , "value": "${pgadmin_database_name}"},
-        {"name": "PGADMIN_CONFIG_SERVER_MODE" , "value": "True"},
-        {"name": "PGADMIN_LISTEN_PORT", "value": "${host_port}"},
-        {"name": "LOG_LEVEL", "value": "ERROR"},
-        {"name": "LOGIN_BANNER", "value": "${login_banner}"}
+        {"name": "PGADMIN_LISTEN_PORT", "value": "${host_port}"}
     ],
     "secrets": [
+        {"name": "DB_ENTITY_VERIFICATION_CLUSTER_USERNAME", "valueFrom": "${db_entity_verification_cluster_username}"},
         {"name": "DB_ENTITY_VERIFICATION_USERNAME", "valueFrom": "${db_entity_verification_username}"},
+        {"name": "DB_SIRSI_CLUSTER_USERNAME", "valueFrom": "${db_sirsi_cluster_username}"},
         {"name": "DB_SIRSI_USERNAME", "valueFrom": "${db_sirsi_username}"},
         {"name": "PGADMIN_DATABASE_PASSWORD" , "valueFrom": "${pgadmin_database_password}"},
         {"name": "PGADMIN_DATABASE_USERNAME" , "valueFrom": "${pgadmin_database_username}"},

--- a/terragrunt/modules/tools/variables.tf
+++ b/terragrunt/modules/tools/variables.tf
@@ -24,6 +24,21 @@ variable "db_entity_verification_port" {
   default     = 5432
 }
 
+variable "db_ev_cluster_address" {
+  description = "Entity Verification database endpoint address"
+  type        = string
+}
+
+variable "db_ev_cluster_credentials_arn" {
+  description = "Entity Verification database secret ARN"
+  type        = string
+}
+
+variable "db_ev_cluster_name" {
+  description = "Entity Verification database name"
+  type        = string
+}
+
 variable "db_postgres_sg_id" {
   description = "Postgres DB security group ID"
   type        = string
@@ -31,6 +46,21 @@ variable "db_postgres_sg_id" {
 
 variable "db_sirsi_address" {
   description = "Sirsi database endpoint address"
+  type        = string
+}
+
+variable "db_sirsi_cluster_address" {
+  description = "Sirsi database endpoint address"
+  type        = string
+}
+
+variable "db_sirsi_cluster_credentials_arn" {
+  description = "Sirsi database secret ARN"
+  type        = string
+}
+
+variable "db_sirsi_cluster_name" {
+  description = "Sirsi database name"
   type        = string
 }
 

--- a/terragrunt/tools/pgadmin/README.md
+++ b/terragrunt/tools/pgadmin/README.md
@@ -14,22 +14,30 @@ export PINNED_PGADMIN_VERSION=8.12.0
 
 ```shell
 docker build --build-arg PGADMIN_VERSION=${PINNED_PGADMIN_VERSION} -t cabinetoffice/cdp-pgadmin:${PINNED_PGADMIN_VERSION} .
+```
 
-## If need local testing ...
-# docker run \
-#  -e DB_SIRSI_ADDRESS='sirsi-address' \
-#  -e DB_SIRSI_NAME='sirsi-db' \
-#  -e DB_SIRSI_USERNAME='sirsi-username' \
-#  -e DB_ENTITY_VERIFICATION_ADDRESS='ev-address' \
-#  -e DB_ENTITY_VERIFICATION_NAME='ev-db' \
-#  -e DB_ENTITY_VERIFICATION_USERNAME='ev-username' \
-#  -e PGADMIN_DATABASE_USERNAME='test-user' \
-#  -e PGADMIN_DATABASE_HOST='pgadmin-address' \
-#  -e PGADMIN_DATABASE_NAME='pgadmin-db' \
-#  -e PGADMIN_DEFAULT_EMAIL='admin@example.com' \
-#  -e PGADMIN_DEFAULT_PASSWORD='admin' \
-#  -e SUPPORT_USERNAMES='ali.bahman, reza.nakhjavani' \
-#  cabinetoffice/cdp-pgadmin:${PINNED_PGADMIN_VERSION}
+If need local testing ...
+```shell
+ docker run \
+  -e DB_ENTITY_VERIFICATION_ADDRESS='ev-address' \
+  -e DB_ENTITY_VERIFICATION_CLUSTER_ADDRESS='ev-address' \
+  -e DB_ENTITY_VERIFICATION_CLUSTER_NAME='ev-db' \
+  -e DB_ENTITY_VERIFICATION_CLUSTER_USERNAME='ev-username' \
+  -e DB_ENTITY_VERIFICATION_NAME='ev-db' \
+  -e DB_ENTITY_VERIFICATION_USERNAME='ev-username' \
+  -e DB_SIRSI_ADDRESS='sirsi-address' \
+  -e DB_SIRSI_CLUSTER_ADDRESS='sirsi-address' \
+  -e DB_SIRSI_CLUSTER_NAME='sirsi-db' \
+  -e DB_SIRSI_CLUSTER_USERNAME='sirsi-username' \
+  -e DB_SIRSI_NAME='sirsi-db' \
+  -e DB_SIRSI_USERNAME='sirsi-username' \
+  -e PGADMIN_DATABASE_HOST='pgadmin-address' \
+  -e PGADMIN_DATABASE_NAME='pgadmin-db' \
+  -e PGADMIN_DATABASE_USERNAME='test-user' \
+  -e PGADMIN_DEFAULT_EMAIL='admin@example.com' \
+  -e PGADMIN_DEFAULT_PASSWORD='admin' \
+  -e SUPPORT_USERNAMES='ali.bahman, reza.nakhjavani' \
+  cabinetoffice/cdp-pgadmin:${PINNED_PGADMIN_VERSION}
 ```
 
 ## Deploy

--- a/terragrunt/tools/pgadmin/configs/custom-entrypoint.sh
+++ b/terragrunt/tools/pgadmin/configs/custom-entrypoint.sh
@@ -45,7 +45,7 @@ add_server_to_json() {
 }
 
 configure_servers_json() {
-  echo "#### Generated servers.json: ####"
+  echo "#### Generating servers.json: ####"
 
   echo '{' >/pgadmin4/servers.json
   echo '  "Servers": {' >>/pgadmin4/servers.json
@@ -54,15 +54,19 @@ configure_servers_json() {
   add_server_to_json "1" "admin@cdp-sirsi-pgadmin" "Admin" "$PGADMIN_DATABASE_HOST" 5432 "$PGADMIN_DATABASE_NAME" "$PGADMIN_DATABASE_USERNAME"
   add_server_to_json "2" "admin@cdp-sirsi" "Admin" "$DB_SIRSI_ADDRESS" 5432 "$DB_SIRSI_NAME" "$DB_SIRSI_USERNAME"
   add_server_to_json "3" "admin@cdp-sirsi-entity-verification" "Admin" "$DB_ENTITY_VERIFICATION_ADDRESS" 5432 "$DB_ENTITY_VERIFICATION_NAME" "$DB_ENTITY_VERIFICATION_USERNAME"
-  add_server_to_json "4" "SIRSI" "CDP" "$DB_SIRSI_ADDRESS" 5432 "$DB_SIRSI_NAME" "${DB_SIRSI_USERNAME}_pgadmin"
-  add_server_to_json "5" "Entity Verification" "CDP" "$DB_ENTITY_VERIFICATION_ADDRESS" 5432 "$DB_ENTITY_VERIFICATION_NAME" "${DB_ENTITY_VERIFICATION_USERNAME}_pgadmin"
+  add_server_to_json "4" "SIRSI Cluster" "Admin" "$DB_SIRSI_CLUSTER_ADDRESS" 5432 "$DB_SIRSI_CLUSTER_NAME" "${DB_SIRSI_CLUSTER_USERNAME}"
+  add_server_to_json "5" "Entity Verification Cluster" "Admin" "$DB_ENTITY_VERIFICATION_CLUSTER_ADDRESS" 5432 "$DB_ENTITY_VERIFICATION_CLUSTER_NAME" "${DB_ENTITY_VERIFICATION_CLUSTER_USERNAME}"
+  add_server_to_json "6" "SIRSI Cluster" "CDP" "$DB_SIRSI_CLUSTER_ADDRESS" 5432 "$DB_SIRSI_CLUSTER_NAME" "${DB_SIRSI_CLUSTER_USERNAME}_pgadmin"
+  add_server_to_json "7" "Entity Verification Cluster" "CDP" "$DB_ENTITY_VERIFICATION_CLUSTER_ADDRESS" 5432 "$DB_ENTITY_VERIFICATION_CLUSTER_NAME" "${DB_ENTITY_VERIFICATION_CLUSTER_USERNAME}_pgadmin"
+  add_server_to_json "8" "SIRSI" "CDP" "$DB_SIRSI_ADDRESS" 5432 "$DB_SIRSI_NAME" "${DB_SIRSI_USERNAME}_pgadmin"
+  add_server_to_json "9" "Entity Verification" "CDP" "$DB_ENTITY_VERIFICATION_ADDRESS" 5432 "$DB_ENTITY_VERIFICATION_NAME" "${DB_ENTITY_VERIFICATION_USERNAME}_pgadmin"
 
   if [ -z "$SUPPORT_USERNAMES" ]; then
     echo "#### No support users provided ####"
   else
     echo "#### Adding servers for support users ####"
 
-    id=6
+    id=10
     for username in $(echo "$SUPPORT_USERNAMES" | tr ',' ' '); do
       add_server_to_json "$id" "$username@cdp-sirsi" "Production Support" "$DB_SIRSI_ADDRESS" 5432 "$DB_SIRSI_NAME" "$username"
       id=$((id + 1))
@@ -74,6 +78,8 @@ configure_servers_json() {
   sed -i '$ s/,$//' /pgadmin4/servers.json
   echo "  }" >>/pgadmin4/servers.json
   echo "}" >>/pgadmin4/servers.json
+
+  cat /pgadmin4/servers.json
 }
 
 write_local_config() {
@@ -93,7 +99,7 @@ write_local_config() {
 }
 
 echo "#### Configuring pgAdmin... ####"
-# clear_all_servers # Use only to force a fresh start
+clear_all_servers # Use only to force a fresh start
 configure_servers_json
 write_local_config
 unlock_pgadmin


### PR DESCRIPTION
### Add Aurora PostgreSQL Clusters for SIRSI and Entity Verification; Update PGAdmin Configuration

  - Provisioned Aurora PostgreSQL clusters for SIRSI and Entity Verification services in staging.
  - Updated PGAdmin configuration to link with new cluster endpoints and credentials.
  - Added new Terragrunt modules for managing Aurora clusters, including configuration for encryption, parameter groups, and instances.
  - Enhanced PGAdmin setup to dynamically configure clusters and associated credentials.
  - Updated ECS configurations and task definitions to accommodate the new database clusters.
  - Modified IAM policies to include new resource ARNs for Aurora clusters and Secrets Manager.
  - Introduced centralized logging improvements and refactored environment variable usage.
  - Documentation updates to reflect the new database cluster setup and PGAdmin configuration process.

### Next Steps:
  - Reconfigure ECS services to use the new Aurora clusters.
  - Test connectivity and functionality for SIRSI and Entity Verification with the updated setup.