### PR TITLE
DP-1037 - corrected CloudWatch config for av-scanner.

### DIFF
--- a/Services/CO.CDP.AntiVirusScanner/appsettings.json
+++ b/Services/CO.CDP.AntiVirusScanner/appsettings.json
@@ -20,7 +20,7 @@
       "WaitTimeSeconds": 20
     },
     "CloudWatch": {
-      "LogGroup": "/etc/av-scanner",
+      "LogGroup": "/ecs/av-scanner",
       "LogStream": "serilog"
     }
   },


### PR DESCRIPTION
Unable to see av-scanner app log in Grafana. This should fix this issue.