### PR TITLE
DP-712 Lock the outbox processor to ensure messages are only processed once

### DIFF
--- a/Libraries/CO.CDP.MQ/Outbox/OutboxProcessor.cs
+++ b/Libraries/CO.CDP.MQ/Outbox/OutboxProcessor.cs
@@ -7,12 +7,43 @@ public interface IOutboxProcessor
     Task<int> ExecuteAsync(int count);
 }
 
-public class OutboxProcessor(IPublisher publisher, IOutboxMessageRepository outbox, ILogger<OutboxProcessor> logger)
+public class OutboxProcessor(
+    IPublisher publisher,
+    IOutboxMessageRepository outbox,
+    TimeSpan lockTimeout,
+    ILogger<OutboxProcessor> logger)
     : IOutboxProcessor
 {
+    private readonly SemaphoreSlim _semaphore = new(1, 1);
+
+    public OutboxProcessor(IPublisher publisher, IOutboxMessageRepository outbox, ILogger<OutboxProcessor> logger) :
+        this(publisher, outbox, TimeSpan.FromSeconds(1), logger)
+    {
+    }
+
     public async Task<int> ExecuteAsync(int count)
     {
-        logger.LogDebug("Executing the outbox processor");
+        logger.LogDebug("Outbox processor waiting for the lock...");
+        if (!await _semaphore.WaitAsync(lockTimeout))
+        {
+            logger.LogDebug("Outbox processor failed to acquire the lock");
+            return 0;
+        }
+
+        try
+        {
+            logger.LogDebug("Executing the outbox processor");
+            return await PublishMessages(count);
+        }
+        finally
+        {
+            logger.LogDebug("Stopping the outbox processor");
+            _semaphore.Release();
+        }
+    }
+
+    private async Task<int> PublishMessages(int count)
+    {
         var messages = await FetchMessages(count);
         foreach (var outboxMessage in messages)
         {


### PR DESCRIPTION
A new postgres NOTIFY might arrive before the previous one was processed. To reduce the likelihood of publishing the same message more than once, the OutboxProcessor now uses a lock. 

If OutboxProcessor is run twice in short span of time, the second run will wait for a short time, and then give up. It's fine to give up, as the current run will handle all messages anyway.

The functionality is still disabled. To enabled it, the `OutboxListener` feature flag needs to be set to `true` in the `Organisation.WebApi` and `EntityVerification` projects.