### PR TITLE
DP-1069 Prepare for domain switch while maintaining private-beta domain

### DIFF
--- a/terragrunt/components/external/networking/terragrunt.hcl
+++ b/terragrunt/components/external/networking/terragrunt.hcl
@@ -24,7 +24,7 @@ locals {
 dependency core_networking {
   config_path = "../../core/networking"
   mock_outputs = {
-    public_hosted_zone_id = "mock"
+    production_private_beta_hosted_zone_id = "mock"
   }
 }
 
@@ -32,5 +32,5 @@ inputs = {
   fts_azure_frontdoor = local.global_vars.locals.fts_azure_frontdoor
   tags                = local.tags
 
-  public_hosted_zone_id = dependency.core_networking.outputs.public_hosted_zone_id
+  hosted_zone_id = dependency.core_networking.outputs.production_private_beta_hosted_zone_id
 }

--- a/terragrunt/components/service/ecs/terragrunt.hcl
+++ b/terragrunt/components/service/ecs/terragrunt.hcl
@@ -39,14 +39,14 @@ dependency core_iam {
 dependency core_networking {
   config_path = "../../core/networking"
   mock_outputs = {
-    private_subnet_ids          = "mock"
-    private_subnets_cidr_blocks = "mock"
-    public_domain               = "mock"
-    public_hosted_zone_id       = "mock"
-    public_subnet_ids           = "mock"
-    public_subnets_cidr_blocks  = "mock"
-    vpc_id                      = "mock"
-    waf_acl_arn                 = "mock"
+    private_subnet_ids                     = "mock"
+    private_subnets_cidr_blocks            = "mock"
+    production_private_beta_domain         = "mock" # @todo (ABN) DP-1069 Switch back to `public_domain` once domain is propagated
+    production_private_beta_hosted_zone_id = "mock" # @todo (ABN) DP-1069 Switch back to `public_hosted_zone_id` once domain is propagated
+    public_subnet_ids                      = "mock"
+    public_subnets_cidr_blocks             = "mock"
+    vpc_id                                 = "mock"
+    waf_acl_arn                            = "mock"
   }
 }
 
@@ -148,8 +148,8 @@ inputs = {
 
   private_subnet_ids          = dependency.core_networking.outputs.private_subnet_ids
   private_subnets_cidr_blocks = dependency.core_networking.outputs.private_subnets_cidr_blocks
-  public_domain               = dependency.core_networking.outputs.public_domain
-  public_hosted_zone_id       = dependency.core_networking.outputs.public_hosted_zone_id
+  public_domain               = dependency.core_networking.outputs.production_private_beta_domain         # @todo (ABN) DP-1069 Switch back to `public_domain` once domain is propagated
+  public_hosted_zone_id       = dependency.core_networking.outputs.production_private_beta_hosted_zone_id # @todo (ABN) DP-1069 Switch back to `public_hosted_zone_id` once domain is propagated
   public_subnet_ids           = dependency.core_networking.outputs.public_subnet_ids
   public_subnets_cidr_blocks  = dependency.core_networking.outputs.public_subnets_cidr_blocks
   vpc_id                      = dependency.core_networking.outputs.vpc_id

--- a/terragrunt/components/terragrunt.hcl
+++ b/terragrunt/components/terragrunt.hcl
@@ -135,7 +135,7 @@ locals {
         "10.${local.cidr_b_production}.2.0/24",
         "10.${local.cidr_b_production}.3.0/24"
       ]
-      top_level_domain = "private-beta.find-tender.service.gov.uk"
+      top_level_domain = "find-tender.service.gov.uk"
 
       externals_cidr_block      = "integration account feature" # To be deprecated after FTS Migration
       externals_private_subnets = "integration account feature" # To be deprecated after FTS Migration

--- a/terragrunt/modules/core-networking/outputs.tf
+++ b/terragrunt/modules/core-networking/outputs.tf
@@ -21,6 +21,18 @@ output "private_subnets_cidr_blocks" {
   value       = aws_subnet.private.*.cidr_block
 }
 
+output "production_private_beta_domain" {
+  value = var.is_production ? "${local.production_subdomain}.${aws_route53_zone.production_private_beta[0].name}" : aws_route53_zone.public.name
+}
+
+output "production_private_beta_hosted_zone_fqdn" {
+  value = try(aws_route53_zone.production_private_beta[0].name, null)
+}
+
+output "production_private_beta_hosted_zone_id" {
+  value = try(aws_route53_zone.production_private_beta[0].id, null)
+}
+
 output "public_domain" {
   value = var.is_production ? "${local.production_subdomain}.${aws_route53_zone.public.name}" : aws_route53_zone.public.name
 }

--- a/terragrunt/modules/core-networking/route53.tf
+++ b/terragrunt/modules/core-networking/route53.tf
@@ -7,3 +7,14 @@ resource "aws_route53_zone" "public" {
     prevent_destroy = true
   }
 }
+
+resource "aws_route53_zone" "production_private_beta" {
+  count = var.is_production ? 1 : 0
+
+  name = "private-beta.find-tender.service.gov.uk"
+  tags = var.tags
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}

--- a/terragrunt/modules/external-networking/route53.tf
+++ b/terragrunt/modules/external-networking/route53.tf
@@ -1,7 +1,7 @@
 resource "aws_route53_record" "www_to_fts" {
   count = var.fts_azure_frontdoor == null ? 0 : 1
 
-  zone_id = var.public_hosted_zone_id
+  zone_id = var.hosted_zone_id
   name    = "www"
   type    = "CNAME"
   ttl     = 60

--- a/terragrunt/modules/external-networking/variables.tf
+++ b/terragrunt/modules/external-networking/variables.tf
@@ -4,8 +4,8 @@ variable "fts_azure_frontdoor" {
   default     = null
 }
 
-variable "public_hosted_zone_id" {
-  description = "ID of the public hosted zone"
+variable "hosted_zone_id" {
+  description = "ID of the hosted zone to deploy to"
   type        = string
 }
 

--- a/terragrunt/modules/orchestrator/ecr/variables.tf
+++ b/terragrunt/modules/orchestrator/ecr/variables.tf
@@ -28,6 +28,10 @@ variable "service_configs" {
   }))
 }
 
+variable "tags" {
+  description = "Tags to apply to all resources in this module"
+  type        = map(string)
+}
 
 variable "tools_configs" {
   description = "Map of tools and their attributes"
@@ -38,9 +42,4 @@ variable "tools_configs" {
     port      = number
     port_host = number
   }))
-}
-
-variable "tags" {
-  description = "Tags to apply to all resources in this module"
-  type        = map(string)
 }


### PR DESCRIPTION
  - Introduced changes to support the transition to the new domain find-tender.service.gov.uk while keeping the existing private-beta.find-tender.service.gov.uk in place.
  - Updated Terragrunt configurations to provision and maintain both hosted zones concurrently.
  - Modified resource dependencies to reference the correct hosted zone (production_private_beta_hosted_zone_id) during the transition phase.
  - Added temporary overrides to facilitate a smooth migration and prevent deployment conflicts.
  - Included safeguards to prevent unintended pipeline overwrites during state management operations.
  - Applied @todo comments for post-propagation clean-up to revert changes once the migration is complete.