### PR TITLE
DP-992 Set data-sharing's default MAX POOL SIZE to 100 in staging, as…

### DIFF
--- a/Services/CO.CDP.DataSharing.WebApi/appsettings.AwsStaging.json
+++ b/Services/CO.CDP.DataSharing.WebApi/appsettings.AwsStaging.json
@@ -1,5 +1,8 @@
 {
   "Features": {
     "SwaggerUI": true
+  },
+  "OrganisationInformationDatabase": {
+    "MaxPoolSize": 100
   }
 }


### PR DESCRIPTION
… per @maciej-goaco request

We need to make sure other sub-attributes will be merged (even though having them set in live account seems wrong) 