### PR TITLE
Support Admin - Search Pagination for Support Screen

### DIFF
--- a/Frontend/CO.CDP.OrganisationApp/Pages/Support/Organisations.cshtml
+++ b/Frontend/CO.CDP.OrganisationApp/Pages/Support/Organisations.cshtml
@@ -33,7 +33,7 @@
             <label class="govuk-label" for="organisation-search-input">
                 @Model.SearchTitle
             </label>
-            <input class="govuk-input" id="organisation-search-input" name="OrganisationSearchInput" type="text">
+            <input class="govuk-input" id="organisation-search-input" name="OrganisationSearchInput" type="text" value="@Model.OrganisationSearchInput">
         </div>
 
         <div class="govuk-grid-column-full">

--- a/Frontend/CO.CDP.OrganisationApp/Pages/Support/Organisations.cshtml.cs
+++ b/Frontend/CO.CDP.OrganisationApp/Pages/Support/Organisations.cshtml.cs
@@ -34,6 +34,8 @@ public class OrganisationsModel(
     {
         InitModel(type, pageNumber);
 
+        OrganisationSearchInput = HttpContext.Session.GetString("OrganisationSearchInput");
+
         await GetResults();
 
         return Page();
@@ -42,6 +44,15 @@ public class OrganisationsModel(
     public async Task<IActionResult> OnPost(string type, int pageNumber = 1)
     {
         InitModel(type, pageNumber);
+
+        if (!string.IsNullOrWhiteSpace(OrganisationSearchInput))
+        {
+            HttpContext.Session.SetString("OrganisationSearchInput", OrganisationSearchInput);
+        }
+        else
+        {
+            HttpContext.Session.Remove("OrganisationSearchInput"); // Clear when input is empty
+        }
 
         await GetResults();
 


### PR DESCRIPTION
Nice simple solution to ensuring the search value is persisted even when navigating through the pages. Saves the search value to the session until it is cleared by the user.