### PR TITLE
DP-1202: reduce the scope of sqs dispatcher

### DIFF
--- a/Libraries/CO.CDP.AwsServices/Sqs/SqsDispatcher.cs
+++ b/Libraries/CO.CDP.AwsServices/Sqs/SqsDispatcher.cs
@@ -50,17 +50,11 @@ public class SqsDispatcher(
         _subscribers.Subscribe(subscriber);
     }
 
-    public Task ExecuteAsync(CancellationToken cancellationToken = default)
+    public async Task ExecuteAsync(CancellationToken cancellationToken = default)
     {
-        return Task.Run(async () =>
-        {
-            logger.LogInformation("Started the SQS message dispatcher");
+        logger.LogInformation("Started the SQS message dispatcher");
 
-            while (!cancellationToken.IsCancellationRequested)
-            {
-                await HandleMessages(cancellationToken);
-            }
-        }, cancellationToken);
+        await HandleMessages(cancellationToken);
     }
 
     private async Task HandleMessages(CancellationToken cancellationToken)

--- a/Libraries/CO.CDP.MQ.Tests/Hosting/DispatcherBackgroundServiceTest.cs
+++ b/Libraries/CO.CDP.MQ.Tests/Hosting/DispatcherBackgroundServiceTest.cs
@@ -12,19 +12,15 @@ public class DispatcherBackgroundServiceTest
     private readonly TestServiceProvider _serviceProvider = new();
 
     [Fact]
-    public void ItExecutesTheQueueDispatcher()
+    public async Task ItExecutesTheQueueDispatcher()
     {
         _serviceProvider.Services.Add(typeof(IDispatcher), _dispatcher.Object);
         _serviceProvider.Services.Add(typeof(IServiceScopeFactory), new TestServiceScopeFactory(_serviceProvider));
 
         var backgroundService = new DispatcherBackgroundService(_serviceProvider);
-        var cancellationToken = CancellationToken.None;
-        var task = Task.CompletedTask;
-        _dispatcher.Setup(d => d.ExecuteAsync(cancellationToken))
-            .Returns(task);
 
-        var result = backgroundService.StartAsync(cancellationToken);
+        await backgroundService.StartAsync(CancellationToken.None);
 
-        result.Should().Be(task);
+        _dispatcher.Verify(d => d.ExecuteAsync(It.IsAny<CancellationToken>()), Times.AtLeastOnce);
     }
 }

--- a/Libraries/CO.CDP.MQ/Hosting/DispatcherBackgroundService.cs
+++ b/Libraries/CO.CDP.MQ/Hosting/DispatcherBackgroundService.cs
@@ -5,7 +5,18 @@ namespace CO.CDP.MQ.Hosting;
 
 public class DispatcherBackgroundService(IServiceProvider services) : BackgroundService
 {
+    private readonly TimeSpan _delayBetweenDispatcherExecutions = TimeSpan.FromSeconds(1);
+
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            await ExecuteDispatcherAsync(stoppingToken);
+            await Task.Delay(_delayBetweenDispatcherExecutions, stoppingToken);
+        }
+    }
+
+    private async Task ExecuteDispatcherAsync(CancellationToken stoppingToken)
     {
         using var scope = services.CreateScope();
         using var dispatcher = scope.ServiceProvider.GetRequiredService<IDispatcher>();


### PR DESCRIPTION
In order to reduce the lifetime of DbContext and flush db operations on each dispatcher run.