### PR TITLE
Bugfix for: DP-1189 - Make user role descriptions specific to each user group (manage users)

### DIFF
--- a/Frontend/CO.CDP.OrganisationApp/Pages/Users/AddUser.cshtml.cs
+++ b/Frontend/CO.CDP.OrganisationApp/Pages/Users/AddUser.cshtml.cs
@@ -53,7 +53,17 @@ public class AddUserModel(
         PersonInviteStateData = session.Get<PersonInviteState>(PersonInviteState.TempDataKey) ?? null;
 
         var organisation = await organisationClient.GetOrganisationAsync(Id);
-        OrganisationRoles = organisation.Roles;
+
+        OrganisationRoles = new List<PartyRole>(organisation.Roles);
+
+        // Add only the roles from PendingRoles that are not already in OrganisationRoles
+        foreach (var role in organisation.PendingRoles)
+        {
+            if (!OrganisationRoles.Contains(role))
+            {
+                OrganisationRoles.Add(role);
+            }
+        }
 
         if (PersonInviteStateData != null)
         {

--- a/Services/CO.CDP.Organisation.WebApi/Model/Organisation.cs
+++ b/Services/CO.CDP.Organisation.WebApi/Model/Organisation.cs
@@ -27,7 +27,9 @@ public record Organisation
     /// <example>["supplier"]</example>
     public required List<PartyRole> Roles { get; init; }
 
-    public required Details Details { get; init; }    
+    public required List<PartyRole> PendingRoles { get; init; }
+
+    public required Details Details { get; init; }
 }
 
 public record SupplierInformation


### PR DESCRIPTION
The content was displaying incorrectly for a pending buyer. This PR fixes that by adding the pending roles to do the content check against.