### PR TITLE
DP-1299 Downsize Redis and ECS resource allocation for production

### DIFF
--- a/terragrunt/components/terragrunt.hcl
+++ b/terragrunt/components/terragrunt.hcl
@@ -187,7 +187,7 @@ locals {
         "10.${local.cidr_b_production}.2.0/24",
         "10.${local.cidr_b_production}.3.0/24"
       ]
-      redis_node_type  = "cache.r5.12xlarge"
+      redis_node_type  = "cache.r5.4xlarge"
       top_level_domain = "supplier-information.find-tender.service.gov.uk"
 
       externals_cidr_block      = "integration account feature" # To be deprecated after FTS Migration
@@ -235,7 +235,7 @@ locals {
     development  = 2
     integration  = 2
     staging      = 2
-    production   = 9
+    production   = 6
   }
 
   resource_defaults = {
@@ -243,7 +243,7 @@ locals {
     orchestrator = { cpu = 256,  memory = 512  }
     integration  = { cpu = 512,  memory = 1024 }
     staging      = { cpu = 512,  memory = 1024 }
-    production   = { cpu = 4096, memory = 8192 }
+    production   = { cpu = 1024, memory = 2048 }
   }
 
   service_configs_scaling = {


### PR DESCRIPTION
- Reduced `redis_node_type` from `cache.r5.12xlarge` to `cache.r5.4xlarge`
- Adjusted production instance count from 9 to 6
- Decreased production ECS resource allocation (`cpu: 4096 → 1024`, `memory: 8192 → 2048`)

These changes aim to balance performance with cost-effectiveness while ensuring production stability.