### PR TITLE
DP-1261 Override should not be phoney

### DIFF
--- a/E2ETests/compose.yml
+++ b/E2ETests/compose.yml
@@ -10,5 +10,5 @@ services:
 
 networks:
   default:
-    name: cdp-sirsi-network
+    name: cdp-sirsi
     driver: bridge

--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,10 @@ build-docker: ## Build Docker images
 .PHONY: build-docker
 
 up: render-compose-override ## Start Docker containers
+	@docker compose ls
 	@docker compose up -d
 	@docker compose ps
+	@docker network list
 .PHONY: up
 
 verify-up: render-compose-override ## Verify if all Docker containers have run
@@ -131,8 +133,18 @@ localization-import-from-csv:
 .PHONY: localization-import-from-csv
 
 render-compose-override: ## Render compose override from template and inject secrets (WIP)
-	cp compose.override.yml.template compose.override.yml
-	docker compose ls
+	@if [ ! -f compose.override.yml ]; then \
+		cp compose.override.yml.template compose.override.yml; \
+		echo "compose.override.yml created from template."; \
+	else \
+		echo "compose.override.yml already exists. Skipping."; \
+	fi
+.PHONY: render-compose-override
+
+render-compose-override-force: ## Force overwrite compose override from template
+	@cp compose.override.yml.template compose.override.yml
+	@echo "compose.override.yml has been overwritten from template."
+.PHONY: render-compose-override-force
 
 e2e-test: up ## Build & run e2e tests in Docker
 	docker network ls

--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,6 @@ localization-import-from-csv:
 render-compose-override: ## Render compose override from template and inject secrets (WIP)
 	cp compose.override.yml.template compose.override.yml
 	docker compose ls
-.PHONY: render-compose-override
 
 e2e-test: up ## Build & run e2e tests in Docker
 	docker network ls

--- a/compose.yml
+++ b/compose.yml
@@ -449,7 +449,7 @@ services:
 
 networks:
   default:
-    name: cdp-sirsi-network
+    name: cdp-sirsi
     driver: bridge
 
 volumes:


### PR DESCRIPTION
- Prevent overwriting the override file by default    
- Add force overwrite target    
- Remove  from the network's name

# Note:
Once this PR is in, a one of removal of the old network will be required (just to keep local stack tidy)
```
docker network rm cdp-sirsi-network
```
_The other option can be running `make down` before fetching latest main and `make up` once pull latest_
 