### PR TITLE
Exclude migration containers from verify up

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,11 +36,12 @@ up: render-compose-override ## Start Docker containers
 	@docker network list
 .PHONY: up
 
-verify-up: render-compose-override ## Verify if all Docker containers have run
-	@timeout=180; \
+verify-up: render-compose-override ## Verify if all Docker containers have run. Migration containers are excluded but are checked in the pipeline when "make db" is run
+	@timeout=60; \
 	interval=5; \
 	while [ $$timeout -gt 0 ]; do \
-		if docker compose ps -a --format json | jq --exit-status 'select(.ExitCode != 0 or (.Health != "healthy" and .Health != ""))' > /dev/null; then \
+		if docker compose ps -a --format json \
+			| jq --exit-status 'select(.Name != "organisation-information-migrations" and .Name != "entity-verification-migrations") | select(.ExitCode != 0 or (.Health != "healthy" and .Health != "")) | any' > /dev/null; then \
 			echo "Waiting for services to be healthy..."; \
 			sleep $$interval; \
 			timeout=$$(($$timeout - $$interval)); \
@@ -53,7 +54,6 @@ verify-up: render-compose-override ## Verify if all Docker containers have run
 	docker compose ps -a --format json | jq --exit-status 'select(.ExitCode != 0 or (.Health != "healthy" and .Health != ""))'; \
 	exit 1
 .PHONY: verify-up
-
 
 down: ## Destroy Docker containers
 	@docker compose down

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ verify-up: render-compose-override ## Verify if all Docker containers have run
 	echo "Services did not become healthy in time"; \
 	docker compose ps -a --format json | jq --exit-status 'select(.ExitCode != 0 or (.Health != "healthy" and .Health != ""))'; \
 	docker compose logs organisation-information-migrations
-	docker compose logs co-cdp-entity-verification-migrations
+	docker compose logs entity-verification-migrations
 	exit 1;
 .PHONY: verify-up
 

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ verify-up: render-compose-override ## Verify if all Docker containers have run. 
 	interval=5; \
 	while [ $$timeout -gt 0 ]; do \
 		if docker compose ps -a --format json \
-			| jq --exit-status 'select(.Name != "organisation-information-migrations" and .Name != "entity-verification-migrations") | select(.ExitCode != 0 or (.Health != "healthy" and .Health != "")) | any' > /dev/null; then \
+			| jq --exit-status 'select(.Name != "organisation-information-migrations" and .Name != "entity-verification-migrations") | select(.ExitCode != 0 or (.Health != "healthy" and .Health != ""))' > /dev/null; then \
 			echo "Waiting for services to be healthy..."; \
 			sleep $$interval; \
 			timeout=$$(($$timeout - $$interval)); \

--- a/Makefile
+++ b/Makefile
@@ -51,9 +51,7 @@ verify-up: render-compose-override ## Verify if all Docker containers have run
 	done; \
 	echo "Services did not become healthy in time"; \
 	docker compose ps -a --format json | jq --exit-status 'select(.ExitCode != 0 or (.Health != "healthy" and .Health != ""))'; \
-	docker compose logs organisation-information-migrations
-	docker compose logs entity-verification-migrations
-	exit 1;
+	exit 1
 .PHONY: verify-up
 
 

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,8 @@ verify-up: render-compose-override ## Verify if all Docker containers have run
 	done; \
 	echo "Services did not become healthy in time"; \
 	docker compose ps -a --format json | jq --exit-status 'select(.ExitCode != 0 or (.Health != "healthy" and .Health != ""))'; \
+	docker compose logs organisation-information-migrations
+	docker compose logs co-cdp-entity-verification-migrations
 	exit 1;
 .PHONY: verify-up
 

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ up: render-compose-override ## Start Docker containers
 .PHONY: up
 
 verify-up: render-compose-override ## Verify if all Docker containers have run
-	@timeout=60; \
+	@timeout=180; \
 	interval=5; \
 	while [ $$timeout -gt 0 ]; do \
 		if docker compose ps -a --format json | jq --exit-status 'select(.ExitCode != 0 or (.Health != "healthy" and .Health != ""))' > /dev/null; then \


### PR DESCRIPTION
(Note: they're still checked in the pipeline via the "Test migrations" command which runs "make db")