### PR TITLE
Revert "Temporarily pin dev to 1.0.65 while tagging branch for integration to stop accidental deploys"

### DIFF
--- a/terragrunt/components/terragrunt.hcl
+++ b/terragrunt/components/terragrunt.hcl
@@ -52,7 +52,7 @@ locals {
         "https://nadeemshafi2.nqc.com/auth/backchannellogout"
       ]
       pinned_fts_service_version        = "0.0.1"
-      pinned_service_version            = "1.0.65"
+      pinned_service_version            = null
       postgres_instance_type            = "db.t4g.micro"
       postgres_aurora_instance_type     = "db.r5.large"
       private_subnets = [


### PR DESCRIPTION
Reverts cabinetoffice/GCGS-Central-Digital-Platform#1591