### PR TITLE
DP-1505 Provision new S3 bucket for secure SQL dumpfile transfer

### DIFF
--- a/terragrunt/modules/auth/outputs.tf
+++ b/terragrunt/modules/auth/outputs.tf
@@ -6,14 +6,6 @@ output "cloud_beaver_user_pool_client_id" {
   value = aws_cognito_user_pool_client.cloud_beaver.id
 }
 
-output "fts_user_pool_arn" {
-  value = aws_cognito_user_pool.auth.arn
-}
-
-output "fts_user_pool_client_id" {
-  value = aws_cognito_user_pool_client.fts.id
-}
-
 output "fts_healthcheck_user_pool_arn" {
   value = aws_cognito_user_pool.auth.arn
 }
@@ -22,6 +14,13 @@ output "fts_healthcheck_user_pool_client_id" {
   value = aws_cognito_user_pool_client.fts_healthcheck.id
 }
 
+output "fts_user_pool_arn" {
+  value = aws_cognito_user_pool.auth.arn
+}
+
+output "fts_user_pool_client_id" {
+  value = aws_cognito_user_pool_client.fts.id
+}
 
 output "grafana_user_pool_arn" {
   value = aws_cognito_user_pool.auth.arn
@@ -30,7 +29,6 @@ output "grafana_user_pool_arn" {
 output "grafana_user_pool_client_id" {
   value = aws_cognito_user_pool_client.grafana.id
 }
-
 
 output "healthcheck_user_pool_arn" {
   value = aws_cognito_user_pool.auth.arn

--- a/terragrunt/modules/database/s3.tf
+++ b/terragrunt/modules/database/s3.tf
@@ -7,3 +7,15 @@ module "deprecated_db_backup" {
 
   tags = var.tags
 }
+
+module "sql_dump_upload_bucket" {
+  source = "../s3-bucket"
+
+  bucket_name           = "${local.name_prefix}-fts-dump-temp-${data.aws_caller_identity.current.account_id}"
+  enable_presigned_urls = true
+  enable_access_logging = true
+  enable_lifecycle      = false
+  kms_key_admin_role    = var.role_terraform_arn
+
+  tags = var.tags
+}

--- a/terragrunt/modules/ecs/outputs.tf
+++ b/terragrunt/modules/ecs/outputs.tf
@@ -26,16 +26,16 @@ output "service_configuration" {
   value = local.service_configs
 }
 
+output "service_version_fts" {
+  value = var.pinned_service_version_sirsi
+}
+
 output "service_version_global" {
   value = nonsensitive(local.orchestrator_service_version)
 }
 
 output "service_version_pinned" {
   value = nonsensitive(var.pinned_service_version_sirsi == null ? "not pinned, using global ${local.orchestrator_service_version}" : var.pinned_service_version_sirsi)
-}
-
-output "service_version_fts" {
-  value = var.pinned_service_version_sirsi
 }
 
 output "services_target_group_arn_suffix_map" {

--- a/terragrunt/modules/ecs/variables.tf
+++ b/terragrunt/modules/ecs/variables.tf
@@ -98,14 +98,14 @@ variable "onelogin_logout_notification_urls" {
   type        = list(string)
 }
 
-variable "pinned_service_version_sirsi" {
-  description = "The service version for the this environment. If null, latest version from Orchestration will be used"
+variable "pinned_service_version_fts" {
+  description = "The FTS service version for the this environment."
   type        = string
   default     = null
 }
 
-variable "pinned_service_version_fts" {
-  description = "The FTS service version for the this environment."
+variable "pinned_service_version_sirsi" {
+  description = "The service version for the this environment. If null, latest version from Orchestration will be used"
   type        = string
   default     = null
 }

--- a/terragrunt/modules/kms/main.tf
+++ b/terragrunt/modules/kms/main.tf
@@ -15,6 +15,8 @@ resource "aws_kms_key" "key" {
   policy = templatefile("${path.module}/templates/key-policy.json.tftpl", {
     account_id              = data.aws_caller_identity.current.account_id
     admin_role              = var.key_admin_role
+    bucket_enable_presigned = var.bucket_enable_presigned
+    bucket_name             = var.bucket_name
     custom_policies         = var.custom_policies
     key_user_arns_json      = jsonencode([for arn in var.key_user_arns : arn])
     key_user_arns_length    = length(var.key_user_arns)

--- a/terragrunt/modules/kms/templates/key-policy.json.tftpl
+++ b/terragrunt/modules/kms/templates/key-policy.json.tftpl
@@ -74,7 +74,27 @@
             "Resource": "*"
         }
         %{ endif }
-
+        %{ if bucket_enable_presigned }
+        ,{
+          "Sid": "AllowS3PresignedUrlUploads",
+          "Effect": "Allow",
+          "Principal": "*",
+          "Action": [
+            "kms:Decrypt",
+            "kms:GenerateDataKey"
+          ],
+          "Resource": "*",
+          "Condition": {
+            "StringEquals": {
+              "aws:ViaAWSService": "s3.amazonaws.com",
+              "aws:SourceAccount": "${account_id}"
+            },
+            "ArnLike": {
+              "aws:SourceArn": "arn:aws:s3:::${bucket_name}"
+            }
+          }
+        }
+        %{ endif }
         %{ if length(custom_policies) > 0 }
           %{ for custom_policy in custom_policies ~}
             %{ if can(jsondecode(custom_policy)) }
@@ -84,6 +104,5 @@
             %{ endif }
           %{ endfor ~}
         %{ endif }
-
     ]
 }

--- a/terragrunt/modules/kms/variables.tf
+++ b/terragrunt/modules/kms/variables.tf
@@ -1,3 +1,15 @@
+variable "bucket_enable_presigned" {
+  type        = bool
+  default     = false
+  description = "Allow pre-signed URLs for S3 buckets"
+}
+
+variable "bucket_name" {
+  type        = string
+  default     = null
+  description = "Used if bucket_enable_presigned is true"
+}
+
 variable "custom_policies" {
   type = list(string)
 }

--- a/terragrunt/modules/s3-bucket/datasource.tf
+++ b/terragrunt/modules/s3-bucket/datasource.tf
@@ -1,25 +1,81 @@
 data "aws_caller_identity" "current" {}
 
 data "aws_iam_policy_document" "bucket" {
+
   statement {
-    sid    = "ApplicationAccess"
-    effect = "Allow"
+    sid    = "EnforceSSL"
+    effect = "Deny"
+
     principals {
-      type        = "AWS"
-      identifiers = local.all_roles
+      type        = "*"
+      identifiers = ["*"]
     }
-    actions = [
-      "s3:DeleteObject",
-      "s3:GetObject",
-      "s3:GetObjectVersion",
-      "s3:GetBucketVersioning",
-      "s3:ListBucket",
-      "s3:PutObjectAcl",
-      "s3:PutObject",
-    ]
+
+    actions = ["s3:*"]
+
     resources = [
       aws_s3_bucket.bucket.arn,
       "${aws_s3_bucket.bucket.arn}/*"
     ]
+
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["false"]
+    }
+  }
+
+  dynamic "statement" {
+    for_each = length(local.all_roles) > 0 ? [local.all_roles] : []
+    content {
+      sid    = "ApplicationAccess"
+      effect = "Allow"
+      principals {
+        type        = "AWS"
+        identifiers = local.all_roles
+      }
+      actions = [
+        "s3:DeleteObject",
+        "s3:GetObject",
+        "s3:GetObjectVersion",
+        "s3:GetBucketVersioning",
+        "s3:ListBucket",
+        "s3:PutObjectAcl",
+        "s3:PutObject",
+      ]
+      resources = [
+        aws_s3_bucket.bucket.arn,
+        "${aws_s3_bucket.bucket.arn}/*"
+      ]
+    }
+  }
+
+  dynamic "statement" {
+    for_each = length(var.read_roles) > 0 ? var.read_roles : []
+    content {
+      sid    = "OptionalReadAccess"
+      effect = "Allow"
+      principals {
+        type        = "AWS"
+        identifiers = [statement.value]
+      }
+      actions = ["s3:GetObject"]
+      resources = ["${aws_s3_bucket.bucket.arn}/*"]
+    }
+  }
+
+  dynamic "statement" {
+    for_each = length(var.write_roles) > 0 ? var.write_roles : []
+    content {
+      sid    = "OptionalWriteAccess"
+      effect = "Allow"
+      principals {
+        type        = "AWS"
+        identifiers = [statement.value]
+      }
+      actions = ["s3:PutObject"]
+      resources = ["${aws_s3_bucket.bucket.arn}/*"]
+    }
   }
 }
+

--- a/terragrunt/modules/s3-bucket/kms.tf
+++ b/terragrunt/modules/s3-bucket/kms.tf
@@ -1,6 +1,8 @@
 module "s3_kms_key" {
   source = "../kms"
 
+  bucket_enable_presigned  = var.enable_presigned_urls
+  bucket_name              = var.bucket_name
   custom_policies          = []
   customer_master_key_spec = "SYMMETRIC_DEFAULT"
   deletion_window_in_days  = 7

--- a/terragrunt/modules/s3-bucket/variables.tf
+++ b/terragrunt/modules/s3-bucket/variables.tf
@@ -3,6 +3,24 @@ variable "bucket_name" {
   type        = string
 }
 
+variable "enable_access_logging" {
+  type        = bool
+  default     = false
+  description = "Enable server access logging for the bucket"
+}
+
+variable "enable_lifecycle" {
+  type        = bool
+  default     = false
+  description = "Enable lifecycle rule to expire files after a few days"
+}
+
+variable "enable_presigned_urls" {
+  type        = bool
+  default     = false
+  description = "Allow pre-signed URLs for S3 buckets"
+}
+
 variable "kms_key_admin_role" {
   default     = "bootstrap"
   description = "IAM role name to administrate the key"
@@ -13,6 +31,12 @@ variable "kms_key_description" {
   default     = ""
   description = "The description of the KMS used to encrypt S3 bucket contents"
   type        = string
+}
+
+variable "lifecycle_expiration_days" {
+  type        = number
+  default     = 7
+  description = "Number of days before files expire (if lifecycle enabled)"
 }
 
 variable "read_roles" {

--- a/terragrunt/tools/scripts/s3-presign.py
+++ b/terragrunt/tools/scripts/s3-presign.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+
+import boto3
+import argparse
+import datetime
+
+parser = argparse.ArgumentParser(description='Generate pre-signed URLs for both upload and download of an S3 object.')
+parser.add_argument('--bucket', required=True, help='Target S3 bucket name')
+parser.add_argument('--key', required=True, help='Base key prefix (e.g. dumps/db_backup)')
+parser.add_argument('--expires', default=3600, type=int, help='Expiration time in seconds (default: 3600)')
+
+args = parser.parse_args()
+
+timestamp = datetime.datetime.utcnow().strftime('%Y%m%d_%H%M%S')
+object_key = f"{args.key}_{timestamp}.sql"
+
+s3 = boto3.client("s3", region_name="eu-west-2", endpoint_url="https://s3.eu-west-2.amazonaws.com")
+
+upload_url = s3.generate_presigned_url(
+    ClientMethod='put_object',
+    Params={'Bucket': args.bucket, 'Key': object_key},
+    ExpiresIn=args.expires
+)
+
+download_url = s3.generate_presigned_url(
+    ClientMethod='get_object',
+    Params={'Bucket': args.bucket, 'Key': object_key},
+    ExpiresIn=args.expires
+)
+
+
+print(f"\n✅ Pre-signed URLs generated for object key:\n  {object_key}\n")
+
+print("📁 Set your local file path:")
+print("export file_to_upload=</your/path/to/file.sql>")
+
+print("\n📦 To upload your file, run:\n")
+print(f'curl --location --request PUT \\')
+print(f'     --upload-file "$file_to_upload" \\')
+print(f'     "{upload_url}"')
+
+print("\n📥 To download the uploaded file, run:\n")
+print(f'curl --location --request GET \\')
+print(f'     --output downloaded_{timestamp}.sql \\')
+print(f'     "{download_url}"\n')


### PR DESCRIPTION
  - Added bucket for temporary upload of sensitive SQL backups using pre-signed URLs
  - Extended KMS key policy to allow anonymous S3 access via pre-signed URLs
  - Conditional logic ensures existing buckets and services remain unaffected
  - Added script to populate pre-signed URLs/Commands to share with FTS

⚠️  Requires testing to confirm KMS and S3 policy changes do not impact other consumers