### PR TITLE
DP-1487 - Fix incorrect last name label used on "your details" page

### DIFF
--- a/Frontend/CO.CDP.OrganisationApp/Pages/YourDetails.cshtml.cs
+++ b/Frontend/CO.CDP.OrganisationApp/Pages/YourDetails.cshtml.cs
@@ -19,7 +19,7 @@ public class YourDetailsModel(
     public string? FirstName { get; set; }
 
     [BindProperty]
-    [DisplayName(nameof(StaticTextResource.Users_LastName_Validation))]
+    [DisplayName(nameof(StaticTextResource.Users_LastName_Label))]
     [Required(ErrorMessageResourceName = nameof(StaticTextResource.Users_LastName_Validation), ErrorMessageResourceType = typeof(StaticTextResource))]
     public string? LastName { get; set; }
 


### PR DESCRIPTION
Changed the label tags for first and last name to pull content from the static text file @StaticTextResource.Users_FirstName_Label 
@StaticTextResource.Users_LastName_Label