### PR TITLE
DP-1692 Refactor SES domain verification to support multiple mail-from domains

### DIFF
--- a/terragrunt/components/service/notification/terragrunt.hcl
+++ b/terragrunt/components/service/notification/terragrunt.hcl
@@ -34,8 +34,8 @@ dependency core_iam {
 }
 
 inputs = {
-  mail_from_domain = local.global_vars.locals.mail_from_domain
-  tags             = local.tags
+  mail_from_domains = local.global_vars.locals.mail_from_domains
+  tags              = local.tags
 
 
   role_ecs_task_arn = dependency.core_iam.outputs.ecs_task_arn

--- a/terragrunt/components/terragrunt.hcl
+++ b/terragrunt/components/terragrunt.hcl
@@ -47,7 +47,7 @@ locals {
       cfs_service_allowed_origins       = []
       fts_extra_domains                 = []
       fts_service_allowed_origins       = []
-      mail_from_domain                  = null
+      mail_from_domains                 = []
       mysql_aurora_engine_version       = "5.7.mysql_aurora.2.12.5"
       mysql_aurora_family               = "aurora-mysql5.7"
       mysql_aurora_instance_type        = "db.r5.8xlarge"
@@ -91,7 +91,7 @@ locals {
         "https://fts.staging.supplier-information.find-tender.service.gov.uk",
       ]
       name                              = "staging"
-      mail_from_domain                  = null
+      mail_from_domains                 = []
       mysql_aurora_engine_version       = "5.7.mysql_aurora.2.12.5"
       mysql_aurora_family               = "aurora-mysql5.7"
       mysql_aurora_instance_type        = "db.r5.8xlarge"
@@ -205,7 +205,7 @@ locals {
         "https://www-tpp-preview.find-tender.service.gov.uk",
         "https://www-tpp.find-tender.service.gov.uk",
       ]
-      mail_from_domain                  = null
+      mail_from_domains                 = []
       mysql_aurora_engine_version       = "5.7.mysql_aurora.2.12.5"
       mysql_aurora_family               = "aurora-mysql5.7"
       mysql_aurora_instance_type        = "db.r5.8xlarge"
@@ -259,7 +259,7 @@ locals {
         "https://fts.supplier-information.find-tender.service.gov.uk",
         "https://www.find-tender.service.gov.uk"
       ]
-      mail_from_domain                  = "find-tender.service.gov.uk"
+      mail_from_domains                 = ["find-tender.service.gov.uk", "contractsfinder.service.gov.uk"]
       mysql_aurora_engine_version       = "5.7.mysql_aurora.2.12.5"
       mysql_aurora_family               = "aurora-mysql5.7"
       mysql_aurora_instance_type        = "db.r5.8xlarge"
@@ -303,7 +303,7 @@ locals {
   fts_extra_domains                 = try(local.environments[local.environment].fts_extra_domains, null)
   fts_azure_frontdoor               = try(local.environments[local.environment].fts_azure_frontdoor, null)
   fts_service_allowed_origins       = try(local.environments[local.environment].fts_service_allowed_origins, null)
-  mail_from_domain                  = try(local.environments[local.environment].mail_from_domain, null)
+  mail_from_domains                  = try(local.environments[local.environment].mail_from_domains, [])
   onelogin_logout_notification_urls = try(local.environments[local.environment].onelogin_logout_notification_urls, null)
   pinned_service_version            = try(local.environments[local.environment].pinned_service_version, null)
   pinned_service_version_cfs        = try(local.environments[local.environment].pinned_service_version_cfs, null)

--- a/terragrunt/modules/notification/datasource.tf
+++ b/terragrunt/modules/notification/datasource.tf
@@ -3,19 +3,22 @@ data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 
 data "aws_iam_policy_document" "ses_send" {
-  statement {
-    effect = "Allow"
+  for_each = toset(local.effective_mail_from_domains)
 
+  statement {
+    sid    = "AllowAppToSendEmails"
+    effect = "Allow"
     actions = [
       "ses:SendEmail",
       "ses:SendRawEmail"
     ]
-
-    resources = [aws_ses_domain_identity.this.arn]
-
+    resources = [
+      "arn:aws:ses:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:identity/${each.key}"
+    ]
     principals {
       type        = "Service"
       identifiers = ["ec2.amazonaws.com"]
     }
   }
 }
+

--- a/terragrunt/modules/notification/locals.tf
+++ b/terragrunt/modules/notification/locals.tf
@@ -1,6 +1,5 @@
 locals {
   name_prefix = var.product.resource_name
 
-  effective_mail_from_domain = var.mail_from_domain != null ? var.mail_from_domain : var.product.public_hosted_zone
-  manage_dns_records         = var.mail_from_domain == null
+  effective_mail_from_domains = length(var.mail_from_domains) > 0 ? var.mail_from_domains : [var.product.public_hosted_zone]
 }

--- a/terragrunt/modules/notification/main.tf
+++ b/terragrunt/modules/notification/main.tf
@@ -1,13 +1,20 @@
 resource "aws_ses_domain_identity" "this" {
-  domain = local.effective_mail_from_domain
+  for_each = toset(local.effective_mail_from_domains)
+
+  domain   = each.value
 }
 
 resource "aws_ses_domain_dkim" "this" {
-  domain = aws_ses_domain_identity.this.domain
+  for_each = aws_ses_domain_identity.this
+
+  domain   = each.value.domain
 }
 
 resource "aws_ses_identity_policy" "send_policy" {
-  name     = "${local.name_prefix}-AllowSESSend"
-  identity = aws_ses_domain_identity.this.arn
-  policy   = data.aws_iam_policy_document.ses_send.json
+  for_each = toset(local.effective_mail_from_domains)
+
+  identity = aws_ses_domain_identity.this[each.key].arn
+  name     = "${local.name_prefix}-AllowSESSend-${replace(replace(each.key, ".", "-"), "/^.{0,64}/", "")}"
+  policy   = data.aws_iam_policy_document.ses_send[each.key].json
 }
+

--- a/terragrunt/modules/notification/outputs.tf
+++ b/terragrunt/modules/notification/outputs.tf
@@ -1,17 +1,24 @@
 output "dkim_tokens" {
-  value       = aws_ses_domain_dkim.this.dkim_tokens
-  description = "DKIM tokens for the domain"
+  value = {
+    for domain, res in aws_ses_domain_dkim.this :
+    domain => res.dkim_tokens
+  }
 }
 
 output "domain_identity_arn" {
-  value = aws_ses_domain_identity.this.arn
+  value = {
+    for domain, res in aws_ses_domain_identity.this :
+    domain => res.arn
+  }
 }
 
-output "ses_verification_record" {
+output "ses_verification_records" {
   value = {
-    name  = "_amazonses.${var.product.public_hosted_zone}"
-    type  = "TXT"
-    value = aws_ses_domain_identity.this.verification_token
+    for domain, res in aws_ses_domain_identity.this :
+    domain => {
+      name  = "_amazonses.${domain}"
+      type  = "TXT"
+      value = res.verification_token
+    }
   }
-  description = "Record to verify SES domain"
 }

--- a/terragrunt/modules/notification/variables.tf
+++ b/terragrunt/modules/notification/variables.tf
@@ -1,7 +1,7 @@
-variable "mail_from_domain" {
-  description = "Domain name to be used for sending email from in each account"
-  type        = string
-  default     = null
+variable "mail_from_domains" {
+  description = "List of domain names to verify with SES and Route53 (e.g., mail-from domains)"
+  type        = list(string)
+  default     = []
 }
 
 variable "product" {


### PR DESCRIPTION
  - Updated SES identity, DKIM, and Route53 resources to use `for_each` for better multi-domain support.
  - Introduced `mail_from_domains` variable as a list to support future extension.
  - Ensured backward compatibility: existing records remain untouched.
  - Outputs now expose verification records and DKIM tokens per domain for external consumption.