### PR TITLE
CFS-Migration Support external domain redirects for staging and integration

### DIFF
--- a/terragrunt/components/service/ecs/terragrunt.hcl
+++ b/terragrunt/components/service/ecs/terragrunt.hcl
@@ -135,6 +135,7 @@ inputs = {
 
   account_ids                       = local.global_vars.locals.account_ids
   cfs_allowed_target_email_domains  = local.global_vars.locals.cfs_allowed_target_email_domains
+  cfs_extra_host_headers            = local.global_vars.locals.cfs_extra_domains
   cfs_service_allowed_origins       = local.global_vars.locals.cfs_service_allowed_origins
   fts_allowed_target_email_domains  = local.global_vars.locals.fts_allowed_target_email_domains
   fts_extra_host_headers            = local.global_vars.locals.fts_extra_domains

--- a/terragrunt/components/terragrunt.hcl
+++ b/terragrunt/components/terragrunt.hcl
@@ -81,6 +81,7 @@ locals {
       account_id                        = 905418042182
       canary_schedule_expression        = "rate(30 minutes)"
       cfs_allowed_target_email_domains  = ["goaco.com"]
+      cfs_extra_domains                 = ["www-preview.contractsfinder.service.gov.uk"]
       fts_allowed_target_email_domains  = ["goaco.com"]
       fts_extra_domains                 = ["www-staging.find-tender.service.gov.uk"]
       fts_azure_frontdoor               = null
@@ -125,6 +126,7 @@ locals {
       account_id                        = 767397666448
       canary_schedule_expression        = "rate(30 minutes)"
       cfs_allowed_target_email_domains  = ["goaco.com"]
+      cfs_extra_domains                 = ["www-integration.contractsfinder.service.gov.uk"]
       cfs_service_allowed_origins       = [
         "https://cfs.integration.supplier-information.find-tender.service.gov.uk",
         "https://test-findtender.nqc.com",
@@ -248,6 +250,7 @@ locals {
       account_id                        = 471112843276
       canary_schedule_expression        = "rate(15 minutes)"
       cfs_allowed_target_email_domains  = ["goaco.com"]
+      fts_extra_domains                 = []
       cfs_service_allowed_origins       = [
         "https://cfs.supplier-information.find-tender.service.gov.uk",
         "https://www.find-tender.service.gov.uk"
@@ -298,9 +301,10 @@ locals {
   aurora_postgres_instance_type     = try(local.environments[local.environment].postgres_aurora_instance_type, null)
   aurora_postgres_instance_type_ev  = try(local.environments[local.environment].postgres_aurora_instance_type_ev, local.aurora_postgres_instance_type)
   cfs_allowed_target_email_domains  = try(local.environments[local.environment].cfs_allowed_target_email_domains, null)
+  cfs_extra_domains                 = try(local.environments[local.environment].cfs_extra_domains, [])
   cfs_service_allowed_origins       = try(local.environments[local.environment].cfs_service_allowed_origins, null)
   fts_allowed_target_email_domains  = try(local.environments[local.environment].fts_allowed_target_email_domains, null)
-  fts_extra_domains                 = try(local.environments[local.environment].fts_extra_domains, null)
+  fts_extra_domains                 = try(local.environments[local.environment].fts_extra_domains, [])
   fts_azure_frontdoor               = try(local.environments[local.environment].fts_azure_frontdoor, null)
   fts_service_allowed_origins       = try(local.environments[local.environment].fts_service_allowed_origins, null)
   mail_from_domains                  = try(local.environments[local.environment].mail_from_domains, [])

--- a/terragrunt/modules/ecs/locals-cfs.tf
+++ b/terragrunt/modules/ecs/locals-cfs.tf
@@ -6,6 +6,13 @@ locals {
 
   cfs_screts_arn = data.aws_secretsmanager_secret.cfs_secrets.arn
 
+  cfs_site_domains = {
+    development = "cfs.${var.public_domain}"
+    staging     = "www-preview.contractsfinder.service.gov.uk"
+    integration = "www-integration.contractsfinder.service.gov.uk"
+    production  = "cfs.${var.public_domain}"
+  }
+
   cfs_secrets = {
     dev_email                             = "${local.cfs_screts_arn}:DEV_EMAIL::"
     email_contactus                       = "${local.cfs_screts_arn}:CONTACTUS_EMAIL::"
@@ -36,7 +43,7 @@ locals {
   cfs_parameters = {
     app_host_address                    = "%"
     buyer_corporate_identifier_prefixes = "sid4gov.cabinetoffice.gov.uk|supplierregistration.cabinetoffice.gov.uk"
-    cookie_domain                       = "cfs.${var.public_domain}"
+    cookie_domain                       = local.cfs_site_domains[var.environment]
     db_host                             = var.db_cfs_cluster_address
     db_name                             = var.db_cfs_cluster_name
     db_port                             = 3306
@@ -47,7 +54,7 @@ locals {
     http_basic_auth_enabled             = 1
     include_devel                       = false
     local_version                       = 1000
-    site_domain                         = "cfs.${var.public_domain}"
+    site_domain                         = local.cfs_site_domains[var.environment]
     ssl_service                         = true
     email_support                       = var.is_production ? "noreply@find-tender.service.gov.uk" : "noreply@${var.public_domain}"
     valid_until                         = 1924990799

--- a/terragrunt/modules/ecs/locals-fts.tf
+++ b/terragrunt/modules/ecs/locals-fts.tf
@@ -20,7 +20,7 @@ locals {
     production  = "https://www.find-tender.service.gov.uk/auth/callback"
   }
 
-  site_domains = {
+  fts_site_domains = {
     development = "fts.${var.public_domain}"
     staging     = "www-staging.find-tender.service.gov.uk"
     integration = "www-tpp.find-tender.service.gov.uk"
@@ -62,7 +62,7 @@ locals {
     dev_email                           = "${local.fts_screts_arn}:DEV_EMAIL::"
     app_host_address                    = "%"
     buyer_corporate_identifier_prefixes = "sid4gov.cabinetoffice.gov.uk|supplierregistration.service.xgov.uk|test-idp-intra.nqc.com"
-    cookie_domain                       = local.site_domains[var.environment]
+    cookie_domain                       = local.fts_site_domains[var.environment]
     database_schema                     = "cdp_sirsi_fts_cluster"
     db_host                             = var.db_fts_cluster_address
     db_name                             = var.db_fts_cluster_name
@@ -77,7 +77,7 @@ locals {
     licenced_to                         = "No-one"
     local_version                       = 1100
     session_name_default                = "SRSI_FT_AUTH"
-    site_domain                         = local.site_domains[var.environment]
+    site_domain                         = local.fts_site_domains[var.environment]
     site_tag                            = "TEST"
     srsi_authority_token_endpoint       = "https://authority.${var.public_domain}/token"
     srsi_dashboard_endpoint             = "https://${var.public_domain}"

--- a/terragrunt/modules/ecs/service-cfs.tf
+++ b/terragrunt/modules/ecs/service-cfs.tf
@@ -13,6 +13,7 @@ module "ecs_service_cfs" {
   ecs_alb_sg_id          = var.alb_sg_id
   ecs_listener_arn       = aws_lb_listener.ecs.arn
   ecs_service_base_sg_id = var.ecs_sg_id
+  extra_host_headers     = var.cfs_extra_host_headers
   family                 = "app"
   healthcheck_path       = "/health"
   host_port              = var.service_configs.cfs.port

--- a/terragrunt/modules/ecs/variables.tf
+++ b/terragrunt/modules/ecs/variables.tf
@@ -13,6 +13,12 @@ variable "cfs_allowed_target_email_domains" {
   type        = list(string)
 }
 
+variable "cfs_extra_host_headers" {
+  description = "Optional list of additional host headers to be added for CFS service"
+  type        = list(string)
+  default     = []
+}
+
 variable "cfs_service_allowed_origins" {
   description = "A list of allowed URLs"
   type        = list(string)


### PR DESCRIPTION
- Add support for extra host headers `cfs_extra_domains` (split `fts_extra_domains`)
- Update site and cookie domains for CFS
- Enable domain handling for www-preview and www-integration subdomains
- Prepare ECS modules and variables to accept traffic from non-owned domains