### PR TITLE
Updates to the Organisation PPON search for Exact match and Org Name Fuzzy Search.

### DIFF
--- a/Frontend/CO.CDP.OrganisationApp.Tests/Pages/Organisation/OrganisationPponSearchModelTest.cs
+++ b/Frontend/CO.CDP.OrganisationApp.Tests/Pages/Organisation/OrganisationPponSearchModelTest.cs
@@ -21,6 +21,7 @@ public class OrganisationPponSearchModelTest
     private const string DefaultSortOrder = "rel";
     private const int DefaultPageSize = 10;
     private const int DefaultPageNumber = 1;
+    private const double DefaultThreshold = 0.3;
     private static readonly Guid Id = Guid.NewGuid();
 
     private readonly Mock<IOrganisationClient> _mockOrganisationClient;
@@ -91,7 +92,7 @@ public class OrganisationPponSearchModelTest
         return new OrganisationSearchByPponResponse(results, results.Count);
     }
 
-    private void SetupSuccessfulSearch(string searchText, string sortOrder, int pageSize, int skip,
+    private void SetupSuccessfulSearch(string searchText, string sortOrder, int pageSize, int skip, double threshold,
         List<OrganisationSearchByPponResult> results)
     {
         var response = CreateTestResponse(results);
@@ -100,7 +101,8 @@ public class OrganisationPponSearchModelTest
                 searchText,
                 pageSize,
                 skip,
-                sortOrder))
+                sortOrder,
+                threshold))
             .ReturnsAsync(response);
     }
 
@@ -169,7 +171,7 @@ public class OrganisationPponSearchModelTest
             CreateTestOrganisationResult("Test Organisation 2", new List<PartyRole> { PartyRole.Buyer })
         };
 
-        SetupSuccessfulSearch(DefaultSearchText, DefaultSortOrder, DefaultPageSize, 0, mockResults);
+        SetupSuccessfulSearch(DefaultSearchText, DefaultSortOrder, DefaultPageSize, 0, DefaultThreshold, mockResults);
 
         var result = await _testOrganisationPponSearchModel.OnGet();
 
@@ -274,7 +276,8 @@ public class OrganisationPponSearchModelTest
                 DefaultSearchText,
                 DefaultPageSize,
                 0,
-                sortOrder))
+                sortOrder,
+                DefaultThreshold))
             .ReturnsAsync(CreateTestResponse(mockResults))
             .Verifiable();
 
@@ -284,7 +287,8 @@ public class OrganisationPponSearchModelTest
                 DefaultSearchText,
                 DefaultPageSize,
                 0,
-                sortOrder),
+                sortOrder,
+                DefaultThreshold),
             Times.Once);
         _testOrganisationPponSearchModel.Id.Should().Be(Id);
     }
@@ -309,7 +313,8 @@ public class OrganisationPponSearchModelTest
                 DefaultSearchText,
                 DefaultPageSize,
                 expectedSkip,
-                DefaultSortOrder))
+                DefaultSortOrder,
+                DefaultThreshold))
             .ReturnsAsync(response)
             .Verifiable();
 
@@ -319,7 +324,8 @@ public class OrganisationPponSearchModelTest
                 DefaultSearchText,
                 DefaultPageSize,
                 expectedSkip,
-                DefaultSortOrder),
+                DefaultSortOrder,
+                DefaultThreshold),
             Times.Once);
 
         _testOrganisationPponSearchModel.CurrentPage.Should().Be(pageNumber);
@@ -359,7 +365,8 @@ public class OrganisationPponSearchModelTest
                 It.IsAny<string>(),
                 It.IsAny<int>(),
                 It.IsAny<int>(),
-                It.IsAny<string>()))
+                It.IsAny<string>(),
+                It.IsAny<double>()))
             .ThrowsAsync(exception);
 
         await _testOrganisationPponSearchModel.OnGet();
@@ -398,7 +405,7 @@ public class OrganisationPponSearchModelTest
             CreateTestOrganisationResult("Test Organisation 1", new List<PartyRole> { PartyRole.Buyer }),
             CreateTestOrganisationResult("Test Organisation 2", new List<PartyRole> { PartyRole.Buyer })
         };
-        SetupSuccessfulSearch(DefaultSearchText, DefaultSortOrder, DefaultPageSize, 0, mockResults);
+        SetupSuccessfulSearch(DefaultSearchText, DefaultSortOrder, DefaultPageSize, 0, DefaultThreshold, mockResults);
         var result = await _testOrganisationPponSearchModel.OnPost();
         result.Should().BeOfType<PageResult>();
         _testOrganisationPponSearchModel.Organisations.Should().HaveCount(2);
@@ -436,7 +443,8 @@ public class OrganisationPponSearchModelTest
                 It.IsAny<string>(),
                 It.IsAny<int>(),
                 It.IsAny<int>(),
-                It.IsAny<string>()))
+                It.IsAny<string>(),
+                It.IsAny<double>()))
             .ThrowsAsync(exception);
         await _testOrganisationPponSearchModel.OnPost();
         _testOrganisationPponSearchModel.Organisations.Should().BeEmpty();
@@ -495,7 +503,7 @@ public class OrganisationPponSearchModelTest
         _testOrganisationPponSearchModel.PageNumber = DefaultPageNumber;
         _testOrganisationPponSearchModel.SearchText = DefaultSearchText;
         _testOrganisationPponSearchModel.SortOrder = DefaultSortOrder;
-        SetupSuccessfulSearch(DefaultSearchText, DefaultSortOrder, DefaultPageSize, 0,
+        SetupSuccessfulSearch(DefaultSearchText, DefaultSortOrder, DefaultPageSize, 0, DefaultThreshold,
             new List<OrganisationSearchByPponResult>());
         await _testOrganisationPponSearchModel.OnGet();
         _testOrganisationPponSearchModel.ErrorMessage.Should().Be(Localization.StaticTextResource.PponSearch_NoResults);
@@ -515,7 +523,8 @@ public class OrganisationPponSearchModelTest
             It.IsAny<string>(),
             It.IsAny<int>(),
             It.IsAny<int>(),
-            It.IsAny<string>())).ThrowsAsync(new HttpRequestException());
+            It.IsAny<string>(),
+            It.IsAny<double>())).ThrowsAsync(new HttpRequestException());
         await _testOrganisationPponSearchModel.OnGet();
         _testOrganisationPponSearchModel.ErrorMessage.Should().Be(Localization.StaticTextResource.PponSearch_NoResults);
         _testOrganisationPponSearchModel.Organisations.Should().BeEmpty();

--- a/Frontend/CO.CDP.OrganisationApp/Pages/Organisation/OrganisationPponSearch.cshtml
+++ b/Frontend/CO.CDP.OrganisationApp/Pages/Organisation/OrganisationPponSearch.cshtml
@@ -140,7 +140,7 @@
             </div>
             <div class="govuk-grid-column-one-third govuk-!-text-align-right">
                 <div class="govuk-grid-row" aria-label="Organisation roles">
-                    @foreach (var partyRole in @org.Roles.Distinct())
+                    @foreach (var partyRole in @org.Roles.Distinct().OrderBy(r=> r.ToString()))
                     {
                         <strong class="govuk-tag @Model.GetTagClassForRole(partyRole)" aria-label="Role: @partyRole">
                             @partyRole

--- a/Frontend/CO.CDP.OrganisationApp/Pages/Organisation/OrganisationPponSearch.cshtml.cs
+++ b/Frontend/CO.CDP.OrganisationApp/Pages/Organisation/OrganisationPponSearch.cshtml.cs
@@ -36,6 +36,8 @@ public class OrganisationPponSearchModel(
 
     public string? ErrorMessage { get; set; }
 
+    public double Threshold { get; set; } = 0.3;
+
     [BindProperty(SupportsGet = true)] public Guid Id { get; set; }
 
     [BindProperty(SupportsGet = true)] public int PageNumber { get; set; } = 1;
@@ -53,7 +55,7 @@ public class OrganisationPponSearchModel(
     {
         if (!string.IsNullOrWhiteSpace(SearchText))
         {
-            var result = await HandleSearch(PageNumber, SearchText, SortOrder);
+            var result = await HandleSearch(PageNumber, SearchText, SortOrder, Threshold);
             ApplySearchResult(result);
         }
         else
@@ -69,7 +71,7 @@ public class OrganisationPponSearchModel(
 
     public async Task<IActionResult> OnPost()
     {
-        var result = await HandleSearch(PageNumber, SearchText, SortOrder);
+        var result = await HandleSearch(PageNumber, SearchText, SortOrder, Threshold);
         ApplySearchResult(result);
         return Page();
     }
@@ -84,7 +86,7 @@ public class OrganisationPponSearchModel(
         string? ErrorMessage
     );
 
-    private async Task<SearchResult> HandleSearch(int pageNumber, string searchText, string sortOrder)
+    private async Task<SearchResult> HandleSearch(int pageNumber, string searchText, string sortOrder, double threshold)
     {
         var (pageSize, skip, currentPage) = CalculatePagination(pageNumber);
         var validationResult = ValidateSearchInput(searchText);
@@ -92,7 +94,7 @@ public class OrganisationPponSearchModel(
         {
             return CreateInvalidSearchResult(pageSize, skip, currentPage, validationResult.ErrorMessage);
         }
-        return await FetchOrganisationSearchResults(validationResult.CleanedSearchText, sortOrder, pageSize, skip, currentPage);
+        return await FetchOrganisationSearchResults(validationResult.CleanedSearchText, sortOrder, pageSize, skip, currentPage, threshold);
     }
 
     private static SearchResult CreateEmptySearchResult(int pageSize, int skip, int currentPage) =>
@@ -111,12 +113,12 @@ public class OrganisationPponSearchModel(
         );
 
     private async Task<SearchResult> FetchOrganisationSearchResults(string cleanedSearchText, string sortOrder,
-        int pageSize, int skip, int currentPage)
+        int pageSize, int skip, int currentPage, double threshold)
     {
         try
         {
             var (orgs, totalCount) =
-                await organisationClient.SearchOrganisationByNameOrPpon(cleanedSearchText, pageSize, skip, sortOrder);
+                await organisationClient.SearchOrganisationByNameOrPpon(cleanedSearchText, pageSize, skip, sortOrder, threshold);
             if (orgs.Count == 0)
             {
                 return new SearchResult(

--- a/Frontend/CO.CDP.OrganisationApp/WebApiClients/OrganisationClientExtensions.cs
+++ b/Frontend/CO.CDP.OrganisationApp/WebApiClients/OrganisationClientExtensions.cs
@@ -262,10 +262,11 @@ internal static class OrganisationClientExtensions
         string searchText,
         int pageSize,
         int skip,
-        string orderBy) {
+        string orderBy,
+        double threshold) {
         try
         {
-            var searchResults =  await organisationClient.SearchByNameOrPponAsync(searchText, pageSize,skip,orderBy);
+            var searchResults =  await organisationClient.SearchByNameOrPponAsync(searchText, pageSize,skip,orderBy, threshold);
             if (searchResults.Results.Count > 0)
             {
                 return (searchResults.Results, searchResults.TotalCount);

--- a/Libraries/CO.CDP.Organisation.WebApiClient.Tests/OrganisationClientIntegrationTest.cs
+++ b/Libraries/CO.CDP.Organisation.WebApiClient.Tests/OrganisationClientIntegrationTest.cs
@@ -1,4 +1,5 @@
 using CO.CDP.GovUKNotify;
+using CO.CDP.MQ;
 using CO.CDP.OrganisationInformation.Persistence;
 using CO.CDP.TestKit.Mvc;
 using FluentAssertions;
@@ -15,15 +16,22 @@ public class OrganisationClientIntegrationTest
 
     public OrganisationClientIntegrationTest(ITestOutputHelper testOutputHelper)
     {
+        var mockPublisher = new Mock<IPublisher>();
         TestWebApplicationFactory<Program> _factory = new(builder =>
         {
             builder.ConfigureInMemoryDbContext<OrganisationInformationContext>();
             builder.ConfigureFakePolicyEvaluator();
             builder.ConfigureLogging(testOutputHelper);
+
             builder.ConfigureServices((_, s) =>
             {
                 s.AddScoped(_ => _govUKNotifyApiClientMock.Object);
+                s.AddScoped(_ => mockPublisher.Object);
             });
+
+
+
+
         });
 
         _httpClient = _factory.CreateClient();

--- a/Services/CO.CDP.Localization/StaticTextResource.resx
+++ b/Services/CO.CDP.Localization/StaticTextResource.resx
@@ -4253,7 +4253,7 @@
     <value>Public procurement organisation number register</value>
   </data>
   <data name="PponSearch_Hint" xml:space="preserve">
-    <value>Search by organisation name or PPON</value>
+    <value>Search by organisation name, PPON or other unique identifiers</value>
   </data>
   <data name="PponSearch_Ppon_Desc_Title" xml:space="preserve">
     <value>Public procurement organisation number (PPON)</value>
@@ -4272,17 +4272,17 @@
   </data>
   <data name="PponSearch_Ppon_Desc_Hint_01" xml:space="preserve">
     <value>
-      &lt;p class=&quot;govuk-body&quot;&gt;
+      &lt;p class="govuk-body"&gt;
         A PPON is a unique identifier assigned to organisations that participate in public procurement, generated when an organisation registers on the
-        &lt;a target=&quot;_blank&quot; href=&quot;https://www.find-tender.service.gov.uk&quot;&gt;
-        Central Digital Platform (opens in a new tab)&lt;/a&gt;. It is used to manage and publish notices related to public procurement and connects information about the organisation digitally.
+        &lt;a target="_blank" href="https://www.find-tender.service.gov.uk"&gt;
+        Find a Tender (opens in a new tab)&lt;/a&gt;. It is used to manage and publish notices related to public procurement and connects information about the organisation digitally.
       &lt;/p&gt;
     </value>
   </data>
   <data name="PponSearch_Ppon_Desc_Hint_02" xml:space="preserve">
     <value>
       &lt;p class=&quot;govuk-body&quot;&gt;
-        Your PPON is a combination of 16 letters and numbers, separated by hyphens. For example, ABCD-EFGH-1234-IJKL.
+        Your PPON is a combination of 12 letters and numbers, separated by hyphens. For example, EFGH-1234-IJKL.
       &lt;/p&gt;
     </value>
   </data>

--- a/Services/CO.CDP.Organisation.WebApi.Tests/Api/OrganisationEndpointsTests.cs
+++ b/Services/CO.CDP.Organisation.WebApi.Tests/Api/OrganisationEndpointsTests.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Hosting;
 using Moq;
 using System.Net;
 using System.Net.Http.Json;
+using CO.CDP.MQ;
 using static CO.CDP.Authentication.Constants;
 using static System.Net.HttpStatusCode;
 
@@ -35,6 +36,11 @@ public class OrganisationEndpointsTests
                 services.AddScoped(_ => _getOrganisationsUseCase.Object);
                 services.AddScoped(_ => _getOrganisationUseCase.Object);
                 services.AddScoped(_ => _updatesOrganisationUseCase.Object);
+                var mockPublisher = new Mock<IPublisher>();
+
+                services.AddScoped(
+                    sp => mockPublisher.Object);
+
                 services.ConfigureFakePolicyEvaluator();
             });
         });

--- a/Services/CO.CDP.Organisation.WebApi.Tests/Api/SupplierInformationEndpointsTests.cs
+++ b/Services/CO.CDP.Organisation.WebApi.Tests/Api/SupplierInformationEndpointsTests.cs
@@ -9,6 +9,7 @@ using System.Net;
 using System.Net.Http.Json;
 using System.Text;
 using System.Text.Json;
+using CO.CDP.MQ;
 using static CO.CDP.Authentication.Constants;
 using static System.Net.HttpStatusCode;
 
@@ -28,6 +29,11 @@ public class SupplierInformationEndpointsTests
             {
                 services.AddScoped(_ => _getSupplierInformationUseCase.Object);
                 services.AddScoped(_ => _updatesSupplierInformationUseCase.Object);
+                var mockPublisher = new Mock<IPublisher>();
+
+                services.AddScoped(
+                    sp => mockPublisher.Object);
+
                 services.ConfigureFakePolicyEvaluator();
             });
         });

--- a/Services/CO.CDP.Organisation.WebApi.Tests/UseCase/SearchOrganisationByPponUseCaseTests.cs
+++ b/Services/CO.CDP.Organisation.WebApi.Tests/UseCase/SearchOrganisationByPponUseCaseTests.cs
@@ -29,8 +29,9 @@ public class SearchOrganisationByPponUseCaseTests : IClassFixture<AutoMapperFixt
         const int limit = 10;
         const int skip = 0;
         const string orderBy = "asc";
+        const double threshold = 1.0;
 
-        var organisationQuery = new OrganisationSearchByPponQuery(searchTerm, limit, skip, orderBy);
+        var organisationQuery = new OrganisationSearchByPponQuery(searchTerm, limit, skip, orderBy, threshold);
 
         var organisations = new List<OrganisationPersistence>
         {
@@ -38,7 +39,7 @@ public class SearchOrganisationByPponUseCaseTests : IClassFixture<AutoMapperFixt
         };
 
         _mockOrganisationRepository
-            .Setup(r => r.SearchByNameOrPpon(searchTerm, limit, skip, orderBy))
+            .Setup(r => r.SearchByNameOrPpon(searchTerm, limit, skip, orderBy, threshold))
             .ReturnsAsync((organisations, organisations.Count));
 
         var useCase = new SearchOrganisationByPponUseCase(
@@ -65,8 +66,9 @@ public class SearchOrganisationByPponUseCaseTests : IClassFixture<AutoMapperFixt
         const int limit = 10;
         const int skip = 0;
         const string orderBy = "asc";
+        const double threshold = 1.0;
 
-        var organisationQuery = new OrganisationSearchByPponQuery(searchTerm, limit, skip, orderBy);
+        var organisationQuery = new OrganisationSearchByPponQuery(searchTerm, limit, skip, orderBy, threshold);
 
         var organisations = new List<OrganisationPersistence>
         {
@@ -75,7 +77,7 @@ public class SearchOrganisationByPponUseCaseTests : IClassFixture<AutoMapperFixt
         };
 
         _mockOrganisationRepository
-            .Setup(r => r.SearchByNameOrPpon(searchTerm, limit, skip, orderBy))
+            .Setup(r => r.SearchByNameOrPpon(searchTerm, limit, skip, orderBy, threshold))
             .ReturnsAsync((organisations, organisations.Count));
 
         var useCase = new SearchOrganisationByPponUseCase(
@@ -101,8 +103,9 @@ public class SearchOrganisationByPponUseCaseTests : IClassFixture<AutoMapperFixt
         const int limit = 10;
         const int skip = 0;
         const string orderBy = "asc";
+        const double threshold = 0.3;
 
-        var organisationQuery = new OrganisationSearchByPponQuery(searchTerm, limit, skip, orderBy);
+        var organisationQuery = new OrganisationSearchByPponQuery(searchTerm, limit, skip, orderBy, threshold);
 
         var organisations = new List<OrganisationPersistence>
         {
@@ -111,7 +114,7 @@ public class SearchOrganisationByPponUseCaseTests : IClassFixture<AutoMapperFixt
         };
 
         _mockOrganisationRepository
-            .Setup(r => r.SearchByNameOrPpon(searchTerm, limit, skip, orderBy))
+            .Setup(r => r.SearchByNameOrPpon(searchTerm, limit, skip, orderBy, threshold))
             .ReturnsAsync((organisations, organisations.Count));
 
         var useCase = new SearchOrganisationByPponUseCase(
@@ -137,8 +140,9 @@ public class SearchOrganisationByPponUseCaseTests : IClassFixture<AutoMapperFixt
         const int limit = 1;
         const int skip = 1;
         const string orderBy = "asc";
+        const double threshold = 0.3;
 
-        var organisationQuery = new OrganisationSearchByPponQuery(searchTerm, limit, skip, orderBy);
+        var organisationQuery = new OrganisationSearchByPponQuery(searchTerm, limit, skip, orderBy, threshold);
 
         var organisations = new List<OrganisationPersistence>
         {
@@ -147,7 +151,7 @@ public class SearchOrganisationByPponUseCaseTests : IClassFixture<AutoMapperFixt
 
         // Repository returns only the second item, but total count is 2
         _mockOrganisationRepository
-            .Setup(r => r.SearchByNameOrPpon(searchTerm, limit, skip, orderBy))
+            .Setup(r => r.SearchByNameOrPpon(searchTerm, limit, skip, orderBy, threshold))
             .ReturnsAsync((organisations, 2));
 
         var useCase = new SearchOrganisationByPponUseCase(
@@ -171,8 +175,9 @@ public class SearchOrganisationByPponUseCaseTests : IClassFixture<AutoMapperFixt
         const int limit = 10;
         const int skip = 0;
         const string orderBy = "desc";
+        const double threshold = 0.3;
 
-        var organisationQuery = new OrganisationSearchByPponQuery(searchTerm, limit, skip, orderBy);
+        var organisationQuery = new OrganisationSearchByPponQuery(searchTerm, limit, skip, orderBy, threshold);
 
         var organisations = new List<OrganisationPersistence>
         {
@@ -181,7 +186,7 @@ public class SearchOrganisationByPponUseCaseTests : IClassFixture<AutoMapperFixt
         };
 
         _mockOrganisationRepository
-            .Setup(r => r.SearchByNameOrPpon(searchTerm, limit, skip, orderBy))
+            .Setup(r => r.SearchByNameOrPpon(searchTerm, limit, skip, orderBy, threshold))
             .ReturnsAsync((organisations, organisations.Count));
 
         var useCase = new SearchOrganisationByPponUseCase(
@@ -205,13 +210,14 @@ public class SearchOrganisationByPponUseCaseTests : IClassFixture<AutoMapperFixt
         const int limit = 10;
         const int skip = 0;
         const string orderBy = "asc";
+        const double threshold = 0.3;
 
-        var organisationQuery = new OrganisationSearchByPponQuery(searchTerm, limit, skip, orderBy);
+        var organisationQuery = new OrganisationSearchByPponQuery(searchTerm, limit, skip, orderBy, threshold);
 
         var organisations = new List<OrganisationPersistence>();
 
         _mockOrganisationRepository
-            .Setup(r => r.SearchByNameOrPpon(searchTerm, limit, skip, orderBy))
+            .Setup(r => r.SearchByNameOrPpon(searchTerm, limit, skip, orderBy, threshold))
             .ReturnsAsync((organisations, 0));
 
         var useCase = new SearchOrganisationByPponUseCase(

--- a/Services/CO.CDP.Organisation.WebApi/Api/Organisation.cs
+++ b/Services/CO.CDP.Organisation.WebApi/Api/Organisation.cs
@@ -1476,11 +1476,12 @@ public static class EndpointExtensions
         app.MapGet("/search-by-name-or-ppon",
                 [OrganisationAuthorize([AuthenticationChannel.OneLogin, AuthenticationChannel.ServiceKey])]
             async ([FromQuery] string searchText, [FromQuery] int limit, [FromQuery] int skip,[FromQuery] string sortOrder,
-                [FromServices] IUseCase<OrganisationSearchByPponQuery, (IEnumerable<Model.OrganisationSearchByPponResult>, int)> useCase) =>
+                [FromServices] IUseCase<OrganisationSearchByPponQuery, (IEnumerable<Model.OrganisationSearchByPponResult>, int)> useCase,
+                [FromQuery] double? threshold = 0.3) =>
             {
                 sortOrder = string.IsNullOrEmpty(sortOrder) ? "rel" : sortOrder;
 
-                return await useCase.Execute(new OrganisationSearchByPponQuery(searchText, limit, skip, sortOrder))
+                return await useCase.Execute(new OrganisationSearchByPponQuery(searchText, limit, skip, sortOrder, threshold))
                     .AndThen(result => {
                         var (results, totalCount) = result;
                         return results.Any()

--- a/Services/CO.CDP.Organisation.WebApi/Model/Command.cs
+++ b/Services/CO.CDP.Organisation.WebApi/Model/Command.cs
@@ -454,8 +454,9 @@ public record OrganisationSearchByPponQuery
     public int? Limit { get; }
     public int Skip { get; }
     public string OrderBy { get; } = "rel";
+    public double Threshold { get; }
 
-    public OrganisationSearchByPponQuery(string searchText, int? limit,int skip, string orderBy)
+    public OrganisationSearchByPponQuery(string searchText, int? limit,int skip, string orderBy, double? threshold)
     {
         SearchText = searchText;
         Limit = limit;
@@ -463,6 +464,11 @@ public record OrganisationSearchByPponQuery
         if (!string.IsNullOrEmpty(orderBy))
         {
             OrderBy = orderBy;
+        }
+
+        if (threshold.HasValue)
+        {
+            Threshold = threshold.Value;
         }
     }
 }

--- a/Services/CO.CDP.Organisation.WebApi/UseCase/SearchOrganisationByPponUseCase.cs
+++ b/Services/CO.CDP.Organisation.WebApi/UseCase/SearchOrganisationByPponUseCase.cs
@@ -11,7 +11,7 @@ public class SearchOrganisationByPponUseCase(IOrganisationRepository organisatio
 {
     public async Task<(IEnumerable<Model.OrganisationSearchByPponResult> Results, int TotalCount)> Execute(OrganisationSearchByPponQuery query)
     {
-        var result = await organisationRepository.SearchByNameOrPpon(query.SearchText, query.Limit, query.Skip, query.OrderBy);
+        var result = await organisationRepository.SearchByNameOrPpon(query.SearchText, query.Limit, query.Skip, query.OrderBy, query.Threshold);
 
         var mappedResults = result.Results.Select(mapper.Map<Model.OrganisationSearchByPponResult>);
 

--- a/Services/CO.CDP.OrganisationInformation.Persistence.Tests/DatabaseOrganisationRepositoryTest.cs
+++ b/Services/CO.CDP.OrganisationInformation.Persistence.Tests/DatabaseOrganisationRepositoryTest.cs
@@ -825,7 +825,7 @@ public class DatabaseOrganisationRepositoryTest(OrganisationInformationPostgreSq
         await context.Organisations.AddRangeAsync(organisation1, organisation2);
         await context.SaveChangesAsync();
 
-        var result = await repository.SearchByNameOrPpon("1758", 10, 0, "asc");
+        var result = await repository.SearchByNameOrPpon("PGWZ-1758-ABCD", 10, 0, "asc");
 
         result.Results.Should().HaveCount(1);
         result.Results.First().Name.Should().Be("COrg");
@@ -939,7 +939,7 @@ public class DatabaseOrganisationRepositoryTest(OrganisationInformationPostgreSq
         await context.Organisations.AddRangeAsync(organisations);
         await context.SaveChangesAsync();
 
-        var result = await repository.SearchByNameOrPpon("Org", 10, 0, "asc");
+        var result = await repository.SearchByNameOrPpon("Org", 10, 0, "asc", 0.2);
 
         result.Results.Should().HaveCount(3);
         result.Results.First().Name.Should().Be("EOrg");
@@ -997,7 +997,7 @@ public class DatabaseOrganisationRepositoryTest(OrganisationInformationPostgreSq
         await context.Organisations.AddRangeAsync(organisations);
         await context.SaveChangesAsync();
 
-        var result = await repository.SearchByNameOrPpon("Org", 10, 0, "desc");
+        var result = await repository.SearchByNameOrPpon("Org", 10, 0, "desc", 0.2);
 
         result.Results.Should().HaveCount(3);
         result.Results.First().Name.Should().Be("JOrg");
@@ -1043,7 +1043,7 @@ public class DatabaseOrganisationRepositoryTest(OrganisationInformationPostgreSq
         await context.Organisations.AddRangeAsync(organisations);
         await context.SaveChangesAsync();
 
-        var result = await repository.SearchByNameOrPpon("Org", 10, 0, "rel");
+        var result = await repository.SearchByNameOrPpon("Org", 10, 0, "rel", 0.2);
 
         result.Results.Should().HaveCount(2);
         result.TotalCount.Should().Be(2);
@@ -1079,7 +1079,7 @@ public class DatabaseOrganisationRepositoryTest(OrganisationInformationPostgreSq
     }
 
     [Fact]
-    public async Task SearchByNameOrPpon_WithPartialPponMatch_ReturnsMatchingOrganisations()
+    public async Task SearchByNameOrPpon_WithPartialPponMatch_ReturnsNoMatchingOrganisations()
     {
         using var repository = OrganisationRepository();
         await using var context = GetDbContext();
@@ -1104,9 +1104,120 @@ public class DatabaseOrganisationRepositoryTest(OrganisationInformationPostgreSq
         // Search with just part of the PPON
         var result = await repository.SearchByNameOrPpon("ABCD", 10, 0, "asc");
 
-        result.Results.Should().HaveCount(1);
-        result.Results.First().Name.Should().Be("KOrg");
-        result.TotalCount.Should().Be(1);
+        result.Results.Should().HaveCount(0);
+        result.TotalCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task SearchByNameOrPpon_WithHighFuzzyMatchThreshold_ReturnsNoResults()
+    {
+        using var repository = OrganisationRepository();
+        await using var context = GetDbContext();
+        await ClearTestData(context);
+
+        var organisations = new[]
+        {
+            GivenOrganisation(
+                name: "Company A",
+                roles: [PartyRole.Buyer, PartyRole.Tenderer],
+                identifiers: [new Identifier
+                {
+                    Primary = true,
+                    Scheme = "GB-PPON",
+                    IdentifierId = "PGWZ-9001-AAAA",
+                    LegalName = "Org1",
+                    Uri = "http://example.org"
+                }]
+            ),
+            GivenOrganisation(
+                name: "Organisation 1",
+                roles: [PartyRole.Buyer, PartyRole.Tenderer],
+                identifiers: [new Identifier
+                {
+                    Primary = true,
+                    Scheme = "GB-PPON",
+                    IdentifierId = "PGWZ-9102-BBBB",
+                    LegalName = "Org2",
+                    Uri = "http://example.org"
+                }]
+            ),
+            GivenOrganisation(
+                name: "Company B",
+                roles: [PartyRole.Buyer, PartyRole.Tenderer],
+                identifiers: [new Identifier
+                {
+                    Primary = true,
+                    Scheme = "GB-PPON",
+                    IdentifierId = "PGWZ-9102-CCCC",
+                    LegalName = "Org3",
+                    Uri = "http://example.org"
+                }]
+            ),
+        };
+
+        await context.Organisations.AddRangeAsync(organisations);
+        await context.SaveChangesAsync();
+
+        var result = await repository.SearchByNameOrPpon("Comp", 10, 0, "rel", 0.9);
+
+        result.Results.Should().HaveCount(0);
+        result.TotalCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task SearchByNameOrPpon_WithLowFuzzyMatchThreshold_ReturnsResults()
+    {
+        using var repository = OrganisationRepository();
+        await using var context = GetDbContext();
+        await ClearTestData(context);
+
+        var organisations = new[]
+        {
+            GivenOrganisation(
+                name: "Company A",
+                roles: [PartyRole.Buyer, PartyRole.Tenderer],
+                identifiers: [new Identifier
+                {
+                    Primary = true,
+                    Scheme = "GB-PPON",
+                    IdentifierId = "PGWZ-9001-AAAA",
+                    LegalName = "Org1",
+                    Uri = "http://example.org"
+                }]
+            ),
+            GivenOrganisation(
+                name: "Organisation 1",
+                roles: [PartyRole.Buyer, PartyRole.Tenderer],
+                identifiers: [new Identifier
+                {
+                    Primary = true,
+                    Scheme = "GB-PPON",
+                    IdentifierId = "PGWZ-9102-BBBB",
+                    LegalName = "Org2",
+                    Uri = "http://example.org"
+                }]
+            ),
+            GivenOrganisation(
+                name: "Company B",
+                roles: [PartyRole.Buyer, PartyRole.Tenderer],
+                identifiers: [new Identifier
+                {
+                    Primary = true,
+                    Scheme = "GB-PPON",
+                    IdentifierId = "PGWZ-9102-CCCC",
+                    LegalName = "Org3",
+                    Uri = "http://example.org"
+                }]
+            ),
+        };
+
+        await context.Organisations.AddRangeAsync(organisations);
+        await context.SaveChangesAsync();
+
+        var result = await repository.SearchByNameOrPpon("Comp", 10, 0, "rel", 0.2);
+
+        result.Results.Should().HaveCount(2);
+        result.TotalCount.Should().Be(2);
     }
 
     private async Task ClearTestData(OrganisationInformationContext context)

--- a/Services/CO.CDP.OrganisationInformation.Persistence/IOrganisationRepository.cs
+++ b/Services/CO.CDP.OrganisationInformation.Persistence/IOrganisationRepository.cs
@@ -51,7 +51,7 @@ public interface IOrganisationRepository : IDisposable
     public Task<Mou?> GetMou(Guid mouId);
     Task<IEnumerable<Organisation>> SearchByName(string name, PartyRole? role, int? limit, double threshold);
 
-    Task<(IEnumerable<Organisation> Results, int TotalCount)> SearchByNameOrPpon(string searchText,  int? limit, int skip,string orderBy);
+    Task<(IEnumerable<Organisation> Results, int TotalCount)> SearchByNameOrPpon(string searchText,  int? limit, int skip,string orderBy, double threshold);
 
     public Task<IEnumerable<Organisation>> FindByAdminEmail(string email, PartyRole? role, int? limit);
 

--- a/TestKit/CO.CDP.TestKit.Mvc/TestAuthorizationWebApplicationFactory.cs
+++ b/TestKit/CO.CDP.TestKit.Mvc/TestAuthorizationWebApplicationFactory.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Moq;
 using System.Security.Claims;
+using CO.CDP.MQ;
 
 namespace CO.CDP.TestKit.Mvc;
 
@@ -52,7 +53,10 @@ public class TestAuthorizationWebApplicationFactory<TProgram>(
                         Scopes = [assignedOrganisationScopes]
                     });
             }
+            var mockPublisher = new Mock<IPublisher>();
 
+            services.AddScoped(
+                sp => mockPublisher.Object);
             services.AddTransient(sc => mockDatabaseOrgRepo.Object);
         });
 


### PR DESCRIPTION
Updated the Organisation search for exact match on PPON, updated the organisation search to Fuzzy match on the organisation name, updated ordering of the tags and included content changes to the PPON Search page. Unit tests refactored for the PPON Search and to allow the Fuzzy Match Threshold to be specified.