### PR TITLE
DP-1712 Add SES JSON logging via SNS and SQS

### DIFF
--- a/terragrunt/modules/core-iam/terraform-global-ses-datasource.tf
+++ b/terragrunt/modules/core-iam/terraform-global-ses-datasource.tf
@@ -2,8 +2,12 @@ data "aws_iam_policy_document" "terraform_global_ses" {
 
   statement {
     actions = [
+      "ses:CreateConfigurationSet",
+      "ses:CreateConfigurationSetEventDestination",
+      "ses:DeleteConfigurationSet",
       "ses:DeleteIdentity",
       "ses:DeleteIdentityPolicy",
+      "ses:DescribeConfigurationSet",
       "ses:GetIdentityDkimAttributes",
       "ses:GetIdentityMailFromDomainAttributes",
       "ses:GetIdentityPolicies",

--- a/terragrunt/modules/core-iam/terraform-product-datasource.tf
+++ b/terragrunt/modules/core-iam/terraform-product-datasource.tf
@@ -264,11 +264,14 @@ data "aws_iam_policy_document" "terraform_product" {
   statement {
     actions = [
       "SNS:CreateTopic",
-      "SNS:TagResource",
-      "SNS:SetTopicAttributes",
+      "SNS:DeleteTopic",
+      "SNS:GetSubscriptionAttributes",
       "SNS:GetTopicAttributes",
       "SNS:ListTagsForResource",
-      "SNS:DeleteTopic",
+      "SNS:SetTopicAttributes",
+      "SNS:Subscribe",
+      "SNS:TagResource",
+      "SNS:Unsubscribe",
     ]
     effect = "Allow"
     resources = [

--- a/terragrunt/modules/notification/datasource.tf
+++ b/terragrunt/modules/notification/datasource.tf
@@ -22,3 +22,52 @@ data "aws_iam_policy_document" "ses_send" {
   }
 }
 
+data "aws_iam_policy_document" "sns_allow_ses_publish" {
+  statement {
+    sid     = "AllowSESPublish"
+    effect  = "Allow"
+    actions = ["sns:Publish"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ses.amazonaws.com"]
+    }
+
+    resources = [aws_sns_topic.ses_json_events.arn]
+
+    condition {
+      test     = "StringEquals"
+      variable = "AWS:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
+
+    condition {
+      test     = "ArnLike"
+      variable = "AWS:SourceArn"
+      values   = [
+        aws_ses_configuration_set.json_logging.arn
+      ]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "sqs_allow_sns" {
+  statement {
+    sid     = "AllowSNSToSendToSQS"
+    effect  = "Allow"
+    actions = ["sqs:SendMessage"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["sns.amazonaws.com"]
+    }
+
+    resources = [aws_sqs_queue.ses_json.arn]
+
+    condition {
+      test     = "ArnEquals"
+      variable = "aws:SourceArn"
+      values   = [aws_sns_topic.ses_json_events.arn]
+    }
+  }
+}

--- a/terragrunt/modules/notification/locals.tf
+++ b/terragrunt/modules/notification/locals.tf
@@ -1,5 +1,6 @@
 locals {
-  name_prefix = var.product.resource_name
+  name_prefix    = var.product.resource_name
+  logging_prefix = "${local.name_prefix}-ses-logging"
 
   effective_mail_from_domains = length(var.mail_from_domains) > 0 ? var.mail_from_domains : [var.product.public_hosted_zone]
 }

--- a/terragrunt/modules/notification/main.tf
+++ b/terragrunt/modules/notification/main.tf
@@ -20,3 +20,18 @@ resource "aws_ses_identity_policy" "send_policy" {
   policy   = data.aws_iam_policy_document.ses_send[each.key].json
 }
 
+resource "aws_ses_configuration_set" "json_logging" {
+  name = "${local.logging_prefix}-config-set"
+}
+
+resource "aws_ses_event_destination" "json_logging" {
+  name                   = "${local.logging_prefix}-to-sns"
+  configuration_set_name = aws_ses_configuration_set.json_logging.name
+  enabled                = true
+
+  matching_types = var.ses_logging_event_types
+
+  sns_destination {
+    topic_arn = aws_sns_topic.ses_json_events.arn
+  }
+}

--- a/terragrunt/modules/notification/sns.tf
+++ b/terragrunt/modules/notification/sns.tf
@@ -1,0 +1,9 @@
+resource "aws_sns_topic" "ses_json_events" {
+  name = "${local.logging_prefix}-json-events"
+  tags = var.tags
+}
+
+resource "aws_sns_topic_policy" "ses_json_events" {
+  arn    = aws_sns_topic.ses_json_events.arn
+  policy = data.aws_iam_policy_document.sns_allow_ses_publish.json
+}

--- a/terragrunt/modules/notification/sqs.tf
+++ b/terragrunt/modules/notification/sqs.tf
@@ -1,0 +1,29 @@
+resource "aws_sqs_queue" "ses_json_dlq" {
+  name                      = "${local.logging_prefix}-json-events-dlq"
+  message_retention_seconds = 1209600
+  tags                      = var.tags
+}
+
+resource "aws_sqs_queue" "ses_json" {
+  name                       = "${local.logging_prefix}-json-events"
+  message_retention_seconds  = 1209600
+  visibility_timeout_seconds = 60
+
+  redrive_policy = jsonencode({
+    deadLetterTargetArn = aws_sqs_queue.ses_json_dlq.arn
+    maxReceiveCount     = 5
+  })
+
+  tags = var.tags
+}
+
+resource "aws_sqs_queue_policy" "ses_json" {
+  queue_url = aws_sqs_queue.ses_json.id
+  policy    = data.aws_iam_policy_document.sqs_allow_sns.json
+}
+
+resource "aws_sns_topic_subscription" "ses_json_sqs" {
+  topic_arn = aws_sns_topic.ses_json_events.arn
+  protocol  = "sqs"
+  endpoint  = aws_sqs_queue.ses_json.arn
+}

--- a/terragrunt/modules/notification/variables.tf
+++ b/terragrunt/modules/notification/variables.tf
@@ -17,3 +17,14 @@ variable "public_hosted_zone_id" {
   description = "ID of the public hosted zone"
   type        = string
 }
+
+variable "ses_logging_event_types" {
+  description = "SES event types to capture"
+  type        = list(string)
+  default     = ["bounce", "complaint", "delivery", "reject", "renderingFailure"]
+}
+
+variable "tags" {
+  description = "Tags to apply to all resources in this module"
+  type        = map(string)
+}


### PR DESCRIPTION
  - Created dedicated SES configuration set for logging
  - Added SNS topic and policy allowing SES to publsh events
  - Added SQS queue and DLQ as buffer
  - Subscribed SQS to SNS topic
  - Added SES event destination to configuration set for specified event types
  - Updated IAM policies to allow managing SES config sets, and required SNS/SQS actions
  - Introduced variables for logging event types