### PR TITLE
DP-1712 Add SES email send POC to PHP healthcheck service

### DIFF
--- a/terragrunt/components/service/ecs/terragrunt.hcl
+++ b/terragrunt/components/service/ecs/terragrunt.hcl
@@ -231,5 +231,6 @@ inputs = {
   queue_organisation_arn        = dependency.service_queue.outputs.organisation_queue_arn
   queue_organisation_url        = dependency.service_queue.outputs.organisation_queue_url
 
+  ses_configuration_set_arn  = dependency.service_notification.outputs.configuration_set_arn
   ses_configuration_set_name = dependency.service_notification.outputs.configuration_set_name
 }

--- a/terragrunt/modules/ecs/datasource.tf
+++ b/terragrunt/modules/ecs/datasource.tf
@@ -146,7 +146,8 @@ data "aws_iam_policy_document" "ecs_task_access_ses" {
     resources = [
       "arn:aws:ses:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:identity/${local.ses_identity_domain}",
       "arn:aws:ses:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:identity/*.service.gov.uk",
-      "arn:aws:ses:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:identity/*goaco.com"
+      "arn:aws:ses:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:identity/*goaco.com",
+      var.ses_configuration_set_arn
     ]
   }
 }

--- a/terragrunt/modules/ecs/service-fts-healthcheck.tf
+++ b/terragrunt/modules/ecs/service-fts-healthcheck.tf
@@ -4,23 +4,24 @@ module "ecs_service_fts_healthcheck" {
   container_definitions = templatefile(
     "${path.module}/templates/task-definitions/${var.service_configs.fts_healthcheck.name}.json.tftpl",
     {
-      aws_region      = data.aws_region.current.name
-      container_port  = var.service_configs.fts_healthcheck.port
-      cpu             = var.service_configs.fts_healthcheck.cpu
-      db_host         = var.db_fts_cluster_address
-      db_name         = var.db_fts_cluster_name
-      db_pass         = local.db_fts_password
-      db_user         = local.db_fts_username
-      host_port       = var.service_configs.fts_healthcheck.port
-      image           = local.ecr_urls[var.service_configs.fts_healthcheck.name]
-      lg_name         = aws_cloudwatch_log_group.tasks[var.service_configs.fts_healthcheck.name].name
-      lg_prefix       = "app"
-      lg_region       = data.aws_region.current.name
-      memory          = var.service_configs.fts_healthcheck.memory
-      name            = var.service_configs.fts_healthcheck.name
-      public_domain   = var.public_domain
+      aws_region                 = data.aws_region.current.name
+      container_port             = var.service_configs.fts_healthcheck.port
+      cpu                        = var.service_configs.fts_healthcheck.cpu
+      db_host                    = var.db_fts_cluster_address
+      db_name                    = var.db_fts_cluster_name
+      db_pass                    = local.db_fts_password
+      db_user                    = local.db_fts_username
+      host_port                  = var.service_configs.fts_healthcheck.port
+      image                      = local.ecr_urls[var.service_configs.fts_healthcheck.name]
+      lg_name                    = aws_cloudwatch_log_group.tasks[var.service_configs.fts_healthcheck.name].name
+      lg_prefix                  = "app"
+      lg_region                  = data.aws_region.current.name
+      memory                     = var.service_configs.fts_healthcheck.memory
+      name                       = var.service_configs.fts_healthcheck.name
+      public_domain              = var.public_domain
+      ses_configuration_set_name = var.ses_configuration_set_name
       service_version = "latest" //local.service_version
-      vpc_cidr        = var.vpc_cider
+      vpc_cidr                   = var.vpc_cider
     }
   )
 

--- a/terragrunt/modules/ecs/templates/task-definitions/fts-healthcheck.json.tftpl
+++ b/terragrunt/modules/ecs/templates/task-definitions/fts-healthcheck.json.tftpl
@@ -23,7 +23,8 @@
       { "name" : "DB_HOST", "value" : "${db_host}"},
       { "name" : "DB_NAME", "value" : "${db_name}"},
       { "name" : "AWS_REGION", "value" : "${aws_region}"},
-      { "name" : "MAIL_DOMAIN", "value" : "${public_domain}"}
+      { "name" : "MAIL_DOMAIN", "value" : "${public_domain}"},
+      { "name" : "SES_CONFIGURATION_SET_NAME", "value" : "${ses_configuration_set_name}"}
     ],
     "secrets": [
       { "name" : "DB_PASS", "valueFrom" : "${db_pass}"},

--- a/terragrunt/modules/ecs/variables.tf
+++ b/terragrunt/modules/ecs/variables.tf
@@ -301,8 +301,13 @@ variable "service_configs" {
   }))
 }
 
+variable "ses_configuration_set_arn" {
+  description = "ARN of the SES Configuration set"
+  type = string
+}
+
 variable "ses_configuration_set_name" {
-  description = "Name of the SES Configuration Configuration"
+  description = "Name of the SES Configuration set"
   type = string
 }
 

--- a/terragrunt/modules/notification/outputs.tf
+++ b/terragrunt/modules/notification/outputs.tf
@@ -1,3 +1,8 @@
+output "configuration_set_arn" {
+  value = aws_ses_configuration_set.json_logging.arn
+}
+
+
 output "configuration_set_name" {
   value = aws_ses_configuration_set.json_logging.name
 }

--- a/terragrunt/tools/healthcheck-fts-service/README.md
+++ b/terragrunt/tools/healthcheck-fts-service/README.md
@@ -36,15 +36,5 @@ docker push ${ACCOUNT_ID}.dkr.ecr.eu-west-2.amazonaws.com/cdp-fts-healthcheck:la
 
 ```shell
 aws-switch-to-cdp-sirsi-development-goaco-terraform
-ave aws ecs update-service --cluster cdp-sirsi --service healthcheck --force-new-deployment | jq .
-```
-
-```shell
-aws-switch-to-cdp-sirsi-staging-goaco-terraform
-ave aws ecs update-service --cluster cdp-sirsi --service healthcheck --force-new-deployment | jq .
-```
-
-```shell
-aws-switch-to-cdp-sirsi-integration-goaco-terraform
-ave aws ecs update-service --cluster cdp-sirsi --service healthcheck --force-new-deployment | jq .
+ave aws ecs update-service --cluster cdp-sirsi --service fts-healthcheck --force-new-deployment | jq .
 ```

--- a/terragrunt/tools/healthcheck-fts-service/php/ses-test.php
+++ b/terragrunt/tools/healthcheck-fts-service/php/ses-test.php
@@ -1,30 +1,140 @@
 <?php
 require __DIR__ . '/vendor/autoload.php';
 
-use Aws\Ses\SesClient;
+use Aws\SesV2\SesV2Client;
 use Aws\Exception\AwsException;
 
-header('Content-Type: application/json');
+$region          = getenv('AWS_REGION') ?: 'eu-west-2';
+$mailDomain      = getenv('MAIL_DOMAIN') ?: 'example.com';
+$envConfigSet    = trim((string) getenv('SES_CONFIGURATION_SET_NAME'));
+$defaultFrom     = 'no-reply@' . $mailDomain;
+$defaultTo       = 'success@simulator.amazonses.com'; // good for delivery tests
 
-try {
-    $client = new SesClient([
-        'version' => '2010-12-01',
-        'region'  => getenv('AWS_REGION') ?: 'eu-west-1',
+$method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
+$debug  = [];
+$result = null;
+$error  = null;
+
+if ($method === 'POST') {
+    $from        = trim($_POST['from'] ?? $defaultFrom);
+    $to          = trim($_POST['to'] ?? $defaultTo);
+    $subject     = (string)($_POST['subject'] ?? 'FTS SES test');
+    $body        = (string)($_POST['body'] ?? 'Hello from the FTS healthcheck service.');
+    $configSet   = trim((string)($_POST['config_set'] ?? $envConfigSet));
+
+    $client = new SesV2Client([
+        'version' => 'latest',
+        'region'  => $region,
     ]);
 
-    $result = $client->sendEmail([
-        'Source' => 'no-reply@' . getenv('MAIL_DOMAIN'),  // Pass MAIL_DOMAIN as env var in ECS
-        'Destination' => [
-            'ToAddresses' => ['ali.bahman@goaco.com'],
+    $send = [
+        'FromEmailAddress' => $from,
+        'Destination'      => ['ToAddresses' => [$to]],
+        'Content'          => [
+            'Simple' => [
+                'Subject' => ['Data' => $subject],
+                'Body'    => ['Text' => ['Data' => $body]],
+            ],
         ],
-        'Message' => [
-            'Subject' => ['Data' => 'Test SES Email'],
-            'Body' => ['Text' => ['Data' => 'Hello! This is a SES test from the healthcheck service.']],
-        ],
-    ]);
+    ];
+    if ($configSet !== '') {
+        $send['ConfigurationSetName'] = $configSet;
+    }
 
-    echo json_encode(['status' => 'success', 'messageId' => $result['MessageId']]);
+    $debug = [
+        'region'                 => $region,
+        'from'                   => $from,
+        'to'                     => $to,
+        'config_set_used'        => $configSet !== '' ? $configSet : '(none)',
+        'env_SES_CONFIGURATION_SET_NAME' => $envConfigSet !== '' ? $envConfigSet : '(unset)',
+        'env_AWS_REGION'         => getenv('AWS_REGION') ?: '(unset)',
+        'env_MAIL_DOMAIN'        => $mailDomain,
+    ];
 
-} catch (AwsException $e) {
-    echo json_encode(['status' => 'error', 'error' => $e->getAwsErrorMessage()]);
+    try {
+        $result = $client->sendEmail($send);
+    } catch (AwsException $e) {
+        $error = [
+            'aws_error_code'    => $e->getAwsErrorCode(),
+            'aws_error_message' => $e->getAwsErrorMessage(),
+            'message'           => $e->getMessage(),
+        ];
+    }
 }
+?>
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>SES Test</title>
+    <style>
+        body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 2rem; background:#f7f7f7; color:#333; }
+        h1 { color:#0078d7; }
+        form { background:#fff; padding:1rem; border-radius:8px; box-shadow: 0 2px 6px rgba(0,0,0,.06); max-width: 800px; }
+        label { display:block; font-weight:600; margin-top:.75rem; }
+        input[type=text], textarea { width:100%; padding:.6rem; border:1px solid #ccc; border-radius:6px; margin-top:.25rem; }
+        textarea { min-height: 120px; }
+        .row { display:grid; grid-template-columns: 1fr 1fr; gap:1rem; }
+        .actions { margin-top:1rem; }
+        button { padding:.6rem 1rem; border:0; border-radius:6px; background:#0078d7; color:#fff; cursor:pointer; }
+        pre { background:#111; color:#eee; padding:1rem; border-radius:8px; overflow:auto; max-width: 980px; }
+        a { color:#0078d7; }
+    </style>
+</head>
+<body>
+<h1>SES Test</h1>
+<p>This page sends a test email via <strong>SESv2</strong> and shows the inputs and the raw AWS response. Use the simulator address
+    (<code>success@simulator.amazonses.com</code>) to verify delivery events without sending a real email.</p>
+
+<form method="post">
+    <div class="row">
+        <div>
+            <label>From</label>
+            <input type="text" name="from" value="<?php echo htmlspecialchars($defaultFrom, ENT_QUOTES); ?>">
+        </div>
+        <div>
+            <label>To</label>
+            <input type="text" name="to" value="<?php echo htmlspecialchars($defaultTo, ENT_QUOTES); ?>">
+        </div>
+    </div>
+    <div class="row">
+        <div>
+            <label>Subject</label>
+            <input type="text" name="subject" value="FTS SES test">
+        </div>
+        <div>
+            <label>Configuration set (optional)</label>
+            <input type="text" name="config_set" placeholder="cdp-sirsi-ses-logging-config-set" value="<?php echo htmlspecialchars($envConfigSet, ENT_QUOTES); ?>">
+        </div>
+    </div>
+    <label>Body</label>
+    <textarea name="body">Hello from the FTS healthcheck service.</textarea>
+    <div class="actions">
+        <button type="submit">Send test email</button>
+        <a href="index.php" style="margin-left:.75rem;">Back</a>
+    </div>
+</form>
+
+<?php if ($method === 'POST'): ?>
+    <h2>Debug</h2>
+    <pre><?php echo htmlspecialchars(json_encode($debug, JSON_PRETTY_PRINT), ENT_QUOTES); ?></pre>
+
+    <?php if ($result): ?>
+        <h2>SES Response</h2>
+        <pre><?php echo htmlspecialchars(json_encode($result->toArray(), JSON_PRETTY_PRINT), ENT_QUOTES); ?></pre>
+    <?php endif; ?>
+
+    <?php if ($error): ?>
+        <h2>Error</h2>
+        <pre><?php echo htmlspecialchars(json_encode($error, JSON_PRETTY_PRINT), ENT_QUOTES); ?></pre>
+    <?php endif; ?>
+<?php endif; ?>
+
+<h3>Notes</h3>
+<ul>
+    <li>Region used: <strong><?php echo htmlspecialchars($region, ENT_QUOTES); ?></strong></li>
+    <li>Set <code>SES_CONFIGURATION_SET_NAME</code> in the service/container to attach your logging config set without editing this page.</li>
+    <li>To test end‑to‑end logging, send to the simulator and then check SQS and CloudWatch Logs.</li>
+</ul>
+</body>
+</html>


### PR DESCRIPTION
  - Added a proof-of-concept email send form and handler to the healthcheck service
  - Allows testing SES email sending with optional configuration set from environment variable
  - Prints debug output including region, sender, recipient, and config set in use
  - To be replicated in the actual FTS service after validation