### PR TITLE
CDPDEL-953: Remove PartyRole filter from Search Registry of PPON

### DIFF
--- a/Services/CO.CDP.OrganisationInformation.Persistence/DatabaseOrganisationRepository.cs
+++ b/Services/CO.CDP.OrganisationInformation.Persistence/DatabaseOrganisationRepository.cs
@@ -124,7 +124,6 @@ public class DatabaseOrganisationRepository(OrganisationInformationContext conte
                 EF.Functions.TrigramsSimilarity(t.Name, searchText) >= threshold ||
                 t.Identifiers.Any(i => i.IdentifierId != null && i.IdentifierId.Equals(searchText)))
             .Where(t => t.Type == OrganisationType.Organisation)
-            .Where(t => t.Roles.Contains(PartyRole.Buyer) || t.Roles.Contains(PartyRole.Tenderer))
             .Where(t => t.Identifiers.Any(i => i.Scheme.Equals("GB-PPON")));
 
         if (orderBy.Equals("asc", StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION
Remove party role filter from Search Registry of PPON that prevents users viewing all available party roles in the system