### PR TITLE
BAU add script to check FTS/CFS certificates expiry dates

### DIFF
--- a/terragrunt/tools/scripts/check_certificates_expiry_dates.sh
+++ b/terragrunt/tools/scripts/check_certificates_expiry_dates.sh
@@ -1,0 +1,15 @@
+for DOMAIN in \
+www-staging.find-tender.service.gov.uk \
+www-tpp.find-tender.service.gov.uk \
+www.find-tender.service.gov.uk \
+www-preview.contractsfinder.service.gov.uk \
+www-integration.contractsfinder.service.gov.uk \
+www.contractsfinder.service.gov.uk
+do
+echo "==> ${DOMAIN}"
+echo | openssl s_client \
+  -connect ${DOMAIN}:443 \
+  -servername ${DOMAIN} 2>/dev/null \
+  | openssl x509 -noout -dates
+echo ""
+done


### PR DESCRIPTION
tested ...
```
./tools/scripts/check_certificates_expiry_dates.sh          
==> www-staging.find-tender.service.gov.uk
notBefore=Jan  7 13:46:38 2026 GMT
notAfter=Apr  7 13:46:37 2026 GMT

==> www-tpp.find-tender.service.gov.uk
notBefore=Jan  7 14:24:07 2026 GMT
notAfter=Apr  7 14:24:06 2026 GMT

==> www.find-tender.service.gov.uk
notBefore=Oct 14 06:39:34 2025 GMT
notAfter=Jan 12 06:39:33 2026 GMT

==> www-preview.contractsfinder.service.gov.uk
notBefore=Jan  7 14:39:37 2026 GMT
notAfter=Apr  7 14:39:36 2026 GMT

==> www-integration.contractsfinder.service.gov.uk
notBefore=Jan  7 14:51:09 2026 GMT
notAfter=Apr  7 14:51:08 2026 GMT

==> www.contractsfinder.service.gov.uk
notBefore=Oct 14 07:28:32 2025 GMT
notAfter=Jan 12 07:28:31 2026 GMT
```