### PR TITLE
DP-2619 - disabled uk17_enable_current_reporting_periods for all environments now UK17 has been deployed into Live

### DIFF
--- a/terragrunt/modules/ecs/locals-fts.tf
+++ b/terragrunt/modules/ecs/locals-fts.tf
@@ -85,7 +85,7 @@ locals {
     ssl_service                           = true
     submission_log_globally_enabled       = contains(["integration"], var.environment) ? true : false
     uk17_enabled                          = true
-    uk17_enable_current_reporting_periods = contains(["development", "production"], var.environment) ? false : true
+    uk17_enable_current_reporting_periods = false
     uk9_enabled                           = true
     uk11_240_enabled                      = true
     use_srsi                              = true


### PR DESCRIPTION
[DP-2619](https://noticingsystem.atlassian.net/browse/DP-2619)