### PR TITLE
FC-1282 Stop deploying UserManagement services

### DIFF
--- a/terragrunt/components/root.hcl
+++ b/terragrunt/components/root.hcl
@@ -284,8 +284,8 @@ locals {
     person                               = {}
     scheduled_worker                     = { desired_count = 1 }
     tenant                               = {}
-    user_management_api                  = { desired_count = local.environment == "development" ? 1 : 0 }
-    user_management_app                  = { desired_count = local.environment == "development" ? 1 : 0 }
+    user_management_api                  = { desired_count = 0 }
+    user_management_app                  = { desired_count = 0 }
     user_management_migrations           = { cpu = 256, memory = 512 }
   }
 


### PR DESCRIPTION
We need to remove all user management services, so this starts by preventing them from being deployed. We can clean up the rest of the infra after the code has been removed.