### PR TITLE
FC-1279: Add env variable to enable notice render cache marker

### DIFF
--- a/terragrunt/modules/ecs/locals-fts.tf
+++ b/terragrunt/modules/ecs/locals-fts.tf
@@ -85,6 +85,7 @@ locals {
     notices_rebuild_enabled               = contains(["development", "staging"], var.environment)
     notice_render_cache_bucket            = module.s3_bucket_fts_notice_render_cache.bucket
     notice_render_cache_cdn_url           = var.cloudfront_downloads_enabled ? "https://${module.cloudfront_fts_notice_render_cache.cloudfront_domain_name}" : ""
+    notice_render_cache_debug_marker      = contains(["development", "staging"], var.environment)
     session_name_default                  = "SRSI_FT_AUTH"
     site_domain                           = local.fts_site_domains[var.environment]
     site_tag                              = "TEST"

--- a/terragrunt/modules/ecs/templates/task-definitions/fts-notice-publish-worker.json.tftpl
+++ b/terragrunt/modules/ecs/templates/task-definitions/fts-notice-publish-worker.json.tftpl
@@ -30,6 +30,7 @@
       { "name" : "LICENCED_TO", "value" : "${licenced_to}"},
       { "name" : "LOCAL_VERSION", "value" : "${local_version}"},
       { "name" : "NOTICE_RENDER_CACHE_BUCKET", "value" : "${notice_render_cache_bucket}"},
+      { "name" : "NOTICE_RENDER_CACHE_DEBUG_MARKER", "value" : "${notice_render_cache_debug_marker}"},
       { "name" : "NOTICE_PUBLISH_QUEUE_URL", "value" : "${notice_publish_queue_url}"},
       { "name" : "SES_CONFIGURATION_SET_NAME", "value" : "${ses_configuration_set_name}"},
       { "name" : "SESSION_NAME_DEFAULT", "value" : "${session_name_default}"},

--- a/terragrunt/modules/ecs/templates/task-definitions/fts.json.tftpl
+++ b/terragrunt/modules/ecs/templates/task-definitions/fts.json.tftpl
@@ -38,6 +38,7 @@
       { "name" : "LOCAL_VERSION", "value" : "${local_version}"},
       { "name" : "MODERNISED_LANDING_PAGE", "value" : "${modernised_landing_page}"},
       { "name" : "NOTICE_RENDER_CACHE_BUCKET", "value" : "${notice_render_cache_bucket}"},
+      { "name" : "NOTICE_RENDER_CACHE_DEBUG_MARKER", "value" : "${notice_render_cache_debug_marker}"},
       { "name" : "NOTICE_RENDER_CACHE_CDN_URL", "value" : "${notice_render_cache_cdn_url}"},
       { "name" : "NOTICE_PUBLISH_QUEUE_URL", "value" : "${notice_publish_queue_url}"},
       { "name" : "NOTICES_REBUILD_ENABLED", "value" : "${notices_rebuild_enabled}"},


### PR DESCRIPTION
Adds `NOTICE_RENDER_CACHE_DEBUG_MARKER` env variable for app/worker on the FTS; enabled on `development`, `staging` environments. Enables render_cache marker in the HTML to help QA verify caching is working correctly.