### PR TITLE
FC-1292: Add feature flag for notice render cache feature

### DIFF
--- a/terragrunt/modules/ecs/locals-fts.tf
+++ b/terragrunt/modules/ecs/locals-fts.tf
@@ -85,6 +85,7 @@ locals {
     notice_render_cache_bucket            = module.s3_bucket_fts_notice_render_cache.bucket
     notice_render_cache_cdn_url           = var.cloudfront_downloads_enabled ? "https://${module.cloudfront_fts_notice_render_cache.cloudfront_domain_name}" : ""
     notice_render_cache_debug_marker      = contains(["development", "staging"], var.environment)
+    notice_render_cache_enabled           = contains(["development"], var.environment)
     session_name_default                  = "SRSI_FT_AUTH"
     site_domain                           = local.fts_site_domains[var.environment]
     site_tag                              = "TEST"

--- a/terragrunt/modules/ecs/templates/task-definitions/fts-notice-publish-worker.json.tftpl
+++ b/terragrunt/modules/ecs/templates/task-definitions/fts-notice-publish-worker.json.tftpl
@@ -31,6 +31,7 @@
       { "name" : "LOCAL_VERSION", "value" : "${local_version}"},
       { "name" : "NOTICE_RENDER_CACHE_BUCKET", "value" : "${notice_render_cache_bucket}"},
       { "name" : "NOTICE_RENDER_CACHE_DEBUG_MARKER", "value" : "${notice_render_cache_debug_marker}"},
+      { "name" : "NOTICE_RENDER_CACHE_ENABLED", "value" : "${notice_render_cache_enabled}"},
       { "name" : "NOTICE_PUBLISH_QUEUE_URL", "value" : "${notice_publish_queue_url}"},
       { "name" : "SES_CONFIGURATION_SET_NAME", "value" : "${ses_configuration_set_name}"},
       { "name" : "SESSION_NAME_DEFAULT", "value" : "${session_name_default}"},

--- a/terragrunt/modules/ecs/templates/task-definitions/fts.json.tftpl
+++ b/terragrunt/modules/ecs/templates/task-definitions/fts.json.tftpl
@@ -41,6 +41,7 @@
       { "name" : "NOTICE_RENDER_CACHE_BUCKET", "value" : "${notice_render_cache_bucket}"},
       { "name" : "NOTICE_RENDER_CACHE_CDN_URL", "value" : "${notice_render_cache_cdn_url}"},
       { "name" : "NOTICE_RENDER_CACHE_DEBUG_MARKER", "value" : "${notice_render_cache_debug_marker}"},
+      { "name" : "NOTICE_RENDER_CACHE_ENABLED", "value" : "${notice_render_cache_enabled}"},
       { "name" : "SESSION_NAME_DEFAULT", "value" : "${session_name_default}"},
       { "name" : "SES_CONFIGURATION_SET_NAME", "value" : "${ses_configuration_set_name}"},
       { "name" : "SITE_DOMAIN", "value" : "${site_domain}"},


### PR DESCRIPTION
Adds `NOTICE_RENDER_CACHE_ENABLED` variable to FTS app and worker; enabled in `development` environment only.