### PR TITLE
Enforce newlines for infrastructure config files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,6 +10,9 @@ indent_size = 4
 [{*.resx,*.har,*.jsb2,*.jsb3,*.json,*.jsonc,*.postman_collection,*.postman_environment,.babelrc,.eslintrc,.prettierrc,.stylelintrc,bowerrc,jest.config}]
 indent_size = 2
 
+[*.{tf,tfvars,tftpl,hcl}]
+insert_final_newline = true
+
 [Makefile]
 indent_style = tab
 


### PR DESCRIPTION
The newlines are often being removed from the terraform/terragrunt files when they're edited with an editor respecting .editorconfig. This overrides the setting for those files so we keep the newline at the end of those files.