### PR TITLE
FC-1420 Revert Set SAVED_SEARCH_IGNORE_TIME_WINDOW in Dev and Staging

### DIFF
--- a/terragrunt/modules/ecs/locals-fts.tf
+++ b/terragrunt/modules/ecs/locals-fts.tf
@@ -80,7 +80,6 @@ locals {
     licenced_to                           = "No-one"
     local_version                         = 1100
     modernised_landing_page               = contains(["development", "staging"], var.environment)
-    saved_search_ignore_time_window       = contains(["development", "staging"], var.environment)
     summarised_search_enabled             = contains(["development", "staging"], var.environment)
     pa23_enabled                          = contains(["development"], var.environment)
     notice_publish_internal_key           = local.fts_notice_publish_internal_key_arn

--- a/terragrunt/modules/ecs/templates/task-definitions/fts-scheduler.json.tftpl
+++ b/terragrunt/modules/ecs/templates/task-definitions/fts-scheduler.json.tftpl
@@ -37,7 +37,6 @@
       { "name" : "FTS_ONE_LOGIN_REDIRECT_URI", "value" : "${fts_one_login_redirect_uri}"},
       { "name" : "LICENCED_TO", "value" : "${licenced_to}"},
       { "name" : "LOCAL_VERSION", "value" : "${local_version}"},
-      { "name" : "SAVED_SEARCH_IGNORE_TIME_WINDOW", "value" : "${saved_search_ignore_time_window}"},
       { "name" : "NOTICE_RENDER_CACHE_BUCKET", "value" : "${notice_render_cache_bucket}"},
       { "name" : "SES_CONFIGURATION_SET_NAME", "value" : "${ses_configuration_set_name}"},
       { "name" : "SESSION_NAME_DEFAULT", "value" : "${session_name_default}"},


### PR DESCRIPTION
Reverts cabinetoffice/GCGS-Central-Digital-Platform#2540

The flag actually causes the limits to be removed on the number of saved searches processed, so now we've proved the fix works it's safe to remove this.