### PR TITLE
Rollback FTS Staging to 1.4.1

### DIFF
--- a/terragrunt/components/root.hcl
+++ b/terragrunt/components/root.hcl
@@ -104,7 +104,7 @@ locals {
       grafana_db_instance_type            = "db.t4g.small"
       grafana_db_multi_az                 = true
       pinned_service_version_cfs          = "1.0.7"
-      pinned_service_version_fts          = "1.4.3"
+      pinned_service_version_fts          = "1.4.1"
       pinned_service_version              = "1.0.89"
       postgres_instance_type              = "db.t4g.micro"
       postgres_aurora_instance_type       = "db.r5.8xlarge"


### PR DESCRIPTION
We need to rollback to the release before the hotfix work relating to saved searches