### PR TITLE
feat: add AWS Budgets configuration for cost optimization

### DIFF
--- a/terragrunt/modules/billing/budgets.tf
+++ b/terragrunt/modules/billing/budgets.tf
@@ -1,0 +1,33 @@
+resource "aws_budgets_budget" "monthly" {
+  name              = "monthly-cost-budget"
+  budget_type       = "COST"
+  limit_amount      = var.budget_amount
+  limit_unit        = "USD"
+  time_period_end   = "2087-06-15_00:00"
+  time_period_start = "2023-01-01_00:00"
+  time_unit         = "MONTHLY"
+
+  dynamic "notification" {
+    for_each = length(var.budget_alert_emails) > 0 ? [1] : []
+    content {
+      comparison_operator        = "GREATER_THAN"
+      threshold                  = 100
+      threshold_type             = "PERCENTAGE"
+      notification_type          = "ACTUAL"
+      subscriber_email_addresses = var.budget_alert_emails
+    }
+  }
+
+  dynamic "notification" {
+    for_each = length(var.budget_alert_emails) > 0 ? [1] : []
+    content {
+      comparison_operator        = "GREATER_THAN"
+      threshold                  = 100
+      threshold_type             = "PERCENTAGE"
+      notification_type          = "FORECASTED"
+      subscriber_email_addresses = var.budget_alert_emails
+    }
+  }
+
+  tags = var.tags
+}

--- a/terragrunt/modules/billing/variables.tf
+++ b/terragrunt/modules/billing/variables.tf
@@ -1,0 +1,22 @@
+variable "tags" {
+  description = "A map of tags to add to all resources"
+  type        = map(string)
+  default     = {}
+}
+
+variable "cur_bucket_name" {
+  description = "Name of the S3 bucket to store Cost and Usage Reports"
+  type        = string
+}
+
+variable "budget_amount" {
+  description = "The amount of cost or usage being measured for a budget"
+  type        = string
+  default     = "1000"
+}
+
+variable "budget_alert_emails" {
+  description = "List of email addresses to send budget alerts to"
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
## Summary

This PR adds Terraform support for **AWS Budgets**, allowing monthly cost budgets and automated email notifications for both actual and forecasted spend.

The implementation is configurable through module variables, making it reusable across different environments.

## Changes

* Added a new `billing` module with an `aws_budgets_budget` resource.
* Added configurable variables for:

  * monthly budget amount,
  * alert email recipients,
  * resource tags.
* Configured notifications for:

  * actual spend reaching the budget,
  * forecasted spend reaching the budget.
* Notifications are only created when email recipients are provided.

## Context

This change addresses one of the cost optimization recommendations identified during the infrastructure audit introduced in **#2557**.

Rather than only reporting the missing AWS Budget configuration, this PR provides an implementation that can be adopted directly to improve cost monitoring and help detect unexpected spending earlier.
