### PR TITLE
Release FTS 2.5.0 to production

### DIFF
--- a/terragrunt/components/root.hcl
+++ b/terragrunt/components/root.hcl
@@ -165,7 +165,7 @@ locals {
       grafana_db_instance_type            = "db.t4g.small"
       grafana_db_multi_az                 = false
       pinned_service_version_cfs          = "1.0.7"
-      pinned_service_version_fts          = "2.0.0"
+      pinned_service_version_fts          = "2.5.0"
       pinned_service_version              = "1.1.1"
       postgres_instance_type              = "db.t4g.micro"
       postgres_aurora_instance_type       = "db.r5.large"
@@ -213,7 +213,7 @@ locals {
       grafana_db_instance_type            = "db.t4g.small"
       grafana_db_multi_az                 = true
       pinned_service_version_cfs          = "1.0.7"
-      pinned_service_version_fts          = "2.0.0"
+      pinned_service_version_fts          = "2.5.0"
       pinned_service_version              = "1.1.1"
       postgres_instance_type              = "db.t4g.micro"
       postgres_aurora_instance_type       = "db.r5.8xlarge"


### PR DESCRIPTION
Updated the pinned service version for FTS from 2.0.0 to 2.5.0 in two instances.