### PR TITLE
FC-1945: enable render-pdf on integration

### DIFF
--- a/terragrunt/modules/ecs/locals-fts.tf
+++ b/terragrunt/modules/ecs/locals-fts.tf
@@ -318,7 +318,7 @@ locals {
     {
       notice_render_dlq_url     = var.queue_fts_notice_render_dlq_url
       notice_render_queue_url   = var.queue_fts_notice_render_url
-      notice_render_pdf_enabled = contains(["development", "staging"], var.environment)
+      notice_render_pdf_enabled = contains(["development", "staging", "integration"], var.environment)
     }
   )
 


### PR DESCRIPTION
Enables `render-pdf` in `integration`, should be merged right before FTS `2.6.0` or newer is deployed to `integration` env.