### PR TITLE
FC-1916: add the FTS PDF render service to the service registry

### DIFF
--- a/terragrunt/components/root.hcl
+++ b/terragrunt/components/root.hcl
@@ -297,6 +297,7 @@ locals {
     fts_user_api                         = { desired_count = 1 }
     fts_notice_publish_worker            = { desired_count = local.environment == "production" ? 5 : 3, cpu = 4096, memory = local.environment == "production" ? 16384 : 8192 }
     fts_notice_render_worker             = { desired_count = local.environment == "production" ? 2 : 1, cpu = 4096, memory = 8192 }
+    fts_pdf_render_service               = { desired_count = local.environment == "production" ? 2 : 1, cpu = 4096, memory = 8192 }
     ocds_exporter                        = { desired_count = 0, cpu = 4096, memory = 8192 }
     organisation                         = {}
     organisation_app                     = {}
@@ -356,6 +357,7 @@ locals {
     fts_findtender_migrations            = { cluster = "fts",       type = "db-migration", name = "fts-findtender-migrations" }
     fts_notice_publish_worker            = { cluster = "sirsi-php", type = "service",      name = "fts-notice-publish-worker" }
     fts_notice_render_worker             = { cluster = "sirsi-php", type = "service",      name = "fts-notice-render-worker" }
+    fts_pdf_render_service               = { cluster = "sirsi-php", type = "service",      name = "fts-pdf-render-service", listener_priority = 313 }
     fts_job_scheduler                    = { cluster = "sirsi-php", type = "service",      name = "fts-job-scheduler" }
     fts_scheduler                        = { cluster = "sirsi-php", type = "service",      name = "fts-scheduler" }
     fts_search_api                       = { cluster = "fts",       type = "service",      name = "fts-search-api", listener_priority = 211 }


### PR DESCRIPTION
Creates the cdp-fts-pdf-render-service ECR repository, which the FTS release build pushes to. Must be applied before the compose entry merges in gcgs-cdp-fts-service, because a push to a missing repository fails the whole release rather than just the new image.

No ECS service is created by this: services come from their own files. The entry also brings the Route53 records and the force-deploy step function, neither of which needs a running service.