### PR TITLE
FC-1917: add PDF render service secret locations

### DIFF
--- a/terragrunt/modules/ecs/locals-fts.tf
+++ b/terragrunt/modules/ecs/locals-fts.tf
@@ -46,6 +46,8 @@ locals {
     one_login_base_url                        = local.one_login.credential_locations.authority
     one_login_fln_api_key_arn                 = data.aws_secretsmanager_secret.one_login_forward_logout_notification_api_key.arn
     one_login_private_key                     = local.one_login.credential_locations.private_key
+    pdf_render_api_key                        = "${local.fts_secrets_arn}:PDF_RENDER_API_KEY::"
+    pdf_signing_combined_pem                  = "${local.fts_secrets_arn}:PDF_SIGNING_COMBINED_PEM::"
     run_guest_token                           = "${local.fts_secrets_arn}:RUN_GUEST_TOKEN::"
     run_migrator_token                        = "${local.fts_secrets_arn}:RUN_MIGRATOR_TOKEN::"
     run_registrar_token                       = "${local.fts_secrets_arn}:RUN_REGISTRAR_TOKEN::"


### PR DESCRIPTION
Binds two keys in the existing cdp-<env>-fts/secrets blob: the shared API key the render worker authenticates with, and the signing certificate and key as one PEM, which is the shape the material is already held in.

The values themselves are added to the secret outside Terraform and must be in place before the service is deployed, because a task referencing a missing key fails to start. No IAM change is needed, as the execution role already reads this secret.