### PR TITLE
FC-1918: add the FTS PDF render service ECS service

### DIFF
--- a/terragrunt/modules/ecs/locals-fts.tf
+++ b/terragrunt/modules/ecs/locals-fts.tf
@@ -321,6 +321,14 @@ locals {
     }
   )
 
+  fts_pdf_render_service_container_parameters = {
+    lg_prefix                = "app"
+    lg_region                = data.aws_region.current.region
+    pdf_render_api_key       = local.fts_secrets.pdf_render_api_key
+    pdf_signing_combined_pem = local.fts_secrets.pdf_signing_combined_pem
+    service_version          = local.service_version_fts
+  }
+
   fts_allowed_target_email_domains = {
     development = [
       "goaco.com"

--- a/terragrunt/modules/ecs/service-fts-pdf-render-service.tf
+++ b/terragrunt/modules/ecs/service-fts-pdf-render-service.tf
@@ -1,0 +1,41 @@
+module "ecs_service_fts_pdf_render_service" {
+  source = "../ecs-service"
+
+  container_definitions = templatefile(
+    "${path.module}/templates/task-definitions/${var.service_configs.fts_pdf_render_service.name}.json.tftpl",
+    merge(
+      local.fts_pdf_render_service_container_parameters,
+      {
+        cpu          = var.service_configs.fts_pdf_render_service.cpu
+        image        = local.ecr_urls[var.service_configs.fts_pdf_render_service.name]
+        lg_name      = aws_cloudwatch_log_group.tasks[var.service_configs.fts_pdf_render_service.name].name
+        memory       = var.service_configs.fts_pdf_render_service.memory
+        name         = var.service_configs.fts_pdf_render_service.name
+        service_port = local.service_ports_by_service[var.service_configs.fts_pdf_render_service.name]
+      }
+    )
+  )
+
+  alb_enabled            = false
+  cluster_id             = local.php_cluster_id
+  cpu                    = var.service_configs.fts_pdf_render_service.cpu
+  desired_count          = var.service_configs.fts_pdf_render_service.desired_count
+  ecs_alb_sg_id          = var.alb_sg_id
+  ecs_service_base_sg_id = var.ecs_sg_id
+  family                 = "app"
+  internal_alb_enabled   = true
+  internal_domain        = local.internal_domain
+  internal_listener_arn  = local.internal_ecs_listener_arn
+  listener_name          = var.service_configs.fts_pdf_render_service.name
+  listener_priority      = var.service_configs.fts_pdf_render_service.listener_priority
+  memory                 = var.service_configs.fts_pdf_render_service.memory
+  name                   = var.service_configs.fts_pdf_render_service.name
+  private_subnet_ids     = var.private_subnet_ids
+  product                = var.product
+  public_domain          = var.public_domain
+  role_ecs_task_arn      = var.role_ecs_task_arn
+  role_ecs_task_exec_arn = var.role_ecs_task_exec_arn
+  service_port           = local.service_ports_by_service[var.service_configs.fts_pdf_render_service.name]
+  tags                   = var.tags
+  vpc_id                 = var.vpc_id
+}

--- a/terragrunt/modules/ecs/templates/task-definitions/fts-pdf-render-service.json.tftpl
+++ b/terragrunt/modules/ecs/templates/task-definitions/fts-pdf-render-service.json.tftpl
@@ -1,0 +1,32 @@
+[
+  {
+    "name" : "${name}",
+    "image" : "${image}:${service_version}",
+    "cpu": ${cpu},
+    "memory": ${memory},
+    "portMappings": [
+      {
+        "containerPort": ${service_port},
+        "protocol" : "tcp"
+      }
+    ],
+    "logConfiguration": {
+      "logDriver" : "awslogs",
+      "options": {
+        "awslogs-group" : "${lg_name}",
+        "awslogs-region" : "${lg_region}",
+        "awslogs-stream-prefix" : "${lg_prefix}"
+      }
+    },
+    "environment": [
+      { "name" : "PDF_SIGNING_ALLOW_EXPIRED", "value" : "true"}
+    ],
+    "secrets": [
+      { "name" : "PDF_RENDER_API_KEY", "valueFrom" : "${pdf_render_api_key}"},
+      { "name" : "PDF_SIGNING_COMBINED_PEM", "valueFrom" : "${pdf_signing_combined_pem}"}
+    ],
+    "volumesFrom": [],
+    "mountPoints": [],
+    "essential": true
+  }
+]


### PR DESCRIPTION
Runs the chromium PDF render service on the php cluster, which puts it on port 8070, and exposes it on the internal load balancer only: alb_enabled is false so no public listener rule is created, and internal_alb_enabled is set directly rather than through use_internal_service_urls, which is hardcoded false.

The task definition is deliberately minimal rather than a copy of the render worker's, which carries around forty variables and thirty-four secrets this service has no use for. It takes the API key and the signing PEM from the FTS secrets blob, and sets PDF_SIGNING_ALLOW_EXPIRED because the certificate in use expired in 2022 and the service refuses to start on an expired certificate otherwise. See FC-1896.

The target group health check uses the module default of /health, which the service exposes and exempts from the API key check.

Nothing points at the service yet: the render worker only calls it once PDF_RENDER_SERVICE_URL is set, which is FC-1919.