### PR TITLE
FC-1946: Enable PDF render on production

### DIFF
--- a/terragrunt/modules/ecs/locals-fts.tf
+++ b/terragrunt/modules/ecs/locals-fts.tf
@@ -318,7 +318,7 @@ locals {
     {
       notice_render_dlq_url     = var.queue_fts_notice_render_dlq_url
       notice_render_queue_url   = var.queue_fts_notice_render_url
-      notice_render_pdf_enabled = contains(["development", "staging", "integration"], var.environment)
+      notice_render_pdf_enabled = true
     }
   )
 


### PR DESCRIPTION
Enables PDF render (FC-1690) in all environments, should be merged after upstream PR is merged.