### PR TITLE
FC-1989: Add NOTICES_REBUILD_ENABLED and NOTICES_DOTNET_DEFAULT to the FTS task definition

### DIFF
--- a/terragrunt/modules/ecs/locals-fts.tf
+++ b/terragrunt/modules/ecs/locals-fts.tf
@@ -92,6 +92,11 @@ locals {
     notice_render_cache_debug_marker      = true
     notice_render_cache_enabled           = true
     notice_render_worker_enabled          = true
+    # Form codes with a .NET build available. Replaces the four uk*_notices_rebuild_enabled
+    # flags below, which FC-1990 removes once dev and staging run FTS with FC-1959.
+    notices_rebuild_enabled               = contains(["development", "staging"], var.environment) ? "UK1,UK2,UK3,UK6" : ""
+    # Form codes that go straight to the .NET flow when created. Empty in every environment.
+    notices_dotnet_default                = ""
     render_cache_purge_on_migrate         = contains(["development", "staging", "integration"], var.environment)
     session_name_default                  = "SRSI_FT_AUTH"
     site_domain                           = local.fts_site_domains[var.environment]

--- a/terragrunt/modules/ecs/templates/task-definitions/fts.json.tftpl
+++ b/terragrunt/modules/ecs/templates/task-definitions/fts.json.tftpl
@@ -42,6 +42,8 @@
       { "name" : "NOTICE_RENDER_CACHE_CDN_URL", "value" : "${notice_render_cache_cdn_url}"},
       { "name" : "NOTICE_RENDER_CACHE_DEBUG_MARKER", "value" : "${notice_render_cache_debug_marker}"},
       { "name" : "NOTICE_RENDER_CACHE_ENABLED", "value" : "${notice_render_cache_enabled}"},
+      { "name" : "NOTICES_DOTNET_DEFAULT", "value" : "${notices_dotnet_default}"},
+      { "name" : "NOTICES_REBUILD_ENABLED", "value" : "${notices_rebuild_enabled}"},
       { "name" : "OCDS_EXPORT_QUEUE_URL", "value" : "${ocds_export_queue_url}"},
       { "name" : "PA23_ENABLED", "value" : "${pa23_enabled}"},
       { "name" : "SESSION_NAME_DEFAULT", "value" : "${session_name_default}"},


### PR DESCRIPTION
We're migrating (FC-1959) variables `UK*_NOTICES_REBUILD_ENABLED` to a single variable `NOTICES_REBUILD_ENABLED`; once supporting change is deployed on FTS, a follow-up PR will remove obsolete variables.